### PR TITLE
Managed group updates

### DIFF
--- a/anvil_consortium_manager/tables.py
+++ b/anvil_consortium_manager/tables.py
@@ -35,13 +35,12 @@ class ManagedGroupTable(tables.Table):
     name = tables.Column(linkify=True)
     number_groups = tables.Column(
         verbose_name="Number of groups",
-        empty_values=(),
+        # empty_values=(0,),
         orderable=False,
         accessor="child_memberships__count",
     )
     number_accounts = tables.Column(
         verbose_name="Number of accounts",
-        empty_values=(),
         orderable=False,
         accessor="groupaccountmembership_set__count",
     )
@@ -49,6 +48,21 @@ class ManagedGroupTable(tables.Table):
     class Meta:
         model = models.ManagedGroup
         fields = ("name", "is_managed_by_app")
+
+    def render_number_groups(self, value, record):
+        """Render the number of groups as --- for groups not managed by the app."""
+        if not record.is_managed_by_app:
+            print("Here")
+            return self.default
+        else:
+            return value
+
+    def render_number_accounts(self, value, record):
+        """Render the number of accounts as --- for groups not managed by the app."""
+        if not record.is_managed_by_app:
+            return self.default
+        else:
+            return value
 
 
 class WorkspaceTable(tables.Table):

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/managedgroup_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/managedgroup_detail.html
@@ -29,7 +29,6 @@
 </div>
 
 
-
 <div class="my-3">
   <div class="accordion" id="accordionWorkspaces">
     <div class="accordion-item">
@@ -50,63 +49,65 @@
 </div>
 
 
+{% if object.is_managed_by_app %}
 
-<div class="my-3">
-  <div class="accordion" id="accordionMembers">
+  <div class="my-3">
+    <div class="accordion" id="accordionMembers">
 
-    <div class="accordion-item">
-      <h2 class="accordion-header" id="headingMembersOne">
-        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseMembersOne" aria-expanded="false" aria-controls="collapseMembersOne">
-          <span class="fa-solid fa-code-fork mx-2" data-fa-transform="flip-v"></span>
-          View group members
-          <span class="badge mx-2 bg-secondary pill"> {{ group_table.rows|length }}</span>
-        </button>
-      </h2>
-      <div id="collapseMembersOne" class="accordion-collapse collapse" aria-labelledby="headingMembersOne">
-        <div class="accordion-body">
-          {% render_table group_table %}
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="headingMembersOne">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseMembersOne" aria-expanded="false" aria-controls="collapseMembersOne">
+            <span class="fa-solid fa-code-fork mx-2" data-fa-transform="flip-v"></span>
+            View group members
+            <span class="badge mx-2 bg-secondary pill"> {{ group_table.rows|length }}</span>
+          </button>
+        </h2>
+        <div id="collapseMembersOne" class="accordion-collapse collapse" aria-labelledby="headingMembersOne">
+          <div class="accordion-body">
+            {% render_table group_table %}
+          </div>
         </div>
       </div>
-    </div>
 
-    <div class="accordion-item">
-      <h2 class="accordion-header" id="headingMembersTwo">
-        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseMembersTwo" aria-expanded="false" aria-controls="collapseMembersTwo">
-          <span class="fa-solid fa-user-group mx-2"></span>
-          View active account members
-          <span class="badge mx-2 bg-secondary pill"> {{ active_account_table.rows|length }}</span>
-        </button>
-      </h2>
-      <div id="collapseMembersTwo" class="accordion-collapse collapse" aria-labelledby="headingMembersTwo">
-        <div class="accordion-body">
-          {% render_table active_account_table %}
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="headingMembersTwo">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseMembersTwo" aria-expanded="false" aria-controls="collapseMembersTwo">
+            <span class="fa-solid fa-user-group mx-2"></span>
+            View active account members
+            <span class="badge mx-2 bg-secondary pill"> {{ active_account_table.rows|length }}</span>
+          </button>
+        </h2>
+        <div id="collapseMembersTwo" class="accordion-collapse collapse" aria-labelledby="headingMembersTwo">
+          <div class="accordion-body">
+            {% render_table active_account_table %}
+          </div>
         </div>
       </div>
-    </div>
 
-    <div class="accordion-item">
-      <h2 class="accordion-header" id="headingMembersThree">
-        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseMembersThree" aria-expanded="false" aria-controls="collapseMembersTwo">
-          <span class="fa-solid fa-users-slash mx-2"></span>
-          View inactive account members
-          <span class="badge mx-2 bg-secondary pill"> {{ inactive_account_table.rows|length }}</span>
-        </button>
-      </h2>
-      <div id="collapseMembersThree" class="accordion-collapse collapse" aria-labelledby="headingMembersThree">
-        <div class="accordion-body">
-          {% render_table inactive_account_table %}
+      <div class="accordion-item">
+        <h2 class="accordion-header" id="headingMembersThree">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseMembersThree" aria-expanded="false" aria-controls="collapseMembersTwo">
+            <span class="fa-solid fa-users-slash mx-2"></span>
+            View inactive account members
+            <span class="badge mx-2 bg-secondary pill"> {{ inactive_account_table.rows|length }}</span>
+          </button>
+        </h2>
+        <div id="collapseMembersThree" class="accordion-collapse collapse" aria-labelledby="headingMembersThree">
+          <div class="accordion-body">
+            {% render_table inactive_account_table %}
+          </div>
         </div>
       </div>
