### PR TITLE
Add views to create Group Membership objects using url parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 - Add Workspace and ManagedGroup methods to check whether a group has access to a workspace.
 - Rename the `WorkspaceGroupAccess` model to `WorkspaceGroupSharing`, which is more consistent with AnVIL terminology.
 - Reword "access" to "sharing" in WorkspaceGroupSharing-related views and templates.
-- Add more views for creating WorkspaceGroupSharing objects using url parameters.
+- Add more views for creating WorkspaceGroupSharing, GroupAccountMembership, and GroupGroupMembership objects using url parameters.
 
 ## 0.3 (2022-09-27)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.3dev6"
+__version__ = "0.3dev7"

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/account_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/account_detail.html
@@ -61,6 +61,9 @@
 </div>
 
 
+<p>
+  <a href="{% url 'anvil_consortium_manager:accounts:add_to_group' uuid=object.uuid %}" class="btn btn-primary" role="button">Add this account to a group</a>
+</p>
 {% if show_edit_links %}
 <p>
   {% if show_deactivate_button %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/groupaccountmembership_form_byaccount.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/groupaccountmembership_form_byaccount.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 
-<h2>Add Account {{ account }} to a Managed Group</h2>
+<h2>Add {{ account }} to a Managed Group</h2>
 
   <form method="post">
     {% csrf_token %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/groupaccountmembership_form_byaccount.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/groupaccountmembership_form_byaccount.html
@@ -1,0 +1,21 @@
+{% extends "anvil_consortium_manager/base.html" %}
+{% load static %}
+{% load crispy_forms_tags %}
+
+{% block title %}New Group Account Membership{% endblock title %}
+
+{% block content %}
+
+<h2>Add Account {{ account }} to a Managed Group</h2>
+
+  <form method="post">
+    {% csrf_token %}
+    {{ form|crispy }}
+    <button type="submit" class="btn btn-success">Save membership</button>
+  </form>
+
+{% endblock content %}
+
+{% block inline_javascript %}
+  {{ form.media }}
+{% endblock inline_javascript %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/groupaccountmembership_form_bygroup.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/groupaccountmembership_form_bygroup.html
@@ -1,0 +1,21 @@
+{% extends "anvil_consortium_manager/base.html" %}
+{% load static %}
+{% load crispy_forms_tags %}
+
+{% block title %}New Group Account Membership{% endblock title %}
+
+{% block content %}
+
+  <h2>Add an account to Managed Group {{ group }}</h2>
+
+  <form method="post">
+    {% csrf_token %}
+    {{ form|crispy }}
+    <button type="submit" class="btn btn-success">Save membership</button>
+  </form>
+
+{% endblock content %}
+
+{% block inline_javascript %}
+  {{ form.media }}
+{% endblock inline_javascript %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/groupaccountmembership_form_bygroup.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/groupaccountmembership_form_bygroup.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 
-  <h2>Add an account to Managed Group {{ group }}</h2>
+  <h2>Add an Account to {{ group }}</h2>
 
   <form method="post">
     {% csrf_token %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/groupaccountmembership_form_bygroupaccount.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/groupaccountmembership_form_bygroupaccount.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 
-  <h2>Add Account {{ account }} to Managed Group {{ group }}</h2>
+  <h2>Add {{ account }} to {{ group }}</h2>
 
   <form method="post">
     {% csrf_token %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/groupaccountmembership_form_bygroupaccount.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/groupaccountmembership_form_bygroupaccount.html
@@ -1,0 +1,21 @@
+{% extends "anvil_consortium_manager/base.html" %}
+{% load static %}
+{% load crispy_forms_tags %}
+
+{% block title %}New Group Account Membership{% endblock title %}
+
+{% block content %}
+
+  <h2>Add Account {{ account }} to Managed Group {{ group }}</h2>
+
+  <form method="post">
+    {% csrf_token %}
+    {{ form|crispy }}
+    <button type="submit" class="btn btn-success">Save membership</button>
+  </form>
+
+{% endblock content %}
+
+{% block inline_javascript %}
+  {{ form.media }}
+{% endblock inline_javascript %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/groupgroupmembership_form_bychild.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/groupgroupmembership_form_bychild.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 
-  <h2>Add {{ child_group }} to a group</h2>
+  <h2>Add {{ child_group }} to a Managed Group</h2>
 
   <form method="post">
     {% csrf_token %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/groupgroupmembership_form_bychild.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/groupgroupmembership_form_bychild.html
@@ -1,0 +1,20 @@
+{% extends "anvil_consortium_manager/base.html" %}
+{% load static %}
+{% load crispy_forms_tags %}
+
+{% block title %}New Group Group Membership{% endblock title %}
+
+{% block content %}
+
+  <h2>Add {{ child_group }} to a group</h2>
+
+  <form method="post">
+    {% csrf_token %}
+    {{ form|crispy }}
+    <button type="submit" class="btn btn-success">Save membership</button>
+  </form>
+{% endblock %}
+
+{% block inline_javascript %}
+  {{ form.media }}
+{% endblock inline_javascript %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/groupgroupmembership_form_byparent.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/groupgroupmembership_form_byparent.html
@@ -1,0 +1,20 @@
+{% extends "anvil_consortium_manager/base.html" %}
+{% load static %}
+{% load crispy_forms_tags %}
+
+{% block title %}New Group Group Membership{% endblock title %}
+
+{% block content %}
+
+<h2>Add a group to {{ parent_group }}</h2>
+
+  <form method="post">
+    {% csrf_token %}
+    {{ form|crispy }}
+    <button type="submit" class="btn btn-success">Save membership</button>
+  </form>
+{% endblock %}
+
+{% block inline_javascript %}
+  {{ form.media }}
+{% endblock inline_javascript %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/groupgroupmembership_form_byparent.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/groupgroupmembership_form_byparent.html
@@ -6,7 +6,7 @@
 
 {% block content %}
 
-<h2>Add a group to {{ parent_group }}</h2>
+<h2>Add a Managed Group to {{ parent_group }}</h2>
 
   <form method="post">
     {% csrf_token %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/groupgroupmembership_form_byparentchild.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/groupgroupmembership_form_byparentchild.html
@@ -1,0 +1,20 @@
+{% extends "anvil_consortium_manager/base.html" %}
+{% load static %}
+{% load crispy_forms_tags %}
+
+{% block title %}New Group Group Membership{% endblock title %}
+
+{% block content %}
+
+<h2>Add {{ child_group }} to {{ parent_group }}</h2>
+
+  <form method="post">
+    {% csrf_token %}
+    {{ form|crispy }}
+    <button type="submit" class="btn btn-success">Save membership</button>
+  </form>
+{% endblock %}
+
+{% block inline_javascript %}
+  {{ form.media }}
+{% endblock inline_javascript %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/managedgroup_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/managedgroup_detail.html
@@ -142,9 +142,13 @@
 
 <p>
   <a href="{% url 'anvil_consortium_manager:managed_groups:sharing:new' group_slug=object.name %}" class="btn btn-primary" role="button">Share a workspace with this group</a>
-  <a href="{% url 'anvil_consortium_manager:managed_groups:member_accounts:new' group_slug=object.name %}" class="btn btn-primary" role="button">Add an account to this group</a>
 </p>
 
+<p>
+  <a href="{% url 'anvil_consortium_manager:managed_groups:member_accounts:new' group_slug=object.name %}" class="btn btn-primary" role="button">Add an account to this group</a>
+  <a href="{% url 'anvil_consortium_manager:managed_groups:member_groups:new' parent_group_slug=object.name %}" class="btn btn-primary" role="button">Add a group to this group</a>
+  <a href="{% url 'anvil_consortium_manager:managed_groups:add_to_group' group_slug=object.name %}" class="btn btn-primary" role="button">Add this group to another group</a>
+</p>
 <p>
   <a href="{% url 'anvil_consortium_manager:managed_groups:audit_membership' slug=object.name %}" class="btn btn-secondary" role="button">Audit membership</a>
 </p>

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/managedgroup_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/managedgroup_detail.html
@@ -142,6 +142,10 @@
 
 <p>
   <a href="{% url 'anvil_consortium_manager:managed_groups:sharing:new' group_slug=object.name %}" class="btn btn-primary" role="button">Share a workspace with this group</a>
+  <a href="{% url 'anvil_consortium_manager:managed_groups:member_accounts:new' group_slug=object.name %}" class="btn btn-primary" role="button">Add an account to this group</a>
+</p>
+
+<p>
   <a href="{% url 'anvil_consortium_manager:managed_groups:audit_membership' slug=object.name %}" class="btn btn-secondary" role="button">Audit membership</a>
 </p>
 {% if show_edit_links %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/workspacegroupsharing_form_bygroup.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/workspacegroupsharing_form_bygroup.html
@@ -5,7 +5,7 @@
 {% block title %}New Workspace Group Sharing{% endblock title %}
 
 {% block content %}
-  <h2>Share a Workspace with Managed Group {{ group }}</h2>
+  <h2>Share a Workspace with {{ group }}</h2>
 
 <p></p>
 

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/workspacegroupsharing_form_byworkspace.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/workspacegroupsharing_form_byworkspace.html
@@ -5,7 +5,7 @@
 {% block title %}New Workspace Group Sharing{% endblock title %}
 
 {% block content %}
-  <h2>Share Workspace {{workspace}} with a Managed Group</h2>
+  <h2>Share {{workspace}} with a Managed Group</h2>
 
 <p></p>
 

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/workspacegroupsharing_form_byworkspacegroup.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/workspacegroupsharing_form_byworkspacegroup.html
@@ -5,7 +5,7 @@
 {% block title %}New Workspace Group Sharing{% endblock title %}
 
 {% block content %}
-  <h2>Share Workspace {{workspace}} with Managed Group {{group}}</h2>
+  <h2>Share {{workspace}} with {{group}}</h2>
 
 <p></p>
 

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -11006,7 +11006,7 @@ class GroupAccountMembershipCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
                 request,
                 group_slug="foo",
             )
-        self.assertEqual(models.WorkspaceGroupSharing.objects.count(), 0)
+        self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
 
     def test_invalid_account(self):
         """Form is not valid if the account does not exist."""
@@ -11183,6 +11183,447 @@ class GroupAccountMembershipCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.group.name),
+            {
+                "group": self.group.pk,
+                "account": account.pk,
+                "role": models.GroupGroupMembership.MEMBER,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("form", response.context_data)
+        form = response.context_data["form"]
+        self.assertFalse(form.is_valid())
+        self.assertEqual(len(form.errors), 1)
+        self.assertIn("account", form.errors.keys())
+        self.assertIn("valid choice", form.errors["account"][0])
+        self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
+
+
+class GroupAccountMembershipCreateByAccountTest(AnVILAPIMockTestMixin, TestCase):
+
+    api_success_code = 204
+
+    def setUp(self):
+        """Set up test class."""
+        # The superclass uses the responses package to mock API responses.
+        super().setUp()
+        self.factory = RequestFactory()
+        # Create a user with both view and edit permissions.
+        self.user = User.objects.create_user(username="test", password="test")
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                codename=models.AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME
+            )
+        )
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                codename=models.AnVILProjectManagerAccess.EDIT_PERMISSION_CODENAME
+            )
+        )
+        self.account = factories.AccountFactory.create()
+        self.group = factories.ManagedGroupFactory.create()
+
+    def get_url(self, *args):
+        """Get the url for the view being tested."""
+        return reverse("anvil_consortium_manager:accounts:add_to_group", args=args)
+
+    def get_view(self):
+        """Return the view being tested."""
+        return views.GroupAccountMembershipCreateByAccount.as_view()
+
+    def get_api_json_response(
+        self, invites_sent=[], users_not_found=[], users_updated=[]
+    ):
+        return {
+            "invitesSent": invites_sent,
+            "usersNotFound": users_not_found,
+            "usersUpdated": users_updated,
+        }
+
+    def test_view_redirect_not_logged_in(self):
+        "View redirects to login view when user is not logged in."
+        # Need a client for redirects.
+        response = self.client.get(self.get_url(self.account.uuid))
+        self.assertRedirects(
+            response,
+            resolve_url(settings.LOGIN_URL)
+            + "?next="
+            + self.get_url(self.account.uuid),
+        )
+
+    def test_status_code_with_user_permission(self):
+        """Returns successful response code."""
+        request = self.factory.get(self.get_url(self.account.uuid))
+        request.user = self.user
+        response = self.get_view()(request, uuid=self.account.uuid)
+        self.assertEqual(response.status_code, 200)
+
+    def test_access_with_view_permission(self):
+        """Raises permission denied if user has only view permission."""
+        user_with_view_perm = User.objects.create_user(
+            username="test-other", password="test-other"
+        )
+        user_with_view_perm.user_permissions.add(
+            Permission.objects.get(
+                codename=models.AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME
+            )
+        )
+        request = self.factory.get(self.get_url(self.account.uuid))
+        request.user = user_with_view_perm
+        with self.assertRaises(PermissionDenied):
+            self.get_view()(request, uuid=self.account.uuid)
+
+    def test_access_without_user_permission(self):
+        """Raises permission denied if user has no permissions."""
+        user_no_perms = User.objects.create_user(
+            username="test-none", password="test-none"
+        )
+        request = self.factory.get(self.get_url(self.account.uuid))
+        request.user = user_no_perms
+        with self.assertRaises(PermissionDenied):
+            self.get_view()(request, uuid=self.account.uuid)
+
+    def test_has_form_in_context(self):
+        """Response includes a form."""
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url(self.account.uuid))
+        self.assertTrue("form" in response.context_data)
+        self.assertIsInstance(
+            response.context_data["form"], forms.GroupAccountMembershipForm
+        )
+
+    def test_context_account(self):
+        """Context contains the account."""
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url(self.account.uuid))
+        self.assertTrue("account" in response.context_data)
+        self.assertEqual(response.context_data["account"], self.account)
+
+    def test_form_hidden_input(self):
+        """The proper inputs are hidden in the form."""
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url(self.account.uuid))
+        self.assertTrue("form" in response.context_data)
+        self.assertIsInstance(
+            response.context_data["form"].fields["account"].widget, HiddenInput
+        )
+
+    def test_can_create_an_object_member(self):
+        """Posting valid data to the form creates an object."""
+        url = (
+            self.entry_point
+            + "/api/groups/"
+            + self.group.name
+            + "/MEMBER/"
+            + self.account.email
+        )
+        responses.add(responses.PUT, url, status=self.api_success_code)
+        self.client.force_login(self.user)
+        response = self.client.post(
+            self.get_url(self.account.uuid),
+            {
+                "group": self.group.pk,
+                "account": self.account.pk,
+                "role": models.GroupAccountMembership.MEMBER,
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        new_object = models.GroupAccountMembership.objects.latest("pk")
+        self.assertIsInstance(new_object, models.GroupAccountMembership)
+        self.assertEqual(new_object.role, models.GroupAccountMembership.MEMBER)
+        self.assertEqual(new_object.group, self.group)
+        self.assertEqual(new_object.account, self.account)
+        responses.assert_call_count(url, 1)
+
+    def test_success_message(self):
+        """Response includes a success message if successful."""
+        url = (
+            self.entry_point
+            + "/api/groups/"
+            + self.group.name
+            + "/MEMBER/"
+            + self.account.email
+        )
+        responses.add(responses.PUT, url, status=self.api_success_code)
+        self.client.force_login(self.user)
+        response = self.client.post(
+            self.get_url(self.account.uuid),
+            {
+                "group": self.group.pk,
+                "account": self.account.pk,
+                "role": models.GroupAccountMembership.MEMBER,
+            },
+            follow=True,
+        )
+        self.assertIn("messages", response.context)
+        messages = list(response.context["messages"])
+        self.assertEqual(len(messages), 1)
+        self.assertEqual(
+            views.GroupAccountMembershipCreate.success_msg, str(messages[0])
+        )
+
+    def test_can_create_an_object_admin(self):
+        """Posting valid data to the form creates an object."""
+        url = (
+            self.entry_point
+            + "/api/groups/"
+            + self.group.name
+            + "/ADMIN/"
+            + self.account.email
+        )
+        responses.add(responses.PUT, url, status=self.api_success_code)
+        self.client.force_login(self.user)
+        response = self.client.post(
+            self.get_url(self.account.uuid),
+            {
+                "group": self.group.pk,
+                "account": self.account.pk,
+                "role": models.GroupAccountMembership.ADMIN,
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        new_object = models.GroupAccountMembership.objects.latest("pk")
+        self.assertIsInstance(new_object, models.GroupAccountMembership)
+        self.assertEqual(new_object.role, models.GroupAccountMembership.ADMIN)
+        self.assertEqual(new_object.group, self.group)
+        self.assertEqual(new_object.account, self.account)
+        responses.assert_call_count(url, 1)
+
+    def test_success_redirect(self):
+        """After successfully creating an object, view redirects to the model's list view."""
+        # This needs to use the client because the RequestFactory doesn't handle redirects.
+        url = (
+            self.entry_point
+            + "/api/groups/"
+            + self.group.name
+            + "/ADMIN/"
+            + self.account.email
+        )
+        responses.add(responses.PUT, url, status=self.api_success_code)
+        self.client.force_login(self.user)
+        response = self.client.post(
+            self.get_url(self.account.uuid),
+            {
+                "group": self.group.pk,
+                "account": self.account.pk,
+                "role": models.GroupAccountMembership.ADMIN,
+            },
+        )
+        obj = models.GroupAccountMembership.objects.latest("pk")
+        self.assertRedirects(response, obj.get_absolute_url())
+        responses.assert_call_count(url, 1)
+
+    def test_cannot_create_duplicate_object_with_different_role(self):
+        """Cannot create a second GroupAccountMembership object for the same account and group with a different role."""
+        obj = factories.GroupAccountMembershipFactory(
+            group=self.group,
+            account=self.account,
+            role=models.GroupAccountMembership.MEMBER,
+        )
+        self.client.force_login(self.user)
+        response = self.client.post(
+            self.get_url(self.account.uuid),
+            {
+                "group": self.group.pk,
+                "account": self.account.pk,
+                "role": models.GroupAccountMembership.ADMIN,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        form = response.context_data["form"]
+        self.assertFalse(form.is_valid())
+        self.assertIn("already exists", form.non_field_errors()[0])
+        self.assertQuerysetEqual(
+            models.GroupAccountMembership.objects.all(),
+            models.GroupAccountMembership.objects.filter(pk=obj.pk),
+        )
+        obj.refresh_from_db()
+        self.assertEqual(obj.role, models.GroupAccountMembership.MEMBER)
+
+    def test_get_account_not_found(self):
+        """Raises 404 if group in URL does not exist when posting data."""
+        uuid = uuid4()
+        request = self.factory.get(self.get_url(uuid))
+        request.user = self.user
+        with self.assertRaises(Http404):
+            self.get_view()(request, uuid=uuid)
+        self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
+
+    def test_post_account_not_found(self):
+        """Raises 404 if group in URL does not exist when posting data."""
+        uuid = uuid4()
+        request = self.factory.post(
+            self.get_url(
+                uuid,
+            ),
+            {
+                "group": self.group.pk,
+                "account": self.account.pk + 1,
+                "role": models.GroupAccountMembership.MEMBER,
+            },
+        )
+        request.user = self.user
+        with self.assertRaises(Http404):
+            self.get_view()(
+                request,
+                uuid=uuid,
+            )
+        self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
+
+    def test_group_not_found(self):
+        """Form is not valid if the group does not exist."""
+        self.client.force_login(self.user)
+        response = self.client.post(
+            self.get_url(self.account.uuid),
+            {
+                "group": self.group.pk + 1,
+                "account": self.account.pk,
+                "role": models.GroupAccountMembership.ADMIN,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        form = response.context_data["form"]
+        self.assertFalse(form.is_valid())
+        self.assertEqual(len(form.errors), 1)
+        self.assertIn("group", form.errors)
+        self.assertEqual(len(form.errors["group"]), 1)
+        self.assertIn("valid choice", form.errors["group"][0])
+        self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
+
+    def test_group_not_managed_by_app(self):
+        """Form is not valid if the group is not managed by the app."""
+        group = factories.ManagedGroupFactory.create(is_managed_by_app=False)
+        self.client.force_login(self.user)
+        response = self.client.post(
+            self.get_url(self.account.uuid),
+            {
+                "group": group.pk,
+                "account": self.account.pk,
+                "role": models.GroupAccountMembership.ADMIN,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        form = response.context_data["form"]
+        self.assertFalse(form.is_valid())
+        self.assertEqual(len(form.errors), 1)
+        self.assertIn("group", form.errors)
+        self.assertEqual(len(form.errors["group"]), 1)
+        self.assertIn("valid choice", form.errors["group"][0])
+        self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
+
+    def test_invalid_input_role(self):
+        """Posting invalid data to role field does not create an object."""
+        self.client.force_login(self.user)
+        response = self.client.post(
+            self.get_url(self.account.uuid),
+            {"group": self.group.pk, "account": self.account.pk, "role": "foo"},
+        )
+        self.assertEqual(response.status_code, 200)
+        form = response.context_data["form"]
+        self.assertFalse(form.is_valid())
+        self.assertIn("role", form.errors.keys())
+        self.assertIn("valid choice", form.errors["role"][0])
+        self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
+
+    def test_post_blank_data(self):
+        """Posting blank data does not create an object."""
+        self.client.force_login(self.user)
+        response = self.client.post(self.get_url(self.account.uuid), {})
+        self.assertEqual(response.status_code, 200)
+        form = response.context_data["form"]
+        self.assertFalse(form.is_valid())
+        self.assertIn("group", form.errors.keys())
+        self.assertIn("required", form.errors["group"][0])
+        self.assertIn("account", form.errors.keys())
+        self.assertIn("required", form.errors["account"][0])
+        self.assertIn("role", form.errors.keys())
+        self.assertIn("required", form.errors["role"][0])
+        self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
+
+    def test_post_blank_data_group(self):
+        """Posting blank data to the group field does not create an object."""
+        self.client.force_login(self.user)
+        response = self.client.post(
+            self.get_url(self.account.uuid),
+            {"account": self.account.pk, "role": models.GroupAccountMembership.MEMBER},
+        )
+        self.assertEqual(response.status_code, 200)
+        form = response.context_data["form"]
+        self.assertFalse(form.is_valid())
+        self.assertIn("group", form.errors.keys())
+        self.assertIn("required", form.errors["group"][0])
+        self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
+
+    def test_post_blank_data_account(self):
+        """Posting blank data to the account field does not create an object."""
+        self.client.force_login(self.user)
+        response = self.client.post(
+            self.get_url(self.account.uuid),
+            {"group": self.group.pk, "role": models.GroupAccountMembership.MEMBER},
+        )
+        self.assertEqual(response.status_code, 200)
+        form = response.context_data["form"]
+        self.assertFalse(form.is_valid())
+        self.assertIn("account", form.errors.keys())
+        self.assertIn("required", form.errors["account"][0])
+        self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
+
+    def test_post_blank_data_role(self):
+        """Posting blank data to the role field does not create an object."""
+        self.client.force_login(self.user)
+        response = self.client.post(
+            self.get_url(self.account.uuid),
+            {"group": self.group.pk, "account": self.account.pk},
+        )
+        self.assertEqual(response.status_code, 200)
+        form = response.context_data["form"]
+        self.assertFalse(form.is_valid())
+        self.assertIn("role", form.errors.keys())
+        self.assertIn("required", form.errors["role"][0])
+        self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
+
+    def test_api_error(self):
+        """Shows a message if an AnVIL API error occurs."""
+        url = (
+            self.entry_point
+            + "/api/groups/"
+            + self.group.name
+            + "/MEMBER/"
+            + self.account.email
+        )
+        responses.add(
+            responses.PUT,
+            url,
+            status=500,
+            json={"message": "group account membership create test error"},
+        )
+        self.client.force_login(self.user)
+        response = self.client.post(
+            self.get_url(self.account.uuid),
+            {
+                "group": self.group.pk,
+                "account": self.account.pk,
+                "role": models.GroupGroupMembership.MEMBER,
+            },
+        )
+        self.assertEqual(response.status_code, 200)
+        self.assertIn("messages", response.context)
+        messages = list(response.context["messages"])
+        self.assertEqual(len(messages), 1)
+        self.assertIn(
+            "AnVIL API Error: group account membership create test error",
+            str(messages[0]),
+        )
+        responses.assert_call_count(url, 1)
+        # Make sure that the object was not created.
+        self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
+
+    def test_cannot_add_inactive_account_to_group(self):
+        """Cannot add an inactive account to a group."""
+        account = factories.AccountFactory.create(status=models.Account.INACTIVE_STATUS)
+        self.client.force_login(self.user)
+        response = self.client.post(
+            self.get_url(self.account.uuid),
             {
                 "group": self.group.pk,
                 "account": account.pk,

--- a/anvil_consortium_manager/urls.py
+++ b/anvil_consortium_manager/urls.py
@@ -48,6 +48,11 @@ account_patterns = (
             views.AccountLinkVerify.as_view(),
             name="verify",
         ),
+        path(
+            "<uuid:uuid>/add_to_group/",
+            views.GroupAccountMembershipCreateByAccount.as_view(),
+            name="add_to_group",
+        ),
         path("audit/", views.AccountAudit.as_view(), name="audit"),
     ],
     "accounts",

--- a/anvil_consortium_manager/urls.py
+++ b/anvil_consortium_manager/urls.py
@@ -72,6 +72,11 @@ member_group_patterns = (
 member_account_patterns = (
     [
         path(
+            "new",
+            views.GroupAccountMembershipCreateByGroup.as_view(),
+            name="new",
+        ),
+        path(
             "<uuid:account_uuid>/",
             views.GroupAccountMembershipDetail.as_view(),
             name="detail",
@@ -79,7 +84,7 @@ member_account_patterns = (
         path(
             "<uuid:account_uuid>/new/",
             views.GroupAccountMembershipCreateByGroupAccount.as_view(),
-            name="new",
+            name="new_by_account",
         ),
         path(
             "<uuid:account_uuid>/delete/",

--- a/anvil_consortium_manager/urls.py
+++ b/anvil_consortium_manager/urls.py
@@ -77,6 +77,11 @@ member_account_patterns = (
             name="detail",
         ),
         path(
+            "<uuid:account_uuid>/new/",
+            views.GroupAccountMembershipCreateByGroupAccount.as_view(),
+            name="new",
+        ),
+        path(
             "<uuid:account_uuid>/delete/",
             views.GroupAccountMembershipDelete.as_view(),
             name="delete",

--- a/anvil_consortium_manager/urls.py
+++ b/anvil_consortium_manager/urls.py
@@ -61,9 +61,19 @@ account_patterns = (
 member_group_patterns = (
     [
         path(
+            "new/",
+            views.GroupGroupMembershipCreateByParent.as_view(),
+            name="new",
+        ),
+        path(
             "<slug:child_group_slug>/",
             views.GroupGroupMembershipDetail.as_view(),
             name="detail",
+        ),
+        path(
+            "<slug:child_group_slug>/new/",
+            views.GroupGroupMembershipCreateByParentChild.as_view(),
+            name="new_by_child",
         ),
         path(
             "<slug:child_group_slug>/delete/",
@@ -130,6 +140,11 @@ managed_group_patterns = (
         path("<slug:parent_group_slug>/member_groups/", include(member_group_patterns)),
         path("<slug:group_slug>/member_accounts/", include(member_account_patterns)),
         path("<slug:group_slug>/sharing/", include(managed_group_sharing_patterns)),
+        path(
+            "<slug:group_slug>/add_to_group/",
+            views.GroupGroupMembershipCreateByChild.as_view(),
+            name="add_to_group",
+        ),
     ],
     "managed_groups",
 )

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -1652,6 +1652,57 @@ class GroupAccountMembershipCreateByGroup(GroupAccountMembershipCreate):
         return self.object.get_absolute_url()
 
 
+class GroupAccountMembershipCreateByAccount(GroupAccountMembershipCreate):
+    """View to create a new GroupAccountMembership for the account specified in the url."""
+
+    template_name = (
+        "anvil_consortium_manager/groupaccountmembership_form_byaccount.html"
+    )
+
+    message_not_managed_by_app = (
+        "Cannot add Account because this group is not managed by the app."
+    )
+    message_group_not_found = "Managed Group not found on AnVIL."
+    """Message to display when the ManagedGroup was not found on AnVIL."""
+
+    message_already_exists = "This Account is already a member of this Managed Group."
+
+    def get_account(self):
+        try:
+            account_uuid = self.kwargs["uuid"]
+            account = models.Account.objects.get(uuid=account_uuid)
+        except models.Account.DoesNotExist:
+            raise Http404("Account not found.")
+        return account
+
+    def get(self, request, *args, **kwargs):
+        self.account = self.get_account()
+        return super().get(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        self.account = self.get_account()
+        return super().post(request, *args, **kwargs)
+
+    def get_initial(self):
+        initial = super().get_initial()
+        initial["account"] = self.account
+        return initial
+
+    def get_form(self, **kwargs):
+        """Get the form and set the inputs to use a hidden widget."""
+        form = super().get_form(**kwargs)
+        form.fields["account"].widget = HiddenInput()
+        return form
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["account"] = self.account
+        return context
+
+    def get_success_url(self):
+        return self.object.get_absolute_url()
+
+
 class GroupAccountMembershipCreateByGroupAccount(GroupAccountMembershipCreate):
     """View to create a new GroupAccountMembership object for the group and account specified in the url."""
 

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -1597,6 +1597,61 @@ class GroupAccountMembershipCreate(
         return super().form_valid(form)
 
 
+class GroupAccountMembershipCreateByGroup(GroupAccountMembershipCreate):
+    """View to create a new GroupAccountMembership for the group specified in the url."""
+
+    template_name = "anvil_consortium_manager/groupaccountmembership_form_bygroup.html"
+
+    message_not_managed_by_app = (
+        "Cannot add Account because this group is not managed by the app."
+    )
+    message_group_not_found = "Managed Group not found on AnVIL."
+    """Message to display when the ManagedGroup was not found on AnVIL."""
+
+    message_already_exists = "This Account is already a member of this Managed Group."
+
+    def get_group(self):
+        try:
+            group_slug = self.kwargs["group_slug"]
+            group = models.ManagedGroup.objects.get(name=group_slug)
+        except models.ManagedGroup.DoesNotExist:
+            raise Http404("Workspace or ManagedGroup not found.")
+        return group
+
+    def get(self, request, *args, **kwargs):
+        self.group = self.get_group()
+        if not self.group.is_managed_by_app:
+            messages.error(self.request, self.message_not_managed_by_app)
+            return HttpResponseRedirect(self.group.get_absolute_url())
+        return super().get(request, *args, **kwargs)
+
+    def post(self, request, *args, **kwargs):
+        self.group = self.get_group()
+        if not self.group.is_managed_by_app:
+            messages.error(self.request, self.message_not_managed_by_app)
+            return HttpResponseRedirect(self.group.get_absolute_url())
+        return super().post(request, *args, **kwargs)
+
+    def get_initial(self):
+        initial = super().get_initial()
+        initial["group"] = self.group
+        return initial
+
+    def get_form(self, **kwargs):
+        """Get the form and set the inputs to use a hidden widget."""
+        form = super().get_form(**kwargs)
+        form.fields["group"].widget = HiddenInput()
+        return form
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context["group"] = self.group
+        return context
+
+    def get_success_url(self):
+        return self.object.get_absolute_url()
+
+
 class GroupAccountMembershipCreateByGroupAccount(GroupAccountMembershipCreate):
     """View to create a new GroupAccountMembership object for the group and account specified in the url."""
 


### PR DESCRIPTION
Add views to create a GroupGroupMembership by specifying:
* The parent group in the url
* The child group in the url
* Both the parent and child groups in the url

Add views to create a GroupAccountMembership by specifying:
* The group in the url
* The account in the url
* Both the group and the account in the url