### PR TITLE
Link to user profile on AccountDetail page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Change `Workspace` link on AnVIL to use `anvil.terra.bio` instead of `app.terra.bio`
 - Add ability to send a notification email when a user links their AnVIL account.
 - Display the linked user in the `AccountTable` table.
+- Show a link to the linked user on the `AccountDetail` page.
 
 ## 0.7 (2022-12-07)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.8dev3"
+__version__ = "0.8dev4"

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/account_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/account_detail.html
@@ -34,7 +34,16 @@
     <li>Status: {{ object.get_status_display }}</li>
     <li>Date added: {{ object.created }}</li>
     <li>Date modified: {{ object.modified }}</li>
-    <li>User: {% if object.verified_email_entry %}{{ object.verified_email_entry.user }}{% else %} &mdash; {% endif %}</li>
+    <li>User:
+      {% if object.verified_email_entry %}
+        {% if object.verified_email_entry.user.get_absolute_url %}
+          <a href="{{ object.verified_email_entry.user.get_absolute_url }}">{{ object.verified_email_entry.user }}</a>
+        {% else %}
+          {{ object.verified_email_entry.user }}
+        {% endif %}
+      {% else %}
+        &mdash;
+      {% endif %}</li>
     <li>Date verified by user: {% if object.verified_email_entry %}{{ object.verified_email_entry.date_verified }}{% else %} &mdash; {% endif %}</li>
   </ul>
 {% endblock panel %}


### PR DESCRIPTION
If the user model has a get_absolute_url method, link to the user profile page on the AccountDetail page. Otherwise, just show the user object.