-    </div>
 
+    </div>
   </div>
-</div>
-
 
 
 
 <p>
   <a href="{% url 'anvil_consortium_manager:managed_groups:delete' pk=object.pk %}" class="btn btn-danger" role="button">Delete on AnVIL</a>
 </p>
+
+{% endif %}
 
 {% endblock content %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/managedgroup_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/managedgroup_detail.html
@@ -28,18 +28,37 @@
   </ul>
 </div>
 
-
 <div class="my-3">
-  <div class="accordion" id="accordionWorkspaces">
+  <div class="accordion" id="accordionWorkspaceAuthDomains">
     <div class="accordion-item">
       <h2 class="accordion-header" id="headingWorkspacesOne">
-        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseWorkspacesOne" aria-expanded="false" aria-controls="collapseWorkspacesOne">
+        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseWorkspaceAuthDomainsOne" aria-expanded="false" aria-controls="collapseWorkspaceAuthDomainsOne">
+          <span class="fa-solid fa-shield mx-2"></span>
+          View workspaces that this group is an authorization domain for
+          <span class="badge mx-2 bg-secondary pill"> {{ workspace_authorization_domain_table.rows|length }}</span>
+        </button>
+      </h2>
+      <div id="collapseWorkspaceAuthDomainsOne" class="accordion-collapse collapse" aria-labelledby="headingWorkspaceAuthDomainsOne" data-bs-parent="#accordionWorkspaceAuthDomains">
+        <div class="accordion-body">
+          {% render_table workspace_authorization_domain_table %}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+
+<div class="my-3">
+  <div class="accordion" id="accordionWorkspaceAccess">
+    <div class="accordion-item">
+      <h2 class="accordion-header" id="headingWorkspaceAccessOne">
+        <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseWorkspaceAccessOne" aria-expanded="false" aria-controls="collapseWorkspaceAccessOne">
           <span class="fa-solid fa-computer mx-2"></span>
           View workspaces that this group has access to
           <span class="badge mx-2 bg-secondary pill"> {{ workspace_table.rows|length }}</span>
         </button>
       </h2>
-      <div id="collapseWorkspacesOne" class="accordion-collapse collapse" aria-labelledby="headingWorkspacesOne" data-bs-parent="#accordionWorkspaces">
+      <div id="collapseWorkspaceAccessOne" class="accordion-collapse collapse" aria-labelledby="headingWorkspaceAccessOne" data-bs-parent="#accordionWorkspaceAccess">
         <div class="accordion-body">
           {% render_table workspace_table %}
         </div>

--- a/anvil_consortium_manager/tests/test_tables.py
+++ b/anvil_consortium_manager/tests/test_tables.py
@@ -98,6 +98,20 @@ class ManagedGroupTableTest(TestCase):
         self.assertEqual(table.rows[1].get_cell("number_accounts"), 1)
         self.assertEqual(table.rows[2].get_cell("number_accounts"), 2)
 
+    def test_number_of_groups_not_managed_by_app(self):
+        """Table displays a --- for number of groups if the group is not managed by the app."""
+        group = self.model_factory.create(is_managed_by_app=False)
+        factories.GroupGroupMembershipFactory.create_batch(2, parent_group=group)
+        table = self.table_class(self.model.objects.filter(pk=group.pk))
+        self.assertEqual(table.rows[0].get_cell("number_groups"), table.default)
+
+    def test_number_of_accounts_not_managed_by_app(self):
+        """Table displays a --- for number of accounts if the group is not managed by the app."""
+        group = self.model_factory.create(is_managed_by_app=False)
+        factories.GroupAccountMembershipFactory.create_batch(2, group=group)
+        table = self.table_class(self.model.objects.filter(pk=group.pk))
+        self.assertEqual(table.rows[0].get_cell("number_accounts"), table.default)
+
 
 class WorkspaceTableTest(TestCase):
     model = models.Workspace

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -406,7 +406,12 @@ class ManagedGroupDetail(auth.AnVILConsortiumManagerViewRequired, DetailView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["workspace_authorization_domain_table"] = tables.WorkspaceTable(
-            self.object.workspace_set.all(), exclude="group"
+            self.object.workspace_set.all(),
+            exclude=(
+                "number_groups",
+                "has_authorization_domains",
+                "billing_project",
+            ),
         )
         context["workspace_table"] = tables.WorkspaceGroupAccessTable(
             self.object.workspacegroupaccess_set.all(), exclude="group"


### PR DESCRIPTION
* In the managed group table, show a dash instead of counts for the number of group or account members.
* Show a table of workspaces that the group is an auth domain for on the detail page. This table was in the context, but wasn't being rendered in the template.