### PR TITLE
Add user to the Account table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Change `Workspace` link on AnVIL to use `anvil.terra.bio` instead of `app.terra.bio`
 - Add ability to send a notification email when a user links their AnVIL account.
+- Display the linked user in the `AccountTable` table.
 
 ## 0.7 (2022-12-07)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.8dev2"
+__version__ = "0.8dev3"

--- a/anvil_consortium_manager/tables.py
+++ b/anvil_consortium_manager/tables.py
@@ -27,7 +27,7 @@ class AccountTable(tables.Table):
 
     class Meta:
         model = models.Account
-        fields = ("email", "is_service_account", "status")
+        fields = ("email", "user", "is_service_account", "status")
 
 
 class ManagedGroupTable(tables.Table):

--- a/anvil_consortium_manager/tables.py
+++ b/anvil_consortium_manager/tables.py
@@ -1,4 +1,5 @@
 import django_tables2 as tables
+from django.utils.safestring import mark_safe
 
 from . import models
 from .adapters.workspace import workspace_adapter_registry
@@ -28,6 +29,16 @@ class AccountTable(tables.Table):
     class Meta:
         model = models.Account
         fields = ("email", "user", "is_service_account", "status")
+
+    def render_user(self, record):
+        """If user.get_absolute_url is defined, then include link to it. Otherwise, just show the user."""
+        if hasattr(record.user, "get_absolute_url"):
+            link = """<a href="{url}">{link_text}</a>""".format(
+                link_text=str(record), url=record.user.get_absolute_url()
+            )
+            return mark_safe(link)
+        else:
+            return str(record.user)
 
 
 class ManagedGroupTable(tables.Table):


### PR DESCRIPTION
* Show the linked user in the Account table.
* If `user` has a `get_absolute_url()` method, display a link to that url.

Closes #236