### PR TITLE
Add error when trying to share a workspace with a group that doesn't exist

### DIFF
--- a/anvil_consortium_manager/exceptions.py
+++ b/anvil_consortium_manager/exceptions.py
@@ -31,3 +31,7 @@ class AnVILRemoveAccountFromGroupError(Exception):
 
 class AnVILGroupDeletionError(Exception):
     """Exception to be raised when a group was not properly deleted on AnVIL."""
+
+
+class AnVILGroupNotFound(Exception):
+    """Exception to be raised when a group is not found on AnVIL."""

--- a/anvil_consortium_manager/models.py
+++ b/anvil_consortium_manager/models.py
@@ -635,9 +635,13 @@ class WorkspaceGroupAccess(TimeStampedModel):
                 "canCompute": self.can_compute,
             }
         ]
-        AnVILAPIClient().update_workspace_acl(
+        response = AnVILAPIClient().update_workspace_acl(
             self.workspace.billing_project.name, self.workspace.name, acl_updates
         )
+        if len(response.json()["usersNotFound"]) > 0:
+            raise exceptions.AnVILGroupNotFound(
+                "{} not found on AnVIL".format(self.group)
+            )
 
     def anvil_delete(self):
         acl_updates = [
@@ -648,6 +652,7 @@ class WorkspaceGroupAccess(TimeStampedModel):
                 "canCompute": self.can_compute,
             }
         ]
+        # It is ok if we try to remove access for a group that doesn't exist on AnVIL.
         AnVILAPIClient().update_workspace_acl(
             self.workspace.billing_project.name, self.workspace.name, acl_updates
         )

--- a/anvil_consortium_manager/tests/test_models_anvil_api_unit.py
+++ b/anvil_consortium_manager/tests/test_models_anvil_api_unit.py
@@ -1596,12 +1596,22 @@ class WorkspaceGroupAccessAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             }
         ]
 
+    def get_api_json_response(
+        self, invites_sent=[], users_not_found=[], users_updated=[]
+    ):
+        return {
+            "invitesSent": invites_sent,
+            "usersNotFound": users_not_found,
+            "usersUpdated": users_updated,
+        }
+
     def test_anvil_create_or_update_successful(self):
         responses.add(
             responses.PATCH,
             self.url,
             status=200,
             match=[responses.matchers.json_params_matcher(self.data_add)],
+            json=self.get_api_json_response(users_updated=self.data_add),
         )
         self.object.anvil_create_or_update()
         responses.assert_call_count(self.url, 1)
@@ -1616,6 +1626,7 @@ class WorkspaceGroupAccessAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             self.url,
             status=200,
             match=[responses.matchers.json_params_matcher(self.data_add)],
+            json=self.get_api_json_response(users_updated=self.data_add),
         )
         self.object.anvil_create_or_update()
         responses.assert_call_count(self.url, 1)
@@ -1668,6 +1679,19 @@ class WorkspaceGroupAccessAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             self.object.anvil_create_or_update()
         responses.assert_call_count(self.url, 1)
 
+    def test_anvil_create_or_update_group_not_found_on_anvil(self):
+        responses.add(
+            responses.PATCH,
+            self.url,
+            status=200,
+            match=[responses.matchers.json_params_matcher(self.data_add)],
+            # Add the full json response.
+            json=self.get_api_json_response(users_not_found=self.data_add),
+        )
+        with self.assertRaises(exceptions.AnVILGroupNotFound):
+            self.object.anvil_create_or_update()
+        responses.assert_call_count(self.url, 1)
+
     def test_anvil_delete_successful(self):
         responses.add(
             responses.PATCH,
@@ -1688,6 +1712,7 @@ class WorkspaceGroupAccessAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             self.url,
             status=200,
             match=[responses.matchers.json_params_matcher(self.data_delete)],
+            json=self.get_api_json_response(users_updated=self.data_delete),
         )
         self.object.anvil_delete()
         responses.assert_call_count(self.url, 1)

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -897,12 +897,18 @@ class WorkspaceGroupAccessDetail(auth.AnVILConsortiumManagerViewRequired, Detail
 class WorkspaceGroupAccessCreate(
     auth.AnVILConsortiumManagerEditRequired, SuccessMessageMixin, CreateView
 ):
+    """View to create a new WorkspaceGroupAccess object and share the Workspace with a Group on AnVIL."""
+
     model = models.WorkspaceGroupAccess
     fields = ("workspace", "group", "access", "can_compute")
     success_msg = "Successfully shared Workspace with Group."
+    """Message to display when the WorkspaceGroupAccess object was successfully created in the app and on AnVIL."""
+
     message_group_not_found = "Managed Group not found on AnVIL."
+    """Message to display when the ManagedGroup was not found on AnVIL."""
 
     def get_success_url(self):
+        """URL to redirect to upon success."""
         return reverse("anvil_consortium_manager:workspace_group_access:list")
 
     def form_valid(self, form):
@@ -930,6 +936,8 @@ class WorkspaceGroupAccessCreate(
 class WorkspaceGroupAccessUpdate(
     auth.AnVILConsortiumManagerEditRequired, SuccessMessageMixin, UpdateView
 ):
+    """View to update a WorkspaceGroupAccess object and update access for the ManagedGroup to the Workspace on AnVIL."""
+
     model = models.WorkspaceGroupAccess
     fields = (
         "access",
@@ -937,6 +945,7 @@ class WorkspaceGroupAccessUpdate(
     )
     template_name = "anvil_consortium_manager/workspacegroupaccess_update.html"
     success_msg = "Successfully updated Workspace sharing."
+    """Message to display when the WorkspaceGroupAccess object was successfully updated."""
 
     def form_valid(self, form):
         """If the form is valid, save the associated model and create it on AnVIL."""

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -900,6 +900,7 @@ class WorkspaceGroupAccessCreate(
     model = models.WorkspaceGroupAccess
     fields = ("workspace", "group", "access", "can_compute")
     success_msg = "Successfully shared Workspace with Group."
+    message_group_not_found = "Managed Group not found on AnVIL."
 
     def get_success_url(self):
         return reverse("anvil_consortium_manager:workspace_group_access:list")
@@ -911,6 +912,11 @@ class WorkspaceGroupAccessCreate(
         # Make an API call to AnVIL to create the group.
         try:
             self.object.anvil_create_or_update()
+        except exceptions.AnVILGroupNotFound:
+            messages.add_message(
+                self.request, messages.ERROR, self.message_group_not_found
+            )
+            return self.render_to_response(self.get_context_data(form=form))
         except AnVILAPIError as e:
             # If the API call failed, rerender the page with the responses and show a message.
             messages.add_message(


### PR DESCRIPTION
* Add an exception to indicate that a group was not found on AnVIL (`AnVILGroupNotFound`).
* Modify the `WorkspaceGroupAccess.anvil_create_or_update()` method to check the `usersNotFound` field of the response to make sure that the group in question was not listed there.
* Modify the `WorkspaceGroupAccessCreate` and `WorkspaceGroupAccessUpdate` views to handle the `AnVILGroupNotFound` exception.
* Modify tests for `WorkspaceGroupAccessCreate` and `WorkspaceGroupAccessUpdate` views as necessary.

Closes #146 