### PR TITLE
Only show links to views requiring edit permission when the user has that permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## Devel
+
+- Only show links to views requiring edit permission if the user has that permission.
+
 ## 0.3 (2022-09-27)
 
 - Show groups that a group is part of on the ManagedGroup detail page.

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3"
+__version__ = "0.3dev1"

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/account_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/account_detail.html
@@ -61,6 +61,7 @@
 </div>
 
 
+{% if show_edit_links %}
 <p>
   {% if show_deactivate_button %}
     <a href="{% url 'anvil_consortium_manager:accounts:deactivate' uuid=object.uuid %}" class="btn btn-secondary" role="button">Deactivate account</a>
@@ -72,5 +73,6 @@
 
   <a href="{% url 'anvil_consortium_manager:accounts:delete' uuid=object.uuid %}" class="btn btn-danger" role="button">Delete from app</a>
 </p>
+{% endif %}
 
 {% endblock content %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/groupaccountmembership_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/groupaccountmembership_detail.html
@@ -16,8 +16,10 @@
   </ul>
 </div>
 
+{% if show_edit_links %}
 <p>
   <a href="{% url 'anvil_consortium_manager:managed_groups:member_accounts:delete' group_slug=object.group.name account_uuid=object.account.uuid %}" class="btn btn-danger" role="button">Delete on AnVIL</a>
 </p>
+{% endif %}
 
 {% endblock content %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/groupgroupmembership_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/groupgroupmembership_detail.html
@@ -17,8 +17,10 @@
   </ul>
 </div>
 
+{% if show_edit_links %}
 <p>
   <a href="{% url 'anvil_consortium_manager:managed_groups:member_groups:delete' parent_group_slug=object.parent_group.name child_group_slug=object.child_group.name %}" class="btn btn-danger" role="button">Delete on AnVIL</a>
 </p>
+{% endif %}
 
 {% endblock content %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/index.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/index.html
@@ -39,10 +39,12 @@
               <a href="{% url 'anvil_consortium_manager:billing_projects:list' %}" class="icon-link">List billing projects</a>
               <span class="fa-solid fa-angle-right"></span>
             </li>
+            {% if perms.anvil_consortium_manager.anvil_project_manager_edit %}
             <li class ="list-group-item">
               <a href="{% url 'anvil_consortium_manager:billing_projects:import' %}" class="icon-link">Import a billing project</a>
               <span class="fa-solid fa-angle-right"></span>
             </li>
+            {% endif %}
           </ul>
         </div>
       </div>
@@ -51,17 +53,21 @@
         <div class="card shadow-sm">
           <h5 class="card-header"><span class="fa-solid fa-user mx-2"></span>Accounts</h5>
           <div class="card-body">
-            <p>View or import accounts from AnVIL.</p>
+            <p>
+              View {% if perms.anvil_consortium_manager.anvil_project_manager_edit %}or import{% endif %} accounts from AnVIL.
+            </p>
           </div>
           <ul class="list-group list-group-flush">
             <li class ="list-group-item">
               <a href="{% url 'anvil_consortium_manager:accounts:list' %}" class="icon-link">List accounts</a>
               <span class="fa-solid fa-angle-right"></span>
             </li>
+            {% if perms.anvil_consortium_manager.anvil_project_manager_edit %}
             <li class ="list-group-item">
               <a href="{% url 'anvil_consortium_manager:accounts:import' %}" class="icon-link">Import an account</a>
               <span class="fa-solid fa-angle-right"></span>
             </li>
+            {% endif %}
           </ul>
         </div>
       </div>
@@ -70,13 +76,17 @@
         <div class="card shadow-sm">
           <h5 class="card-header"><span class="fa-solid fa-user-group mx-2"></span>Managed groups</h5>
           <div class="card-body">
-            <p>Interact with Managed Groups on AnVIL. You can add accounts to a group so a the access for set of related accounts can be managed together.</p>
+            <p>
+              Interact with Managed Groups on AnVIL.
+              {% if perms.anvil_consortium_manager.anvil_project_manager_edit %}You can add accounts to a group so a the access for set of related accounts can be managed together.{% endif %}
+            </p>
           </div>
           <ul class="list-group list-group-flush">
             <li class ="list-group-item">
               <a href="{% url 'anvil_consortium_manager:managed_groups:list' %}" class="icon-link">List groups</a>
               <span class="fa-solid fa-angle-right"></span>
             </li>
+            {% if perms.anvil_consortium_manager.anvil_project_manager_edit %}
             <li class ="list-group-item">
               <a href="{% url 'anvil_consortium_manager:managed_groups:new' %}" class="icon-link">Add a group</a>
               <span class="fa-solid fa-angle-right"></span>
@@ -89,6 +99,7 @@
               <a href="{% url 'anvil_consortium_manager:group_group_membership:new' %}" class="icon-link">Add a group to a group</a>
               <span class="fa-solid fa-angle-right"></span>
             </li>
+            {% endif %}
           </ul>
         </div>
       </div>
@@ -99,7 +110,10 @@
         <div class="card shadow-sm">
           <h5 class="card-header"><span class="fa-solid fa-computer mx-2"></span>{{ workspace_name }}s</h5>
           <div class="card-body">
-            <p>Interact with <b>{{ workspace_name }}s</b> on AnVIL. You can create or import workspaces and then share them with a group.</p>
+            <p>
+              Interact with {{ workspace_name }}s on AnVIL.
+              {% if perms.anvil_consortium_manager.anvil_project_manager_edit %}You can create or import workspaces and then share them with a group.{% endif%}
+            </p>
           </div>
 
           <ul class="list-group list-group-flush">
@@ -107,6 +121,7 @@
               <a href="{% url 'anvil_consortium_manager:workspaces:list' workspace_type %}" class="icon-link">List workspaces</a>
               <span class="fa-solid fa-angle-right"></span>
             </li>
+            {% if perms.anvil_consortium_manager.anvil_project_manager_edit %}
             <li class ="list-group-item">
               <a href="{% url 'anvil_consortium_manager:workspaces:new' workspace_type %}" class="icon-link">Add a workspace</a>
               <span class="fa-solid fa-angle-right"></span>
@@ -115,6 +130,7 @@
               <a href="{% url 'anvil_consortium_manager:workspaces:import' workspace_type  %}" class="icon-link">Import a workspace from AnVIL</a>
               <span class="fa-solid fa-angle-right"></span>
             </li>
+            {% endif %}
           </ul>
 
         </div>

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/managedgroup_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/managedgroup_detail.html
@@ -143,9 +143,11 @@
 <p>
   <a href="{% url 'anvil_consortium_manager:managed_groups:audit_membership' slug=object.name %}" class="btn btn-primary" role="button">Audit membership</a>
 </p>
+{% if show_edit_links %}
 <p>
   <a href="{% url 'anvil_consortium_manager:managed_groups:delete' slug=object.name %}" class="btn btn-danger" role="button">Delete on AnVIL</a>
 </p>
+{% endif %}
 
 {% endif %}
 

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/navbar.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/navbar.html
@@ -107,6 +107,9 @@
               <li>
                 <a class="dropdown-item" href="{% url 'anvil_consortium_manager:workspace_group_access:list' %}">Workspace access</a>
               </li>
+              <li>
+                <a class="dropdown-item" href="{% url 'anvil_consortium_manager:workspace_group_access:new' %}">Give a group access to a workspace</a>
+              </li>
 
               <li>
                 <a class="dropdown-item" href="{% url 'anvil_consortium_manager:workspaces:audit' %}">Audit workspaces</a>

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/navbar.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/navbar.html
@@ -25,15 +25,21 @@
               Billing Projects
             </a>
             <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="navbarDarkDropdownMenuLink">
+
               <li>
                 <a class="dropdown-item" href="{% url 'anvil_consortium_manager:billing_projects:list' %}">List billing projects</a>
               </li>
-              <li>
-                <a class="dropdown-item" href="{% url 'anvil_consortium_manager:billing_projects:import' %}">Import a billing project</a>
-              </li>
+
+              {% if perms.anvil_consortium_manager.anvil_project_manager_edit %}
+                <li>
+                  <a class="dropdown-item" href="{% url 'anvil_consortium_manager:billing_projects:import' %}">Import a billing project</a>
+                </li>
+              {% endif %}
+
               <li>
                 <a class="dropdown-item" href="{% url 'anvil_consortium_manager:billing_projects:audit' %}">Audit billing projects</a>
               </li>
+
             </ul>
           </li>
 
@@ -42,12 +48,17 @@
               Accounts
             </a>
             <ul class="dropdown-menu dropdown-menu-dark" aria-labelledby="navbarDarkDropdownMenuLink">
+
               <li>
                 <a class="dropdown-item" href="{% url 'anvil_consortium_manager:accounts:list' %}">List accounts</a>
               </li>
+
+              {% if perms.anvil_consortium_manager.anvil_project_manager_edit %}
               <li>
                 <a class="dropdown-item" href="{% url 'anvil_consortium_manager:accounts:import' %}">Import an account</a>
               </li>
+              {% endif %}
+
               <li>
                 <a class="dropdown-item" href="{% url 'anvil_consortium_manager:accounts:audit' %}">Audit accounts</a>
               </li>
@@ -62,21 +73,25 @@
               <li>
                 <a class="dropdown-item" href="{% url 'anvil_consortium_manager:managed_groups:list' %}">List groups</a>
               </li>
+              {% if perms.anvil_consortium_manager.anvil_project_manager_edit %}
               <li>
                 <a class="dropdown-item" href="{% url 'anvil_consortium_manager:managed_groups:new' %}">Add a group</a>
               </li>
+              {% endif %}
               <li>
                 <a class="dropdown-item" href="{% url 'anvil_consortium_manager:group_account_membership:list' %}">Group-account membership</a>
               </li>
               <li>
                 <a class="dropdown-item" href="{% url 'anvil_consortium_manager:group_group_membership:list' %}">Group-group membership</a>
               </li>
+              {% if perms.anvil_consortium_manager.anvil_project_manager_edit %}
               <li>
                 <a class="dropdown-item" href="{% url 'anvil_consortium_manager:group_account_membership:new' %}">Add an account to a group</a>
               </li>
               <li>
                 <a class="dropdown-item" href="{% url 'anvil_consortium_manager:group_group_membership:new' %}">Add a group to a group</a>
               </li>
+              {% endif %}
               <li>
                 <a class="dropdown-item" href="{% url 'anvil_consortium_manager:managed_groups:audit' %}">Audit groups</a>
               </li>
@@ -95,21 +110,25 @@
                 <li>
                   <a class="dropdown-item" href="{% url 'anvil_consortium_manager:workspaces:list' workspace_type %}">List workspaces</a>
                 </li>
+                {% if perms.anvil_consortium_manager.anvil_project_manager_edit %}
                 <li>
                   <a class="dropdown-item" href="{% url 'anvil_consortium_manager:workspaces:new' workspace_type %}">Create a new workspace</a>
                 </li>
                 <li>
                   <a class="dropdown-item" href="{% url 'anvil_consortium_manager:workspaces:import' workspace_type %}">Import a workspace from AnVIL</a>
                 </li>
+                {% endif %}
                 <li><hr class="dropdown-divider"></li>
               {% endfor %}
 
               <li>
                 <a class="dropdown-item" href="{% url 'anvil_consortium_manager:workspace_group_access:list' %}">Workspace access</a>
               </li>
+              {% if perms.anvil_consortium_manager.anvil_project_manager_edit %}
               <li>
                 <a class="dropdown-item" href="{% url 'anvil_consortium_manager:workspace_group_access:new' %}">Give a group access to a workspace</a>
               </li>
+              {% endif %}
 
               <li>
                 <a class="dropdown-item" href="{% url 'anvil_consortium_manager:workspaces:audit' %}">Audit workspaces</a>

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
@@ -62,8 +62,10 @@
 <p>
   <a href="{% url 'anvil_consortium_manager:workspaces:audit_access' billing_project_slug=object.billing_project.name workspace_slug=object.name %}" class="btn btn-primary" role="button">Audit membership</a>
 </p>
+{% if show_edit_links %}
 <p>
   <a href="{% url 'anvil_consortium_manager:workspaces:delete' billing_project_slug=object.billing_project.name workspace_slug=object.name %}" class="btn btn-danger" role="button">Delete on AnVIL</a>
 </p>
+{% endif %}
 
 {% endblock content %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/workspacegroupaccess_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/workspacegroupaccess_detail.html
@@ -18,9 +18,11 @@
   </ul>
 </div>
 
+{% if show_edit_links %}
 <p>
   <a href="{% url 'anvil_consortium_manager:workspaces:access:update' billing_project_slug=object.workspace.billing_project.name workspace_slug=object.workspace.name group_slug=object.group.name %}" class="btn btn-secondary" role="button">Update Access</a>
   <a href="{% url 'anvil_consortium_manager:workspaces:access:delete' billing_project_slug=object.workspace.billing_project.name workspace_slug=object.workspace.name group_slug=object.group.name %}" class="btn btn-danger" role="button">Delete on AnVIL</a>
 </p>
+{% endif %}
 
 {% endblock content %}

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -4054,6 +4054,51 @@ class ManagedGroupDetailTest(TestCase):
             grandparent_parent_membership, response.context_data["parent_table"].data
         )
 
+    def test_edit_permission(self):
+        """Links to reactivate/deactivate/delete pages appear if the user has edit permission."""
+        edit_user = User.objects.create_user(username="edit", password="test")
+        edit_user.user_permissions.add(
+            Permission.objects.get(
+                codename=models.AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME
+            ),
+            Permission.objects.get(
+                codename=models.AnVILProjectManagerAccess.EDIT_PERMISSION_CODENAME
+            ),
+        )
+        self.client.force_login(edit_user)
+        obj = factories.ManagedGroupFactory.create()
+        response = self.client.get(self.get_url(obj.name))
+        self.assertIn("show_edit_links", response.context_data)
+        self.assertTrue(response.context_data["show_edit_links"])
+        self.assertContains(
+            response,
+            reverse(
+                "anvil_consortium_manager:managed_groups:delete",
+                kwargs={"slug": obj.name},
+            ),
+        )
+
+    def test_view_permission(self):
+        """Links to reactivate/deactivate/delete pages appear if the user has edit permission."""
+        view_user = User.objects.create_user(username="view", password="test")
+        view_user.user_permissions.add(
+            Permission.objects.get(
+                codename=models.AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME
+            ),
+        )
+        self.client.force_login(view_user)
+        obj = factories.ManagedGroupFactory.create()
+        response = self.client.get(self.get_url(obj.name))
+        self.assertIn("show_edit_links", response.context_data)
+        self.assertFalse(response.context_data["show_edit_links"])
+        self.assertNotContains(
+            response,
+            reverse(
+                "anvil_consortium_manager:managed_groups:delete",
+                kwargs={"slug": obj.name},
+            ),
+        )
+
 
 class ManagedGroupCreateTest(AnVILAPIMockTestMixin, TestCase):
 
@@ -5594,6 +5639,57 @@ class WorkspaceDetailTest(TestCase):
         self.assertIn("authorization_domain_table", response.context_data)
         self.assertEqual(
             len(response.context_data["authorization_domain_table"].rows), 0
+        )
+
+    def test_edit_permission(self):
+        """Links to reactivate/deactivate/delete pages appear if the user has edit permission."""
+        edit_user = User.objects.create_user(username="edit", password="test")
+        edit_user.user_permissions.add(
+            Permission.objects.get(
+                codename=models.AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME
+            ),
+            Permission.objects.get(
+                codename=models.AnVILProjectManagerAccess.EDIT_PERMISSION_CODENAME
+            ),
+        )
+        self.client.force_login(edit_user)
+        obj = factories.WorkspaceFactory.create()
+        response = self.client.get(obj.get_absolute_url())
+        self.assertIn("show_edit_links", response.context_data)
+        self.assertTrue(response.context_data["show_edit_links"])
+        self.assertContains(
+            response,
+            reverse(
+                "anvil_consortium_manager:workspaces:delete",
+                kwargs={
+                    "billing_project_slug": obj.billing_project.name,
+                    "workspace_slug": obj.name,
+                },
+            ),
+        )
+
+    def test_view_permission(self):
+        """Links to reactivate/deactivate/delete pages appear if the user has edit permission."""
+        view_user = User.objects.create_user(username="view", password="test")
+        view_user.user_permissions.add(
+            Permission.objects.get(
+                codename=models.AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME
+            ),
+        )
+        self.client.force_login(view_user)
+        obj = factories.WorkspaceFactory.create()
+        response = self.client.get(obj.get_absolute_url())
+        self.assertIn("show_edit_links", response.context_data)
+        self.assertFalse(response.context_data["show_edit_links"])
+        self.assertNotContains(
+            response,
+            reverse(
+                "anvil_consortium_manager:workspaces:delete",
+                kwargs={
+                    "billing_project_slug": obj.billing_project.name,
+                    "workspace_slug": obj.name,
+                },
+            ),
         )
 
 
@@ -8967,6 +9063,57 @@ class GroupGroupMembershipDetailTest(TestCase):
                 request, parent_group_slug="parent", child_group_slug="child"
             )
 
+    def test_edit_permission(self):
+        """Links to delete url appears if the user has edit permission."""
+        edit_user = User.objects.create_user(username="edit", password="test")
+        edit_user.user_permissions.add(
+            Permission.objects.get(
+                codename=models.AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME
+            ),
+            Permission.objects.get(
+                codename=models.AnVILProjectManagerAccess.EDIT_PERMISSION_CODENAME
+            ),
+        )
+        self.client.force_login(edit_user)
+        obj = factories.GroupGroupMembershipFactory.create()
+        response = self.client.get(obj.get_absolute_url())
+        self.assertIn("show_edit_links", response.context_data)
+        self.assertTrue(response.context_data["show_edit_links"])
+        self.assertContains(
+            response,
+            reverse(
+                "anvil_consortium_manager:managed_groups:member_groups:delete",
+                kwargs={
+                    "parent_group_slug": obj.parent_group.name,
+                    "child_group_slug": obj.child_group.name,
+                },
+            ),
+        )
+
+    def test_view_permission(self):
+        """Links to delete url appears if the user has edit permission."""
+        view_user = User.objects.create_user(username="view", password="test")
+        view_user.user_permissions.add(
+            Permission.objects.get(
+                codename=models.AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME
+            ),
+        )
+        self.client.force_login(view_user)
+        obj = factories.GroupGroupMembershipFactory.create()
+        response = self.client.get(obj.get_absolute_url())
+        self.assertIn("show_edit_links", response.context_data)
+        self.assertFalse(response.context_data["show_edit_links"])
+        self.assertNotContains(
+            response,
+            reverse(
+                "anvil_consortium_manager:managed_groups:member_groups:delete",
+                kwargs={
+                    "parent_group_slug": obj.parent_group.name,
+                    "child_group_slug": obj.child_group.name,
+                },
+            ),
+        )
+
 
 class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
 
@@ -9996,6 +10143,57 @@ class GroupAccountMembershipDetailTest(TestCase):
         request.user = self.user
         with self.assertRaises(Http404):
             self.get_view()(request, group_slug="foo1", account_uuid=uuid)
+
+    def test_edit_permission(self):
+        """Links to delete url appears if the user has edit permission."""
+        edit_user = User.objects.create_user(username="edit", password="test")
+        edit_user.user_permissions.add(
+            Permission.objects.get(
+                codename=models.AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME
+            ),
+            Permission.objects.get(
+                codename=models.AnVILProjectManagerAccess.EDIT_PERMISSION_CODENAME
+            ),
+        )
+        self.client.force_login(edit_user)
+        obj = factories.GroupAccountMembershipFactory.create()
+        response = self.client.get(obj.get_absolute_url())
+        self.assertIn("show_edit_links", response.context_data)
+        self.assertTrue(response.context_data["show_edit_links"])
+        self.assertContains(
+            response,
+            reverse(
+                "anvil_consortium_manager:managed_groups:member_accounts:delete",
+                kwargs={
+                    "group_slug": obj.group.name,
+                    "account_uuid": obj.account.uuid,
+                },
+            ),
+        )
+
+    def test_view_permission(self):
+        """Links to delete url appears if the user has edit permission."""
+        view_user = User.objects.create_user(username="view", password="test")
+        view_user.user_permissions.add(
+            Permission.objects.get(
+                codename=models.AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME
+            ),
+        )
+        self.client.force_login(view_user)
+        obj = factories.GroupAccountMembershipFactory.create()
+        response = self.client.get(obj.get_absolute_url())
+        self.assertIn("show_edit_links", response.context_data)
+        self.assertFalse(response.context_data["show_edit_links"])
+        self.assertNotContains(
+            response,
+            reverse(
+                "anvil_consortium_manager:managed_groups:member_accounts:delete",
+                kwargs={
+                    "group_slug": obj.group.name,
+                    "account_uuid": obj.account.uuid,
+                },
+            ),
+        )
 
 
 class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
@@ -11165,6 +11363,59 @@ class WorkspaceGroupAccessDetailTest(TestCase):
                 workspace_slug="workspace",
                 group_slug="group",
             )
+
+    def test_edit_permission(self):
+        """Links to delete url appears if the user has edit permission."""
+        edit_user = User.objects.create_user(username="edit", password="test")
+        edit_user.user_permissions.add(
+            Permission.objects.get(
+                codename=models.AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME
+            ),
+            Permission.objects.get(
+                codename=models.AnVILProjectManagerAccess.EDIT_PERMISSION_CODENAME
+            ),
+        )
+        self.client.force_login(edit_user)
+        obj = factories.WorkspaceGroupAccessFactory.create()
+        response = self.client.get(obj.get_absolute_url())
+        self.assertIn("show_edit_links", response.context_data)
+        self.assertTrue(response.context_data["show_edit_links"])
+        self.assertContains(
+            response,
+            reverse(
+                "anvil_consortium_manager:workspaces:access:delete",
+                kwargs={
+                    "billing_project_slug": obj.workspace.billing_project.name,
+                    "workspace_slug": obj.workspace.name,
+                    "group_slug": obj.group.name,
+                },
+            ),
+        )
+
+    def test_view_permission(self):
+        """Links to delete url appears if the user has edit permission."""
+        view_user = User.objects.create_user(username="view", password="test")
+        view_user.user_permissions.add(
+            Permission.objects.get(
+                codename=models.AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME
+            ),
+        )
+        self.client.force_login(view_user)
+        obj = factories.WorkspaceGroupAccessFactory.create()
+        response = self.client.get(obj.get_absolute_url())
+        self.assertIn("show_edit_links", response.context_data)
+        self.assertFalse(response.context_data["show_edit_links"])
+        self.assertNotContains(
+            response,
+            reverse(
+                "anvil_consortium_manager:workspaces:access:delete",
+                kwargs={
+                    "billing_project_slug": obj.workspace.billing_project.name,
+                    "workspace_slug": obj.workspace.name,
+                    "group_slug": obj.group.name,
+                },
+            ),
+        )
 
 
 class WorkspaceGroupAccessCreateTest(AnVILAPIMockTestMixin, TestCase):

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -244,6 +244,12 @@ class AccountDetail(
         context = super().get_context_data(**kwargs)
         # Add an indicator of whether the account is inactive.
         context["is_inactive"] = self.object.status == models.Account.INACTIVE_STATUS
+        edit_permission_codename = (
+            models.AnVILProjectManagerAccess.EDIT_PERMISSION_CODENAME
+        )
+        context["show_edit_links"] = self.request.user.has_perm(
+            "anvil_consortium_manager." + edit_permission_codename
+        )
         context["show_deactivate_button"] = not context["is_inactive"]
         context["show_reactivate_button"] = context["is_inactive"]
         return context

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -707,6 +707,12 @@ class ManagedGroupDetail(auth.AnVILConsortiumManagerViewRequired, DetailView):
         context["parent_table"] = tables.GroupGroupMembershipTable(
             self.object.parent_memberships.all(), exclude="child_group"
         )
+        edit_permission_codename = (
+            models.AnVILProjectManagerAccess.EDIT_PERMISSION_CODENAME
+        )
+        context["show_edit_links"] = self.request.user.has_perm(
+            "anvil_consortium_manager." + edit_permission_codename
+        )
         return context
 
 
@@ -966,6 +972,12 @@ class WorkspaceDetail(auth.AnVILConsortiumManagerViewRequired, DetailView):
         context["authorization_domain_table"] = tables.ManagedGroupTable(
             self.object.authorization_domains.all(),
             exclude=["workspace", "number_groups", "number_accounts"],
+        )
+        edit_permission_codename = (
+            models.AnVILProjectManagerAccess.EDIT_PERMISSION_CODENAME
+        )
+        context["show_edit_links"] = self.request.user.has_perm(
+            "anvil_consortium_manager." + edit_permission_codename
         )
         return context
 
@@ -1394,6 +1406,16 @@ class GroupGroupMembershipDetail(auth.AnVILConsortiumManagerViewRequired, Detail
             )
         return obj
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        edit_permission_codename = (
+            models.AnVILProjectManagerAccess.EDIT_PERMISSION_CODENAME
+        )
+        context["show_edit_links"] = self.request.user.has_perm(
+            "anvil_consortium_manager." + edit_permission_codename
+        )
+        return context
+
 
 class GroupGroupMembershipCreate(
     auth.AnVILConsortiumManagerEditRequired, SuccessMessageMixin, CreateView
@@ -1530,6 +1552,16 @@ class GroupAccountMembershipDetail(auth.AnVILConsortiumManagerViewRequired, Deta
                 % {"verbose_name": queryset.model._meta.verbose_name}
             )
         return obj
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        edit_permission_codename = (
+            models.AnVILProjectManagerAccess.EDIT_PERMISSION_CODENAME
+        )
+        context["show_edit_links"] = self.request.user.has_perm(
+            "anvil_consortium_manager." + edit_permission_codename
+        )
+        return context
 
 
 class GroupAccountMembershipCreate(
@@ -1692,6 +1724,16 @@ class WorkspaceGroupAccessDetail(auth.AnVILConsortiumManagerViewRequired, Detail
                 % {"verbose_name": queryset.model._meta.verbose_name}
             )
         return obj
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        edit_permission_codename = (
+            models.AnVILProjectManagerAccess.EDIT_PERMISSION_CODENAME
+        )
+        context["show_edit_links"] = self.request.user.has_perm(
+            "anvil_consortium_manager." + edit_permission_codename
+        )
+        return context
 
 
 class WorkspaceGroupAccessCreate(


### PR DESCRIPTION
* Modify most Detail views to add a context_data key "has_edit_permission" to indicate if the user has edit permission.
* Add checks for has_edit_permission on Detail view templates before showing buttons to delete or update objects.
* Modify navbar template to show links to edit views only if the user has edit permission.
* Modify index/home template to show links to edit views only if the user has edit permission.
* Modify index/home template to include text about adding/deleting/etc resources if the user has edit permission.

Closes #191 