### PR TITLE
Feature/notification when account is linked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## 0.8 (unreleased)
+
+- Add ability to send a notification email when a user links their AnVIL account.
+
 ## 0.6 (2022-11-29)
 
 - Add ability to update `BillingProject`, `Account`, `ManagedGroup`, and `Workspace`, and workspace data models.

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.6"
+__version__ = "0.8dev2"

--- a/anvil_consortium_manager/models.py
+++ b/anvil_consortium_manager/models.py
@@ -175,6 +175,25 @@ class UserEmailEntry(TimeStampedModel, models.Model):
         )
         send_mail(mail_subject, message, None, [self.email], fail_silently=False)
 
+    def send_notification_email(self):
+        """Send notification email after account is verified if the email setting is set"""
+        if hasattr(settings, "ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL"):
+            mail_subject = "User verified AnVIL account"
+            message = render_to_string(
+                "anvil_consortium_manager/account_notification_email.html",
+                {
+                    "email": self.email,
+                    "user": self.user,
+                },
+            )
+            send_mail(
+                mail_subject,
+                message,
+                None,
+                [settings.ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL],
+                fail_silently=False,
+            )
+
 
 class Account(TimeStampedModel, ActivatorModel):
     """A model to store information about AnVIL accounts."""

--- a/anvil_consortium_manager/models.py
+++ b/anvil_consortium_manager/models.py
@@ -177,7 +177,10 @@ class UserEmailEntry(TimeStampedModel, models.Model):
 
     def send_notification_email(self):
         """Send notification email after account is verified if the email setting is set"""
