### PR TITLE
Feature/show list of groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 0.3 (unreleased)
+
+- Show groups that a group is part of on the ManagedGroup detail page.
+
 ## 0.2 (2022-09-12)
 
 - Add account linking functionality

--- a/add_test_data.py
+++ b/add_test_data.py
@@ -14,6 +14,9 @@ factories.GroupGroupMembershipFactory.create(
 factories.GroupGroupMembershipFactory.create(
     parent_group=groups[0], child_group=groups[2]
 )
+factories.GroupGroupMembershipFactory.create(
+    parent_group=groups[3], child_group=groups[2]
+)
 
 # Add accounts to groups.
 factories.GroupAccountMembershipFactory.create(group=groups[1], account=accounts[0])

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.2"
+__version__ = "0.3dev1"

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/managedgroup_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/managedgroup_detail.html
@@ -74,6 +74,22 @@
     <div class="accordion" id="accordionMembers">
 
       <div class="accordion-item">
+        <h2 class="accordion-header" id="headingParents">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseParents" aria-expanded="false" aria-controls="collapseParents">
+            <span class="fa-solid fa-code-fork mx-2" data-fa-transform="flip-v"></span>
+            View group Parents
+            <span class="badge mx-2 bg-secondary pill"> {{ parent_table.rows|length }}</span>
+          </button>
+        </h2>
+        <div id="collapseParents" class="accordion-collapse collapse" aria-labelledby="headingParents">
+          <div class="accordion-body">
+            {% render_table parent_table %}
+          </div>
+        </div>
+      </div>
+
+
+      <div class="accordion-item">
         <h2 class="accordion-header" id="headingMembersOne">
           <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseMembersOne" aria-expanded="false" aria-controls="collapseMembersOne">
             <span class="fa-solid fa-code-fork mx-2" data-fa-transform="flip-v"></span>

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/managedgroup_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/managedgroup_detail.html
@@ -77,7 +77,7 @@
         <h2 class="accordion-header" id="headingParents">
           <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseParents" aria-expanded="false" aria-controls="collapseParents">
             <span class="fa-solid fa-code-fork mx-2" data-fa-transform="flip-v"></span>
-            View group Parents
+            View groups that this group is in
             <span class="badge mx-2 bg-secondary pill"> {{ parent_table.rows|length }}</span>
           </button>
         </h2>

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -3442,10 +3442,10 @@ class ManagedGroupDetailTest(TestCase):
         parent = factories.ManagedGroupFactory.create()
         child = factories.ManagedGroupFactory.create()
         grandchild = factories.ManagedGroupFactory.create()
-        factories.GroupGroupMembershipFactory.create(
+        parent_child_membership = factories.GroupGroupMembershipFactory.create(
             parent_group=parent, child_group=child
         )
-        factories.GroupGroupMembershipFactory.create(
+        child_grandchild_membership = factories.GroupGroupMembershipFactory.create(
             parent_group=child, child_group=grandchild
         )
         request = self.factory.get(self.get_url(parent.name))
@@ -3453,6 +3453,12 @@ class ManagedGroupDetailTest(TestCase):
         response = self.get_view()(request, slug=parent.name)
         self.assertIn("group_table", response.context_data)
         self.assertEqual(len(response.context_data["group_table"].rows), 1)
+        self.assertIn(
+            parent_child_membership, response.context_data["group_table"].data
+        )
+        self.assertNotIn(
+            child_grandchild_membership, response.context_data["group_table"].data
+        )
 
     def test_workspace_auth_domain_table(self):
         """The auth_domain table exists."""
@@ -3566,10 +3572,10 @@ class ManagedGroupDetailTest(TestCase):
         grandparent = factories.ManagedGroupFactory.create()
         parent = factories.ManagedGroupFactory.create()
         child = factories.ManagedGroupFactory.create()
-        factories.GroupGroupMembershipFactory.create(
+        grandparent_parent_membership = factories.GroupGroupMembershipFactory.create(
             parent_group=grandparent, child_group=parent
         )
-        factories.GroupGroupMembershipFactory.create(
+        parent_child_membership = factories.GroupGroupMembershipFactory.create(
             parent_group=parent, child_group=child
         )
         request = self.factory.get(self.get_url(child.name))
@@ -3577,6 +3583,12 @@ class ManagedGroupDetailTest(TestCase):
         response = self.get_view()(request, slug=child.name)
         self.assertIn("parent_table", response.context_data)
         self.assertEqual(len(response.context_data["parent_table"].rows), 1)
+        self.assertIn(
+            parent_child_membership, response.context_data["parent_table"].data
+        )
+        self.assertNotIn(
+            grandparent_parent_membership, response.context_data["parent_table"].data
+        )
 
 
 class ManagedGroupCreateTest(AnVILAPIMockTestMixin, TestCase):

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -648,6 +648,9 @@ class ManagedGroupDetail(auth.AnVILConsortiumManagerViewRequired, DetailView):
         context["group_table"] = tables.GroupGroupMembershipTable(
             self.object.child_memberships.all(), exclude="parent_group"
         )
+        context["parent_table"] = tables.GroupGroupMembershipTable(
+            self.object.parent_memberships.all(), exclude="child_group"
+        )
         return context
 
 


### PR DESCRIPTION
- Add a table in managed group details showing a list of groups that a group is part of.
- Add parent groups of a group into context in views.
- Add a test data that a group is part of 2 groups.
- Add tests for the view. 