### PR TITLE
Change the navbar brand name for the pilot site

### DIFF
--- a/example_site/templates/base.html
+++ b/example_site/templates/base.html
@@ -4,7 +4,7 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
-    <title>{% block title %}example_site{% endblock title %}</title>
+    <title>{% block title %}PRIMED Pilot{% endblock title %}</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="Django app to manage consortium resources on AnVIL">
     <meta name="author" content="Adrienne Stilp">
@@ -45,7 +45,7 @@
           <button class="navbar-toggler navbar-toggler-right" type="button" data-bs-toggle="collapse" data-bs-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
             <span class="navbar-toggler-icon"></span>
           </button>
-          <a class="navbar-brand" href="{% url 'home' %}">example_site</a>
+          <a class="navbar-brand" href="{% url 'home' %}">PRIMED Pilot</a>
 
           <div class="collapse navbar-collapse" id="navbarSupportedContent">
             <ul class="navbar-nav mr-auto">


### PR DESCRIPTION
Instead of using "example_site", use "PRIMED Pilot" to differentiate from main branch.