-        if hasattr(settings, "ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL"):
+        if (
+            hasattr(settings, "ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL")
+            and settings.ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL
+        ):
             mail_subject = "User verified AnVIL account"
             message = render_to_string(
                 "anvil_consortium_manager/account_notification_email.html",

--- a/anvil_consortium_manager/models.py
+++ b/anvil_consortium_manager/models.py
@@ -180,6 +180,7 @@ class UserEmailEntry(TimeStampedModel, models.Model):
         if (
             hasattr(settings, "ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL")
             and settings.ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL
+            and not settings.ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL.isspace()
         ):
             mail_subject = "User verified AnVIL account"
             message = render_to_string(

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/account_notification_email.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/account_notification_email.html
@@ -1,0 +1,5 @@
+{% autoescape off %}
+
+{{ user.username }} has verified {{ email }}
+
+{% endautoescape %}

--- a/anvil_consortium_manager/tests/test_models.py
+++ b/anvil_consortium_manager/tests/test_models.py
@@ -2,13 +2,12 @@ import datetime
 import time
 from unittest import skip
 
-from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core import mail
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.db.models.deletion import ProtectedError
 from django.db.utils import IntegrityError
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from django.utils import timezone
 from freezegun import freeze_time
 
@@ -179,9 +178,9 @@ class UserEmailEntryTest(TestCase):
         self.assertIn(account_verification_token.make_token(email_entry), email_body)
         self.assertIn(str(email_entry.uuid), email_body)
 
+    @override_settings(ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL="notify@example.com")
     def test_send_notification_email(self):
         """Notification email is sent if ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL is set"""
-        settings.ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL = "notify@example.com"
         email_entry = factories.UserEmailEntryFactory.create()
         email_entry.send_notification_email()
         self.assertEqual(len(mail.outbox), 1)

--- a/anvil_consortium_manager/tests/test_models.py
+++ b/anvil_consortium_manager/tests/test_models.py
@@ -2,6 +2,7 @@ import datetime
 import time
 from unittest import skip
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.core import mail
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
@@ -177,6 +178,19 @@ class UserEmailEntryTest(TestCase):
         self.assertIn(email_entry.user.username, email_body)
         self.assertIn(account_verification_token.make_token(email_entry), email_body)
         self.assertIn(str(email_entry.uuid), email_body)
+
+    def test_send_notification_email(self):
+        """Notification email is sent if ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL is set"""
+        settings.ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL = "notify@example.com"
+        email_entry = factories.UserEmailEntryFactory.create()
+        email_entry.send_notification_email()
+        self.assertEqual(len(mail.outbox), 1)
+
+    def test_not_send_notification_email(self):
+        """Notification email is not sent if ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL is not set"""
+        email_entry = factories.UserEmailEntryFactory.create()
+        email_entry.send_notification_email()
+        self.assertEqual(len(mail.outbox), 0)
 
 
 class AccountTest(TestCase):

--- a/anvil_consortium_manager/tests/test_models.py
+++ b/anvil_consortium_manager/tests/test_models.py
@@ -186,7 +186,21 @@ class UserEmailEntryTest(TestCase):
         self.assertEqual(len(mail.outbox), 1)
 
     def test_not_send_notification_email(self):
-        """Notification email is not sent if ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL is not set"""
+        """Notification email is not sent if ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL is not set."""
+        email_entry = factories.UserEmailEntryFactory.create()
+        email_entry.send_notification_email()
+        self.assertEqual(len(mail.outbox), 0)
+
+    @override_settings(ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL=None)
+    def test_send_notification_email_none(self):
+        """Notification email is sent if ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL is set."""
+        email_entry = factories.UserEmailEntryFactory.create()
+        email_entry.send_notification_email()
+        self.assertEqual(len(mail.outbox), 0)
+
+    @override_settings(ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL="  ")
+    def test_send_notification_email_spaces(self):
+        """Notification email is sent if ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL is set to only spaces."""
         email_entry = factories.UserEmailEntryFactory.create()
         email_entry.send_notification_email()
         self.assertEqual(len(mail.outbox), 0)

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -497,6 +497,7 @@ class AccountLinkVerify(LoginRequiredMixin, RedirectView):
         # Mark the entry as verified.
         email_entry.date_verified = timezone.now()
         email_entry.save()
+        email_entry.send_notification_email()
 
         # Save the account
         account.full_clean()

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -57,6 +57,8 @@ Settings
       ANVIL_ACCOUNT_LINK_REDIRECT = "home"
       # Specify the subject for AnVIL account verification emails.
       ANVIL_ACCOUNT_LINK_EMAIL_SUBJECT = "Verify your AnVIL account email"
+      # Specify the email to receive notification when account is linked
+      ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL = "to@example.com"
 
 
 Permissions

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -57,7 +57,14 @@ Settings
       ANVIL_ACCOUNT_LINK_REDIRECT = "home"
       # Specify the subject for AnVIL account verification emails.
       ANVIL_ACCOUNT_LINK_EMAIL_SUBJECT = "Verify your AnVIL account email"
-      # Specify the email to receive notification when account is linked
+
+
+Optional settings
+~~~~~~~~~~~~~~~~~
+If you would like to receive emails when a user links their account, set the ``ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL`` setting in your settings file.
+
+  .. code-block:: python
+
       ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL = "to@example.com"
 
 

--- a/example_site/settings.py
+++ b/example_site/settings.py
@@ -213,8 +213,8 @@ ANVIL_API_SERVICE_ACCOUNT_FILE = os.getenv("ANVIL_API_SERVICE_ACCOUNT_FILE")
 ANVIL_ACCOUNT_LINK_REDIRECT = "home"
 # Specify the subject for AnVIL account verification emails.
 ANVIL_ACCOUNT_LINK_EMAIL_SUBJECT = "Verify your AnVIL account email"
-# Specify the email address to send an email to after a user verifies an account
-ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL = ""
+# If desired, specify the email address to send an email to after a user verifies an account.
+# ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL = "to@example.com"
 
 # Workspace adapters.
 ANVIL_WORKSPACE_ADAPTERS = [

--- a/example_site/settings.py
+++ b/example_site/settings.py
@@ -213,6 +213,8 @@ ANVIL_API_SERVICE_ACCOUNT_FILE = os.getenv("ANVIL_API_SERVICE_ACCOUNT_FILE")
 ANVIL_ACCOUNT_LINK_REDIRECT = "home"
 # Specify the subject for AnVIL account verification emails.
 ANVIL_ACCOUNT_LINK_EMAIL_SUBJECT = "Verify your AnVIL account email"
+# Specify the email address to send an email to after a user verifies an account
+ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL = ""
 
 # Workspace adapters.
 ANVIL_WORKSPACE_ADAPTERS = [


### PR DESCRIPTION
- Add a setting ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL
- If setttings.ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL is set, after a user verifies an account with views.AccountLinkVerify send an email to the email specified in settings.ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL.
- Add a test to check if the email is sent when settings.ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL is set.
- Add a test to check if the email is not sent when settings.ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL is not set.