### PR TITLE
Remove authorization_domain from Workspace model

### DIFF
--- a/anvil_project_manager/models.py
+++ b/anvil_project_manager/models.py
@@ -65,9 +65,6 @@ class Workspace(models.Model):
     # For internal consistency, call it "billing project" here.
     billing_project = models.ForeignKey("BillingProject", on_delete=models.PROTECT)
     name = models.SlugField(max_length=64)
-    authorization_domain = models.ForeignKey(
-        "Group", on_delete=models.PROTECT, null=True, blank=True
-    )
 
     class Meta:
         constraints = [

--- a/anvil_project_manager/tables.py
+++ b/anvil_project_manager/tables.py
@@ -37,14 +37,10 @@ class WorkspaceTable(tables.Table):
     pk = tables.LinkColumn(
         "anvil_project_manager:workspaces:detail", args=[tables.utils.A("pk")]
     )
-    authorization_domain = tables.LinkColumn(
-        "anvil_project_manager:groups:detail",
-        args=[tables.utils.A("authorization_domain__pk")],
-    )
 
     class Meta:
         model = models.Workspace
-        fields = ("pk", "billing_project", "name", "authorization_domain")
+        fields = ("pk", "billing_project", "name")
 
 
 class GroupMembershipTable(tables.Table):

--- a/anvil_project_manager/tests/test_models.py
+++ b/anvil_project_manager/tests/test_models.py
@@ -144,17 +144,6 @@ class WorkspaceTest(TestCase):
         instance = factories.WorkspaceFactory()
         self.assertIsInstance(instance.get_absolute_url(), str)
 
-    def test_can_have_authorization_domain(self):
-        """A workspace can have a group as its authorization domain."""
-        billing_project = factories.BillingProjectFactory.create()
-        auth_domain_group = factories.GroupFactory.create()
-        instance = Workspace(
-            billing_project=billing_project,
-            name="test-name",
-            authorization_domain=auth_domain_group,
-        )
-        instance.save()
-
     def test_cannot_have_duplicated_billing_project_and_name(self):
         """Cannot have two workspaces with the same billing_project and name."""
         billing_project = factories.BillingProjectFactory.create()

--- a/anvil_project_manager/views.py
+++ b/anvil_project_manager/views.py
@@ -60,7 +60,6 @@ class WorkspaceCreate(CreateView):
     fields = (
         "billing_project",
         "name",
-        "authorization_domain",
     )
 
 


### PR DESCRIPTION
Tracking authorization domains is more complicated (see #28) so remove them until we figure out the best way to represent them in the models.