### PR TITLE
Verify that group was actually deleted on AnVIL

### DIFF
--- a/anvil_project_manager/exceptions.py
+++ b/anvil_project_manager/exceptions.py
@@ -27,3 +27,7 @@ class AnVILAlreadyImported(Exception):
 
 class AnVILRemoveAccountFromGroupError(Exception):
     """Exception to be raised when an account cannot be removed from a group on AnVIL."""
+
+
+class AnVILGroupDeletionError(Exception):
+    """Exception to be raised when a group was not properly deleted on AnVIL."""

--- a/anvil_project_manager/tests/test_models_anvil_api_unit.py
+++ b/anvil_project_manager/tests/test_models_anvil_api_unit.py
@@ -272,8 +272,24 @@ class ManagedGroupAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         responses.add(
             responses.DELETE, self.url, status=204, json={"message": "mock message"}
         )
+        responses.add(
+            responses.GET, self.url, status=404, json={"message": "mock message"}
+        )
         self.object.anvil_delete()
-        responses.assert_call_count(self.url, 1)
+        responses.assert_call_count(self.url, 2)
+
+    def test_anvil_delete_existing_not_actually_deleted_on_anvil(self):
+        """anvil_delete raises exception with successful API response but group was not actually deleted.
+
+        The AnVIL group delete API is buggy and often returns a successful API response when it should return an error.
+        """
+        responses.add(
+            responses.DELETE, self.url, status=204, json={"message": "mock message"}
+        )
+        responses.add(responses.GET, self.url, status=200)
+        with self.assertRaises(exceptions.AnVILGroupDeletionError):
+            self.object.anvil_delete()
+        responses.assert_call_count(self.url, 2)
 
     def test_anvil_delete_forbidden(self):
         responses.add(


### PR DESCRIPTION
Handle AnVIL API bugs for deleting groups - it often returns a successful response code when the group was not actually deleted.
* Add a custom exception to indicate that a group could not be deleted on AnVIL.
* Make a second API call in anvil_delete to check if the group still exists, and raise an exception if it does.
* Handle the exception in the ManagedGroupDelete view when trying to delete a group. Redirect with a message and do not delete it from Django.

Closes #92 