### PR TITLE
Workspace data get_absolute_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Devel
 
 - Only show links to views requiring edit permission if the user has that permission.
+- Add a get_absolute_url method for `WorkspaceData` which returns the absolute url of the associated workspace.
 
 ## 0.3 (2022-09-27)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3dev1"
+__version__ = "0.3dev2"

--- a/anvil_consortium_manager/models.py
+++ b/anvil_consortium_manager/models.py
@@ -906,6 +906,9 @@ class BaseWorkspaceData(models.Model):
     class Meta:
         abstract = True
 
+    def get_absolute_url(self):
+        return self.workspace.get_absolute_url()
+
 
 class DefaultWorkspaceData(BaseWorkspaceData):
     """Default empty WorkspaceData model."""

--- a/anvil_consortium_manager/tests/test_models.py
+++ b/anvil_consortium_manager/tests/test_models.py
@@ -13,6 +13,7 @@ from ..adapters.default import DefaultWorkspaceAdapter
 from ..models import (
     Account,
     BillingProject,
+    DefaultWorkspaceData,
     GroupAccountMembership,
     GroupGroupMembership,
     ManagedGroup,
@@ -1152,6 +1153,18 @@ class WorkspaceTest(TestCase):
         with self.assertRaises(ValidationError) as e:
             instance.clean_fields()
         self.assertIn("not a registered adapter type", str(e.exception))
+
+
+class WorkspaceDataTest(TestCase):
+    """Tests for the WorkspaceData models (default and base)."""
+
+    def test_get_absolute_url(self):
+        """get_absolute_url returns the url of the workspace."""
+        workspace = factories.WorkspaceFactory.create()
+        workspace_data = DefaultWorkspaceData(workspace=workspace)
+        self.assertEqual(
+            workspace_data.get_absolute_url(), workspace.get_absolute_url()
+        )
 
 
 class WorkspaceAuthorizationDomainTestCase(TestCase):


### PR DESCRIPTION
- Add a get_absolute_url method to the BaseWorkspaceData class that returns the url of the workspace.

This makes sense because the app doesn't differentiate between WorkspaceData and Workspace in its urls.