### PR TITLE
Use `responses.RequestMock` in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Devel
 
 - Update `anvil_api` to use Rawls and Sam APIs for most API calls. These APIs were recommended over the Firecloud API by Terra support.
+- Modify `AnVILAPIMockTestMixin` to use the `responses.RequestMock` object instead of just adding to `responses`.
+- In tests, require that all registered requests are actually requested.
 
 ## 0.9 (2023-01-09)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.10dev1"
+__version__ = "0.10dev2"

--- a/anvil_consortium_manager/tests/test_models_anvil_api_unit.py
+++ b/anvil_consortium_manager/tests/test_models_anvil_api_unit.py
@@ -20,16 +20,14 @@ class BillingProjectAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
 
     def test_anvil_exists_does_exist(self):
-        responses.add(responses.GET, self.url, status=200)
+        self.response_mock.add(responses.GET, self.url, status=200)
         self.assertIs(self.object.anvil_exists(), True)
-        responses.assert_call_count(self.url, 1)
 
     def test_anvil_exists_does_not_exist(self):
-        responses.add(
+        self.response_mock.add(
             responses.GET, self.url, status=404, json={"message": "mock message"}
         )
         self.assertIs(self.object.anvil_exists(), False)
-        responses.assert_call_count(self.url, 1)
 
 
 class BillingProjectAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
@@ -50,7 +48,7 @@ class BillingProjectAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase)
     def test_can_import_billing_project_where_we_are_users(self):
         """A BillingProject is created if there if we are users of the billing project on AnVIL."""
         billing_project_name = "test-billing-project"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(billing_project_name),
             status=200,
@@ -70,7 +68,7 @@ class BillingProjectAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase)
     def test_cannot_import_billing_project_where_we_are_not_users(self):
         """No BillingProjects are created if there if we are not users of the billing project."""
         billing_project_name = "test-billing-project"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(billing_project_name),
             status=404,
@@ -96,7 +94,7 @@ class BillingProjectAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase)
     def test_anvil_import_api_internal_error(self):
         """No BillingProjects are created if there is an internal error from the AnVIL API."""
         billing_project_name = "test-billing-project"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(billing_project_name),
             status=500,  # error response code.
@@ -110,7 +108,7 @@ class BillingProjectAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase)
     def test_anvil_import_api_error_other(self):
         """No BillingProjects are created if there is some other error from the AnVIL API."""
         billing_project_name = "test-billing-project"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(billing_project_name),
             status=499,  # error response code.
@@ -158,7 +156,7 @@ class BillingProjectAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         """anvil_audit works correct if one billing project exists in the app and in AnVIL."""
         billing_project = factories.BillingProjectFactory.create(has_app_as_user=True)
         api_url = self.get_api_url(billing_project.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -170,13 +168,12 @@ class BillingProjectAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(audit_results.get_verified(), {billing_project})
         self.assertEqual(audit_results.get_errors(), {})
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(api_url, 1)
 
     def test_anvil_audit_one_billing_project_not_on_anvil(self):
         """anvil_audit raises exception with one billing project exists in the app but not on AnVIL."""
         billing_project = factories.BillingProjectFactory.create(has_app_as_user=True)
         api_url = self.get_api_url(billing_project.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=404,
@@ -191,13 +188,12 @@ class BillingProjectAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             {billing_project: [audit_results.ERROR_NOT_IN_ANVIL]},
         )
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(api_url, 1)
 
     def test_anvil_audit_two_billing_projects_no_errors(self):
         """anvil_audit returns None if there are two billing projects and both exist on AnVIL."""
         billing_project_1 = factories.BillingProjectFactory.create(has_app_as_user=True)
         api_url_1 = self.get_api_url(billing_project_1.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_1,
             status=200,
@@ -205,7 +201,7 @@ class BillingProjectAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         billing_project_2 = factories.BillingProjectFactory.create(has_app_as_user=True)
         api_url_2 = self.get_api_url(billing_project_2.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_2,
             status=200,
@@ -219,14 +215,12 @@ class BillingProjectAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         self.assertEqual(audit_results.get_errors(), {})
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(api_url_1, 1)
-        responses.assert_call_count(api_url_2, 1)
 
     def test_anvil_audit_two_billing_projects_first_not_on_anvil(self):
         """anvil_audit raises exception if two billing projects exist in the app but the first is not on AnVIL."""
         billing_project_1 = factories.BillingProjectFactory.create(has_app_as_user=True)
         api_url_1 = self.get_api_url(billing_project_1.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_1,
             status=404,
@@ -234,7 +228,7 @@ class BillingProjectAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         billing_project_2 = factories.BillingProjectFactory.create(has_app_as_user=True)
         api_url_2 = self.get_api_url(billing_project_2.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_2,
             status=200,
@@ -249,14 +243,12 @@ class BillingProjectAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             {billing_project_1: [audit_results.ERROR_NOT_IN_ANVIL]},
         )
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(api_url_1, 1)
-        responses.assert_call_count(api_url_2, 1)
 
     def test_anvil_audit_two_billing_projects_both_missing(self):
         """anvil_audit raises exception if there are two billing projects that exist in the app but not in AnVIL."""
         billing_project_1 = factories.BillingProjectFactory.create(has_app_as_user=True)
         api_url_1 = self.get_api_url(billing_project_1.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_1,
             status=404,
@@ -264,7 +256,7 @@ class BillingProjectAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         billing_project_2 = factories.BillingProjectFactory.create(has_app_as_user=True)
         api_url_2 = self.get_api_url(billing_project_2.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_2,
             status=404,
@@ -282,8 +274,6 @@ class BillingProjectAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             },
         )
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(api_url_1, 1)
-        responses.assert_call_count(api_url_2, 1)
 
     def test_anvil_audit_ignore_not_has_app_has_user(self):
         """anvil_audit does not check AnVIL about billing projects that do not have the app as a user."""
@@ -316,26 +306,23 @@ class UserEmailEntryAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         }
 
     def test_anvil_account_exists_does_exist(self):
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
             json=self.get_api_user_json_response(self.object.email),
         )
         self.assertIs(self.object.anvil_account_exists(), True)
-        responses.assert_call_count(self.api_url, 1)
 
     def test_anvil_account_exists_does_not_exist(self):
-        responses.add(
+        self.response_mock.add(
             responses.GET, self.api_url, status=404, json={"message": "mock message"}
         )
         self.assertIs(self.object.anvil_account_exists(), False)
-        responses.assert_call_count(self.api_url, 1)
 
     def test_anvil_account_exists_associated_with_group(self):
-        responses.add(responses.GET, self.api_url, status=204)
+        self.response_mock.add(responses.GET, self.api_url, status=204)
         self.assertIs(self.object.anvil_account_exists(), False)
-        responses.assert_call_count(self.api_url, 1)
 
 
 class AccountAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
@@ -373,26 +360,23 @@ class AccountAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         }
 
     def test_anvil_exists_does_exist(self):
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
             json=self.get_api_user_json_response(self.object.email),
         )
         self.assertIs(self.object.anvil_exists(), True)
-        responses.assert_call_count(self.api_url, 1)
 
     def test_anvil_exists_does_not_exist(self):
-        responses.add(
+        self.response_mock.add(
             responses.GET, self.api_url, status=404, json={"message": "mock message"}
         )
         self.assertIs(self.object.anvil_exists(), False)
-        responses.assert_call_count(self.api_url, 1)
 
     def test_anvil_exists_email_is_group(self):
-        responses.add(responses.GET, self.api_url, status=204)
+        self.response_mock.add(responses.GET, self.api_url, status=204)
         self.assertIs(self.object.anvil_exists(), False)
-        responses.assert_call_count(self.api_url, 1)
 
     def test_anvil_remove_from_groups_in_no_groups(self):
         """anvil_remove_from_groups succeeds if the account is not in any groups."""
@@ -404,11 +388,10 @@ class AccountAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         membership = factories.GroupAccountMembershipFactory.create(account=self.object)
         group = membership.group
         remove_from_group_url = self.get_api_remove_from_group_url(group.name)
-        responses.add(responses.DELETE, remove_from_group_url, status=204)
+        self.response_mock.add(responses.DELETE, remove_from_group_url, status=204)
         self.object.anvil_remove_from_groups()
         # The membership was removed.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 1)
-        responses.assert_call_count(remove_from_group_url, 1)
 
     def test_anvil_remove_from_groups_in_two_groups(self):
         """anvil_remove_from_groups succeeds if the account is in two groups."""
@@ -419,13 +402,11 @@ class AccountAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         group_2 = memberships[1].group
         remove_from_group_url_1 = self.get_api_remove_from_group_url(group_1.name)
         remove_from_group_url_2 = self.get_api_remove_from_group_url(group_2.name)
-        responses.add(responses.DELETE, remove_from_group_url_1, status=204)
-        responses.add(responses.DELETE, remove_from_group_url_2, status=204)
+        self.response_mock.add(responses.DELETE, remove_from_group_url_1, status=204)
+        self.response_mock.add(responses.DELETE, remove_from_group_url_2, status=204)
         self.object.anvil_remove_from_groups()
         # The membership was removed.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 2)
-        responses.assert_call_count(remove_from_group_url_1, 1)
-        responses.assert_call_count(remove_from_group_url_2, 1)
 
     def test_anvil_remove_from_groups_api_failure(self):
         """anvil_remove_from_groups does not remove group memberships if any API call failed."""
@@ -434,8 +415,8 @@ class AccountAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         group_2 = self.object.groupaccountmembership_set.all()[1].group
         remove_from_group_url_1 = self.get_api_remove_from_group_url(group_1.name)
         remove_from_group_url_2 = self.get_api_remove_from_group_url(group_2.name)
-        responses.add(responses.DELETE, remove_from_group_url_1, status=204)
-        responses.add(
+        self.response_mock.add(responses.DELETE, remove_from_group_url_1, status=204)
+        self.response_mock.add(
             responses.DELETE,
             remove_from_group_url_2,
             status=409,
@@ -445,8 +426,6 @@ class AccountAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             self.object.anvil_remove_from_groups()
         # No memberships were removed.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 2)
-        responses.assert_call_count(remove_from_group_url_1, 1)
-        responses.assert_call_count(remove_from_group_url_2, 1)
 
     def test_deactivate_no_groups(self):
         """deactivate properly sets the status field if the account is not in any groups."""
@@ -460,14 +439,12 @@ class AccountAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         membership = factories.GroupAccountMembershipFactory.create(account=self.object)
         group = membership.group
         remove_from_group_url = self.get_api_remove_from_group_url(group.name)
-        responses.add(responses.DELETE, remove_from_group_url, status=204)
+        self.response_mock.add(responses.DELETE, remove_from_group_url, status=204)
         self.object.deactivate()
         self.object.refresh_from_db()
         self.assertEqual(self.object.status, self.object.INACTIVE_STATUS)
         # The membership was not removed from the app.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 1)
-        # The URL was called.
-        responses.assert_call_count(remove_from_group_url, 1)
 
     def test_deactivate_two_groups(self):
         """deactivate succeeds if the account is in two groups."""
@@ -478,16 +455,13 @@ class AccountAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         group_2 = memberships[1].group
         remove_from_group_url_1 = self.get_api_remove_from_group_url(group_1.name)
         remove_from_group_url_2 = self.get_api_remove_from_group_url(group_2.name)
-        responses.add(responses.DELETE, remove_from_group_url_1, status=204)
-        responses.add(responses.DELETE, remove_from_group_url_2, status=204)
+        self.response_mock.add(responses.DELETE, remove_from_group_url_1, status=204)
+        self.response_mock.add(responses.DELETE, remove_from_group_url_2, status=204)
         self.object.deactivate()
         self.object.refresh_from_db()
         self.assertEqual(self.object.status, self.object.INACTIVE_STATUS)
         # The memberships were not removed.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 2)
-        # API was called.
-        responses.assert_call_count(remove_from_group_url_1, 1)
-        responses.assert_call_count(remove_from_group_url_2, 1)
 
     def test_reactivate_no_groups(self):
         """reactivate properly sets the status field if the account is not in any groups."""
@@ -505,14 +479,12 @@ class AccountAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         membership = factories.GroupAccountMembershipFactory.create(account=self.object)
         group = membership.group
         add_to_group_url = self.get_api_add_to_group_url(group.name)
-        responses.add(responses.PUT, add_to_group_url, status=204)
+        self.response_mock.add(responses.PUT, add_to_group_url, status=204)
         self.object.reactivate()
         self.object.refresh_from_db()
         self.assertEqual(self.object.status, self.object.ACTIVE_STATUS)
         # The membership was not removed from the app.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 1)
-        # The URL was called.
-        responses.assert_call_count(add_to_group_url, 1)
 
     def test_reactivate_two_groups(self):
         """reactivate succeeds if the account is in two groups."""
@@ -525,16 +497,13 @@ class AccountAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         group_2 = memberships[1].group
         add_to_group_url_1 = self.get_api_add_to_group_url(group_1.name)
         add_to_group_url_2 = self.get_api_add_to_group_url(group_2.name)
-        responses.add(responses.PUT, add_to_group_url_1, status=204)
-        responses.add(responses.PUT, add_to_group_url_2, status=204)
+        self.response_mock.add(responses.PUT, add_to_group_url_1, status=204)
+        self.response_mock.add(responses.PUT, add_to_group_url_2, status=204)
         self.object.reactivate()
         self.object.refresh_from_db()
         self.assertEqual(self.object.status, self.object.ACTIVE_STATUS)
         # The memberships were not removed.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 2)
-        # API was called.
-        responses.assert_call_count(add_to_group_url_1, 1)
-        responses.assert_call_count(add_to_group_url_2, 1)
 
 
 class AccountAnVILAuditAnVILAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
@@ -564,7 +533,7 @@ class AccountAnVILAuditAnVILAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         """anvil_audit works correct if there is one account in the app and it exists on AnVIL."""
         account = factories.AccountFactory.create()
         api_url = self.get_api_url(account.email)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -575,13 +544,12 @@ class AccountAnVILAuditAnVILAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(audit_results.get_verified(), {account})
         self.assertEqual(audit_results.get_errors(), {})
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(api_url, 1)
 
     def test_anvil_audit_one_account_not_on_anvil(self):
         """anvil_audit raises exception if one billing project exists in the app but not on AnVIL."""
         account = factories.AccountFactory.create()
         api_url = self.get_api_url(account.email)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=404,
@@ -594,13 +562,12 @@ class AccountAnVILAuditAnVILAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             audit_results.get_errors(), {account: [audit_results.ERROR_NOT_IN_ANVIL]}
         )
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(api_url, 1)
 
     def test_anvil_audit_two_accounts_no_errors(self):
         """anvil_audit returns None if if two accounts exist in both the app and AnVIL."""
         account_1 = factories.AccountFactory.create()
         api_url_1 = self.get_api_url(account_1.email)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_1,
             status=200,
@@ -608,7 +575,7 @@ class AccountAnVILAuditAnVILAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         account_2 = factories.AccountFactory.create()
         api_url_2 = self.get_api_url(account_2.email)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_2,
             status=200,
@@ -619,14 +586,12 @@ class AccountAnVILAuditAnVILAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(audit_results.get_verified(), set([account_1, account_2]))
         self.assertEqual(audit_results.get_errors(), {})
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(api_url_1, 1)
-        responses.assert_call_count(api_url_2, 1)
 
     def test_anvil_audit_two_accounts_first_not_on_anvil(self):
         """anvil_audit raises exception if two accounts exist in the app but the first is not not on AnVIL."""
         account_1 = factories.AccountFactory.create()
         api_url_1 = self.get_api_url(account_1.email)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_1,
             status=404,
@@ -634,7 +599,7 @@ class AccountAnVILAuditAnVILAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         account_2 = factories.AccountFactory.create()
         api_url_2 = self.get_api_url(account_2.email)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_2,
             status=200,
@@ -647,14 +612,12 @@ class AccountAnVILAuditAnVILAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             audit_results.get_errors(), {account_1: [audit_results.ERROR_NOT_IN_ANVIL]}
         )
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(api_url_1, 1)
-        responses.assert_call_count(api_url_2, 1)
 
     def test_anvil_audit_two_accounts_both_missing(self):
         """anvil_audit raises exception if there are two accounts that exist in the app but not in AnVIL."""
         account_1 = factories.AccountFactory.create()
         api_url_1 = self.get_api_url(account_1.email)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_1,
             status=404,
@@ -662,7 +625,7 @@ class AccountAnVILAuditAnVILAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         account_2 = factories.AccountFactory.create()
         api_url_2 = self.get_api_url(account_2.email)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_2,
             status=404,
@@ -679,8 +642,6 @@ class AccountAnVILAuditAnVILAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             },
         )
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(api_url_1, 1)
-        responses.assert_call_count(api_url_2, 1)
 
     def test_anvil_audit_deactivated_account(self):
         """anvil_audit does not check AnVIL about accounts that are deactivated."""
@@ -709,24 +670,22 @@ class ManagedGroupAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
 
     def test_anvil_exists_does_exist(self):
-        responses.add(
+        self.response_mock.add(
             responses.GET, self.api_url_exists, status=200, json=self.object.get_email()
         )
         self.assertIs(self.object.anvil_exists(), True)
-        responses.assert_call_count(self.api_url_exists, 1)
 
     def test_anvil_exists_does_not_exist(self):
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url_exists,
             status=404,
             json={"message": "mock message"},
         )
         self.assertIs(self.object.anvil_exists(), False)
-        responses.assert_call_count(self.api_url_exists, 1)
 
     def test_anvil_exists_internal_error(self):
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url_exists,
             status=500,
@@ -734,21 +693,19 @@ class ManagedGroupAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError500):
             self.object.anvil_exists()
-        responses.assert_call_count(self.api_url_exists, 1)
 
     def test_anvil_create_successful(self):
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url_create,
             status=201,
             json={"message": "mock message"},
         )
         self.object.anvil_create()
-        responses.assert_call_count(self.api_url_create, 1)
 
     def test_anvil_create_already_exists(self):
         """Returns documented response code when a group already exists."""
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url_create,
             status=409,
@@ -756,12 +713,11 @@ class ManagedGroupAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError409):
             self.object.anvil_create()
-        responses.assert_call_count(self.api_url_create, 1)
 
     def test_anvil_create_internal_error(
         self,
     ):
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url_create,
             status=500,
@@ -769,10 +725,9 @@ class ManagedGroupAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError500):
             self.object.anvil_create()
-        responses.assert_call_count(self.api_url_create, 1)
 
     def test_anvil_create_other(self):
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url_create,
             status=499,
@@ -780,20 +735,18 @@ class ManagedGroupAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError):
             self.object.anvil_create()
-        responses.assert_call_count(self.api_url_create, 1)
 
     def test_anvil_delete_existing(self):
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             self.api_url_delete,
             status=204,
             json={"message": "mock message"},
         )
         self.object.anvil_delete()
-        responses.assert_call_count(self.api_url_delete, 1)
 
     def test_anvil_delete_forbidden(self):
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             self.api_url_delete,
             status=403,
@@ -801,10 +754,9 @@ class ManagedGroupAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError403):
             self.object.anvil_delete()
-        responses.assert_call_count(self.api_url_delete, 1)
 
     def test_anvil_delete_not_found(self):
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             self.api_url_delete,
             status=404,
@@ -812,10 +764,9 @@ class ManagedGroupAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError404):
             self.object.anvil_delete()
-        responses.assert_call_count(self.api_url_delete, 1)
 
     def test_anvil_delete_in_use(self):
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             self.api_url_delete,
             status=409,
@@ -823,10 +774,9 @@ class ManagedGroupAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError409):
             self.object.anvil_delete()
-        responses.assert_call_count(self.api_url_delete, 1)
 
     def test_anvil_delete_other(self):
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             self.api_url_delete,
             status=499,
@@ -834,7 +784,6 @@ class ManagedGroupAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError):
             self.object.anvil_delete()
-        responses.assert_call_count(self.api_url_delete, 1)
 
 
 class ManagedGroupAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
@@ -859,7 +808,7 @@ class ManagedGroupAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_anvil_import_admin_on_anvil(self):
         group_name = "test-group"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(),
             status=200,  # successful response code.
@@ -882,7 +831,7 @@ class ManagedGroupAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_anvil_import_admin_on_anvil_lowercase(self):
         group_name = "test-group"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(),
             status=200,  # successful response code.
@@ -905,7 +854,7 @@ class ManagedGroupAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_anvil_import_member_on_anviL(self):
         group_name = "test-group"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(),
             status=200,  # successful response code.
@@ -928,7 +877,7 @@ class ManagedGroupAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_anvil_import_member_on_anvil_lowercase(self):
         group_name = "test-group"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(),
             status=200,  # successful response code.
@@ -951,7 +900,7 @@ class ManagedGroupAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_anvil_import_not_member_or_admin(self):
         group_name = "test-group"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(),
             status=200,  # successful response code.
@@ -985,7 +934,7 @@ class ManagedGroupAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_anvil_import_api_internal_error(self):
         group_name = "test-group"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(),
             status=500,
@@ -1045,7 +994,7 @@ class ManagedGroupAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
     def test_anvil_audit_no_groups(self):
         """anvil_audit works correct if there are no ManagedGroups in the app."""
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -1062,21 +1011,21 @@ class ManagedGroupAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         """anvil_audit works correct if there is one account in the app and it exists on AnVIL."""
         group = factories.ManagedGroupFactory.create(is_managed_by_app=True)
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
             json=[self.get_api_group_json(group.name, "admin")],
         )
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -1088,29 +1037,26 @@ class ManagedGroupAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(audit_results.get_verified(), set([group]))
         self.assertEqual(audit_results.get_errors(), {})
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(api_url, 1)
-        responses.assert_call_count(api_url_members, 1)
-        responses.assert_call_count(api_url_admins, 1)
 
     def test_anvil_audit_one_group_managed_by_app_lowercase_role(self):
         """anvil_audit works correct if there is one account in the app and it exists on AnVIL."""
         group = factories.ManagedGroupFactory.create(is_managed_by_app=True)
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
             json=[self.get_api_group_json(group.name, "admin")],
         )
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -1122,15 +1068,12 @@ class ManagedGroupAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(audit_results.get_verified(), set([group]))
         self.assertEqual(audit_results.get_errors(), {})
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(api_url, 1)
-        responses.assert_call_count(api_url_members, 1)
-        responses.assert_call_count(api_url_admins, 1)
 
     def test_anvil_audit_one_group_not_managed_by_app_no_errors(self):
         """anvil_audit works correct if there is one account in the app and it exists on AnVIL."""
         group = factories.ManagedGroupFactory.create(is_managed_by_app=False)
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -1142,13 +1085,12 @@ class ManagedGroupAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(audit_results.get_verified(), set([group]))
         self.assertEqual(audit_results.get_errors(), {})
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(api_url, 1)
 
     def test_anvil_audit_one_group_not_managed_by_app_no_errors_lowercase_role(self):
         """anvil_audit works correct if there is one account in the app and it exists on AnVIL."""
         group = factories.ManagedGroupFactory.create(is_managed_by_app=False)
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -1160,13 +1102,12 @@ class ManagedGroupAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(audit_results.get_verified(), set([group]))
         self.assertEqual(audit_results.get_errors(), {})
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(api_url, 1)
 
     def test_anvil_audit_one_group_not_on_anvil(self):
         """anvil_audit raises exception if one group exists in the app but not on AnVIL."""
         group = factories.ManagedGroupFactory.create()
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -1180,13 +1121,12 @@ class ManagedGroupAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             audit_results.get_errors(), {group: [audit_results.ERROR_NOT_IN_ANVIL]}
         )
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(api_url, 1)
 
     def test_anvil_audit_one_group_admin_in_app_member_on_anvil(self):
         """anvil_audit raises exception if one group exists in the app as an admin but the role on AnVIL is member."""
         group = factories.ManagedGroupFactory.create(is_managed_by_app=True)
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -1200,13 +1140,12 @@ class ManagedGroupAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             audit_results.get_errors(), {group: [audit_results.ERROR_DIFFERENT_ROLE]}
         )
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(api_url, 1)
 
     def test_anvil_audit_one_group_member_in_app_admin_on_anvil(self):
         """anvil_audit raises exception if one group exists in the app as an member but the role on AnVIL is admin."""
         group = factories.ManagedGroupFactory.create(is_managed_by_app=False)
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -1220,14 +1159,13 @@ class ManagedGroupAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             audit_results.get_errors(), {group: [audit_results.ERROR_DIFFERENT_ROLE]}
         )
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(api_url, 1)
 
     def test_anvil_audit_two_groups_no_errors(self):
         """anvil_audit works correctly if if two groups exist in both the app and AnVIL."""
         group_1 = factories.ManagedGroupFactory.create()
         group_2 = factories.ManagedGroupFactory.create(is_managed_by_app=False)
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -1237,14 +1175,14 @@ class ManagedGroupAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             ],
         )
         api_url_members = self.get_api_url_members(group_1.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group_1.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -1256,16 +1194,13 @@ class ManagedGroupAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(audit_results.get_verified(), set([group_1, group_2]))
         self.assertEqual(audit_results.get_errors(), {})
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(api_url, 1)
-        responses.assert_call_count(api_url_members, 1)
-        responses.assert_call_count(api_url_admins, 1)
 
     def test_anvil_audit_two_groups_json_response_order_does_not_matter(self):
         """Order of groups in the json response does not matter."""
         group_1 = factories.ManagedGroupFactory.create()
         group_2 = factories.ManagedGroupFactory.create(is_managed_by_app=False)
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -1275,14 +1210,14 @@ class ManagedGroupAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             ],
         )
         api_url_members = self.get_api_url_members(group_1.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group_1.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -1294,30 +1229,27 @@ class ManagedGroupAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(audit_results.get_verified(), set([group_1, group_2]))
         self.assertEqual(audit_results.get_errors(), {})
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(api_url, 1)
-        responses.assert_call_count(api_url_members, 1)
-        responses.assert_call_count(api_url_admins, 1)
 
     def test_anvil_audit_two_groups_first_not_on_anvil(self):
         """anvil_audit raises exception if two groups exist in the app but the first is not not on AnVIL."""
         group_1 = factories.ManagedGroupFactory.create()
         group_2 = factories.ManagedGroupFactory.create()
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
             json=[self.get_api_group_json(group_2.name, "admin")],
         )
         api_url_members = self.get_api_url_members(group_2.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group_2.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -1331,16 +1263,13 @@ class ManagedGroupAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             audit_results.get_errors(), {group_1: [audit_results.ERROR_NOT_IN_ANVIL]}
         )
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(api_url, 1)
-        responses.assert_call_count(api_url_members, 1)
-        responses.assert_call_count(api_url_admins, 1)
 
     def test_anvil_audit_two_accounts_both_missing(self):
         """anvil_audit raises exception if there are two groups that exist in the app but not in AnVIL."""
         group_1 = factories.ManagedGroupFactory.create()
         group_2 = factories.ManagedGroupFactory.create()
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -1358,12 +1287,11 @@ class ManagedGroupAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             },
         )
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(api_url, 1)
 
     def test_anvil_audit_one_group_member_missing_in_app(self):
         """anvil_audit works correctly if the service account is a member of a group not in the app."""
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -1375,12 +1303,11 @@ class ManagedGroupAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(audit_results.get_verified(), set([]))
         self.assertEqual(audit_results.get_errors(), {})
         self.assertEqual(audit_results.get_not_in_app(), set(["test-group"]))
-        responses.assert_call_count(api_url, 1)
 
     def test_anvil_audit_one_group_admin_missing_in_app(self):
         """anvil_audit works correctly if the service account is an admin of a group not in the app."""
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -1392,12 +1319,11 @@ class ManagedGroupAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(audit_results.get_verified(), set([]))
         self.assertEqual(audit_results.get_errors(), {})
         self.assertEqual(audit_results.get_not_in_app(), set(["test-group"]))
-        responses.assert_call_count(api_url, 1)
 
     def test_anvil_audit_two_groups_missing_in_app(self):
         """anvil_audit works correctly if there are two groups in AnVIL that aren't in the app."""
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -1415,28 +1341,27 @@ class ManagedGroupAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             audit_results.get_not_in_app(),
             set(["test-group-admin", "test-group-member"]),
         )
-        responses.assert_call_count(api_url, 1)
 
     def test_fails_membership_audit(self):
         """Error is reported when a group fails the membership audit."""
         group = factories.ManagedGroupFactory.create()
         factories.GroupAccountMembershipFactory.create(group=group)
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
             json=[self.get_api_group_json(group.name, "Admin")],
         )
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -1487,14 +1412,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
         """anvil_audit works correctly if this group has no members."""
         group = factories.ManagedGroupFactory.create()
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -1514,14 +1439,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
         group = factories.ManagedGroupFactory.create()
         membership = factories.GroupAccountMembershipFactory.create(group=group)
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[membership.account.email]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -1542,7 +1467,7 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
         membership_1 = factories.GroupAccountMembershipFactory.create(group=group)
         membership_2 = factories.GroupAccountMembershipFactory.create(group=group)
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
@@ -1551,7 +1476,7 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
             ),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -1573,14 +1498,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
         group = factories.ManagedGroupFactory.create()
         membership = factories.GroupAccountMembershipFactory.create(group=group)
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -1604,14 +1529,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
         membership_1 = factories.GroupAccountMembershipFactory.create(group=group)
         membership_2 = factories.GroupAccountMembershipFactory.create(group=group)
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -1636,14 +1561,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
         """anvil_audit works correctly if this group has one account member not in the app."""
         group = factories.ManagedGroupFactory.create()
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=["test-member@example.com"]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -1664,7 +1589,7 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
         """anvil_audit works correctly if this group has two account member not in the app."""
         group = factories.ManagedGroupFactory.create()
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
@@ -1673,7 +1598,7 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
             ),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -1703,14 +1628,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
             group=group, account__email="tEsT-mEmBeR@example.com"
         )
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=["Test-Member@example.com"]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -1732,14 +1657,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
             group=group, role=models.GroupAccountMembership.ADMIN
         )
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -1764,14 +1689,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
             group=group, role=models.GroupAccountMembership.ADMIN
         )
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -1797,14 +1722,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
             group=group, role=models.GroupAccountMembership.ADMIN
         )
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -1832,14 +1757,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
             group=group, role=models.GroupAccountMembership.ADMIN
         )
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -1864,14 +1789,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
         """anvil_audit works correctly if this group has one account member not in the app."""
         group = factories.ManagedGroupFactory.create()
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -1892,14 +1817,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
         """anvil_audit works correctly if this group has two account admin not in the app."""
         group = factories.ManagedGroupFactory.create()
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -1928,14 +1853,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
             role=models.GroupAccountMembership.ADMIN,
         )
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -1957,14 +1882,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
             group=group, role=models.GroupAccountMembership.MEMBER
         )
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -1989,7 +1914,7 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
         group = factories.ManagedGroupFactory.create()
         membership = factories.GroupGroupMembershipFactory.create(parent_group=group)
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
@@ -1998,7 +1923,7 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
             ),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -2019,7 +1944,7 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
         membership_1 = factories.GroupGroupMembershipFactory.create(parent_group=group)
         membership_2 = factories.GroupGroupMembershipFactory.create(parent_group=group)
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
@@ -2031,7 +1956,7 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
             ),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -2053,14 +1978,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
         group = factories.ManagedGroupFactory.create()
         membership = factories.GroupGroupMembershipFactory.create(parent_group=group)
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -2084,14 +2009,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
         membership_1 = factories.GroupGroupMembershipFactory.create(parent_group=group)
         membership_2 = factories.GroupGroupMembershipFactory.create(parent_group=group)
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -2116,7 +2041,7 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
         """anvil_audit works correctly if this group has one group member not in the app."""
         group = factories.ManagedGroupFactory.create()
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
@@ -2125,7 +2050,7 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
             ),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -2146,7 +2071,7 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
         """anvil_audit works correctly if this group has two group member not in the app."""
         group = factories.ManagedGroupFactory.create()
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
@@ -2155,7 +2080,7 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
             ),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -2185,7 +2110,7 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
             parent_group=group, child_group__name="tEsT-mEmBeR"
         )
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
@@ -2194,7 +2119,7 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
             ),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -2216,14 +2141,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
             parent_group=group, role=models.GroupGroupMembership.ADMIN
         )
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -2250,14 +2175,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
             parent_group=group, role=models.GroupGroupMembership.ADMIN
         )
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -2286,14 +2211,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
             parent_group=group, role=models.GroupGroupMembership.ADMIN
         )
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -2321,14 +2246,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
             parent_group=group, role=models.GroupGroupMembership.ADMIN
         )
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -2353,14 +2278,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
         """anvil_audit works correctly if this group has one group member not in the app."""
         group = factories.ManagedGroupFactory.create()
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -2381,14 +2306,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
         """anvil_audit works correctly if this group has two group admin not in the app."""
         group = factories.ManagedGroupFactory.create()
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -2422,14 +2347,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
             role=models.GroupGroupMembership.ADMIN,
         )
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -2451,14 +2376,14 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
             parent_group=group, role=models.GroupGroupMembership.MEMBER
         )
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -2485,7 +2410,7 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
         """No errors are reported when the service account is both a member and an admin of a group."""
         group = factories.ManagedGroupFactory.create()
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
@@ -2494,7 +2419,7 @@ class ManagedGroupMembershipAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, Te
             ),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -2524,22 +2449,20 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
 
     def test_anvil_exists_does_exist(self):
-        responses.add(responses.GET, self.url_workspace, status=200)
+        self.response_mock.add(responses.GET, self.url_workspace, status=200)
         self.assertIs(self.object.anvil_exists(), True)
-        responses.assert_call_count(self.url_workspace, 1)
 
     def test_anvil_exists_does_not_exist(self):
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.url_workspace,
             status=404,
             json={"message": "mock message"},
         )
         self.assertIs(self.object.anvil_exists(), False)
-        responses.assert_call_count(self.url_workspace, 1)
 
     def test_anvil_exists_forbidden(self):
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.url_workspace,
             status=403,
@@ -2547,10 +2470,9 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError403):
             self.object.anvil_exists()
-        responses.assert_call_count(self.url_workspace, 1)
 
     def test_anvil_exists_internal_error(self):
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.url_workspace,
             status=500,
@@ -2558,7 +2480,6 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError500):
             self.object.anvil_exists()
-        responses.assert_call_count(self.url_workspace, 1)
 
     def test_anvil_create_successful(self):
         json = {
@@ -2566,14 +2487,13 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             "name": self.object.name,
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.url_create,
             status=201,
             match=[responses.matchers.json_params_matcher(json)],
         )
         self.object.anvil_create()
-        responses.assert_call_count(self.url_create, 1)
 
     def test_anvil_create_bad_request(self):
         """Returns documented response code when workspace already exists."""
@@ -2582,7 +2502,7 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             "name": self.object.name,
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.url_create,
             status=400,
@@ -2591,7 +2511,6 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError):
             self.object.anvil_create()
-        responses.assert_call_count(self.url_create, 1)
 
     def test_anvil_create_forbidden(self):
         """Returns documented response code when a workspace can't be created."""
@@ -2600,7 +2519,7 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             "name": self.object.name,
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.url_create,
             status=403,
@@ -2609,7 +2528,6 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError403):
             self.object.anvil_create()
-        responses.assert_call_count(self.url_create, 1)
 
     def test_anvil_create_404(self):
         """Returns documented response code when a workspace can't be created."""
@@ -2618,7 +2536,7 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             "name": self.object.name,
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.url_create,
             status=404,
@@ -2627,7 +2545,6 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError404):
             self.object.anvil_create()
-        responses.assert_call_count(self.url_create, 1)
 
     def test_anvil_create_already_exists(self):
         """Returns documented response code when a workspace already exists."""
@@ -2636,7 +2553,7 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             "name": self.object.name,
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.url_create,
             status=409,
@@ -2645,7 +2562,6 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError409):
             self.object.anvil_create()
-        responses.assert_call_count(self.url_create, 1)
 
     def test_anvil_create_422(self):
         json = {
@@ -2653,7 +2569,7 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             "name": self.object.name,
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.url_create,
             status=422,
@@ -2662,7 +2578,6 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError):
             self.object.anvil_create()
-        responses.assert_call_count(self.url_create, 1)
 
     def test_anvil_create_internal_error(self):
         json = {
@@ -2670,7 +2585,7 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             "name": self.object.name,
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.url_create,
             status=500,
@@ -2679,7 +2594,6 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError500):
             self.object.anvil_create()
-        responses.assert_call_count(self.url_create, 1)
 
     def test_anvil_create_other(self):
         json = {
@@ -2687,7 +2601,7 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             "name": self.object.name,
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.url_create,
             status=404,
@@ -2696,7 +2610,6 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError):
             self.object.anvil_create()
-        responses.assert_call_count(self.url_create, 1)
 
     def test_anvil_create_one_auth_domain_success(self):
         """Returns documented response code when trying to create a workspace with a valid auth domain."""
@@ -2708,7 +2621,7 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             "attributes": {},
             "authorizationDomain": [{"membersGroupName": auth_domain.name}],
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.url_create,
             status=201,
@@ -2716,7 +2629,6 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             json={"message": "mock message"},
         )
         self.object.anvil_create()
-        responses.assert_call_count(self.url_create, 1)
 
     def test_anvil_create_two_auth_domains_success(self):
         """Returns documented response code when trying to create a workspace with two valid auth domains."""
@@ -2733,7 +2645,7 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
                 {"membersGroupName": auth_domain_2.name},
             ],
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.url_create,
             status=201,
@@ -2741,7 +2653,6 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             json={"message": "mock message"},
         )
         self.object.anvil_create()
-        responses.assert_call_count(self.url_create, 1)
 
     def test_anvil_create_one_auth_domain_error(self):
         """Returns documented response code when trying to create a workspace with a valid auth domain."""
@@ -2753,7 +2664,7 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             "attributes": {},
             "authorizationDomain": [{"membersGroupName": auth_domain.name}],
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.url_create,
             status=400,
@@ -2762,15 +2673,13 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError400):
             self.object.anvil_create()
-        responses.assert_call_count(self.url_create, 1)
 
     def test_anvil_delete_existing(self):
-        responses.add(responses.DELETE, self.url_workspace, status=202)
+        self.response_mock.add(responses.DELETE, self.url_workspace, status=202)
         self.object.anvil_delete()
-        responses.assert_call_count(self.url_workspace, 1)
 
     def test_anvil_delete_forbidden(self):
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             self.url_workspace,
             status=403,
@@ -2778,10 +2687,9 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError403):
             self.object.anvil_delete()
-        responses.assert_call_count(self.url_workspace, 1)
 
     def test_anvil_delete_not_found(self):
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             self.url_workspace,
             status=404,
@@ -2789,10 +2697,9 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError404):
             self.object.anvil_delete()
-        responses.assert_call_count(self.url_workspace, 1)
 
     def test_anvil_delete_in_use(self):
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             self.url_workspace,
             status=500,
@@ -2800,10 +2707,9 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError500):
             self.object.anvil_delete()
-        responses.assert_call_count(self.url_workspace, 1)
 
     def test_anvil_delete_other(self):
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             self.url_workspace,
             status=499,
@@ -2811,7 +2717,6 @@ class WorkspaceAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError):
             self.object.anvil_delete()
-        responses.assert_call_count(self.url_workspace, 1)
 
 
 class WorkspaceAnVILCloneTest(AnVILAPIMockTestMixin, TestCase):
@@ -2843,7 +2748,7 @@ class WorkspaceAnVILCloneTest(AnVILAPIMockTestMixin, TestCase):
         """Can clone a workspace with no auth domains."""
         billing_project = factories.BillingProjectFactory.create()
         # Add response.
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.get_api_url(self.workspace.billing_project.name, self.workspace.name),
             status=201,  # successful response code.
@@ -2869,7 +2774,7 @@ class WorkspaceAnVILCloneTest(AnVILAPIMockTestMixin, TestCase):
         self.workspace.authorization_domains.add(auth_domain)
         billing_project = factories.BillingProjectFactory.create()
         # Add response.
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.get_api_url(self.workspace.billing_project.name, self.workspace.name),
             status=201,  # successful response code.
@@ -2894,7 +2799,7 @@ class WorkspaceAnVILCloneTest(AnVILAPIMockTestMixin, TestCase):
         self.workspace.authorization_domains.add(auth_domain_1, auth_domain_2)
         billing_project = factories.BillingProjectFactory.create()
         # Add response.
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.get_api_url(self.workspace.billing_project.name, self.workspace.name),
             status=201,  # successful response code.
@@ -2920,7 +2825,7 @@ class WorkspaceAnVILCloneTest(AnVILAPIMockTestMixin, TestCase):
         auth_domain = factories.ManagedGroupFactory.create()
         billing_project = factories.BillingProjectFactory.create()
         # Add response.
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.get_api_url(self.workspace.billing_project.name, self.workspace.name),
             status=201,  # successful response code.
@@ -2949,7 +2854,7 @@ class WorkspaceAnVILCloneTest(AnVILAPIMockTestMixin, TestCase):
         auth_domain_2 = factories.ManagedGroupFactory.create()
         billing_project = factories.BillingProjectFactory.create()
         # Add response.
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.get_api_url(self.workspace.billing_project.name, self.workspace.name),
             status=201,  # successful response code.
@@ -2981,7 +2886,7 @@ class WorkspaceAnVILCloneTest(AnVILAPIMockTestMixin, TestCase):
         new_auth_domain = factories.ManagedGroupFactory.create()
         billing_project = factories.BillingProjectFactory.create()
         # Add response.
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.get_api_url(self.workspace.billing_project.name, self.workspace.name),
             status=201,  # successful response code.
@@ -3014,7 +2919,7 @@ class WorkspaceAnVILCloneTest(AnVILAPIMockTestMixin, TestCase):
         new_auth_domain_2 = factories.ManagedGroupFactory.create()
         billing_project = factories.BillingProjectFactory.create()
         # Add response.
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.get_api_url(self.workspace.billing_project.name, self.workspace.name),
             status=201,  # successful response code.
@@ -3046,7 +2951,7 @@ class WorkspaceAnVILCloneTest(AnVILAPIMockTestMixin, TestCase):
         self.workspace.authorization_domains.add(auth_domain)
         billing_project = factories.BillingProjectFactory.create()
         # Add response.
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.get_api_url(self.workspace.billing_project.name, self.workspace.name),
             status=201,  # successful response code.
@@ -3083,7 +2988,7 @@ class WorkspaceAnVILCloneTest(AnVILAPIMockTestMixin, TestCase):
         """Error when the workspace to be cloned already exists in AnVIL but is not in the app."""
         billing_project = factories.BillingProjectFactory.create()
         # Add response.
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.get_api_url(self.workspace.billing_project.name, self.workspace.name),
             status=409,  # already exists
@@ -3108,7 +3013,7 @@ class WorkspaceAnVILCloneTest(AnVILAPIMockTestMixin, TestCase):
         """Error the workspace to clone does not exist on AnVIL."""
         billing_project = factories.BillingProjectFactory.create()
         # Add response.
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.get_api_url(self.workspace.billing_project.name, self.workspace.name),
             status=404,  # already exists
@@ -3134,7 +3039,7 @@ class WorkspaceAnVILCloneTest(AnVILAPIMockTestMixin, TestCase):
         billing_project = factories.BillingProjectFactory.create()
         new_auth_domain = factories.ManagedGroupFactory.create()
         # Add response.
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.get_api_url(self.workspace.billing_project.name, self.workspace.name),
             status=404,  # resource not found
@@ -3166,7 +3071,7 @@ class WorkspaceAnVILCloneTest(AnVILAPIMockTestMixin, TestCase):
         """Error when the response is an error for an unknown reason."""
         billing_project = factories.BillingProjectFactory.create()
         # Add response.
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.get_api_url(self.workspace.billing_project.name, self.workspace.name),
             status=500,  # other
@@ -3228,7 +3133,7 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_name = "test-workspace"
         billing_project = factories.BillingProjectFactory.create()
         # No API call for billing projects.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(billing_project.name, workspace_name),
             status=200,  # successful response code.
@@ -3254,7 +3159,7 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_name = "test-workspace"
         billing_project = factories.BillingProjectFactory.create()
         # No API call for billing projects.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(billing_project.name, workspace_name),
             status=200,  # successful response code.
@@ -3280,13 +3185,13 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         billing_project_name = "test-billing-project"
         workspace_name = "test-workspace"
         # Response from checking the billing project.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_billing_project_api_url(billing_project_name),
             status=200,
         )
         # Response from checking the workspace.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(billing_project_name, workspace_name),
             status=200,  # successful response code.
@@ -3315,14 +3220,14 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         billing_project_name = "test-billing-project"
         workspace_name = "test-workspace"
         # Response from checking the billing project.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_billing_project_api_url(billing_project_name),
             status=404,  # billing project does not exist.
             json={"message": "other"},
         )
         # Response from checking the workspace.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(billing_project_name, workspace_name),
             status=200,  # successful response code.
@@ -3351,7 +3256,7 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         billing_project_name = "test-billing-project"
         workspace_name = "test-workspace"
         # No billing project API calls.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(billing_project_name, workspace_name),
             status=200,  # successful response code.
@@ -3378,7 +3283,7 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         workspace_name = "test-workspace"
         # No billing project API calls.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(billing_project.name, workspace_name),
             status=200,  # successful response code.
@@ -3403,7 +3308,7 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         billing_project_name = "test-billing-project"
         workspace_name = "test-workspace"
         # No API call for billing projects.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(billing_project_name, workspace_name),
             status=404,  # successful response code.
@@ -3432,7 +3337,7 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         workspace_name = "test-workspace"
         # No API call for billing projects.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(billing_project.name, workspace_name),
             status=404,  # successful response code.
@@ -3472,7 +3377,7 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         """No workspaces are created if there is an internal error from the AnVIL API for the workspace call."""
         billing_project_name = "test-billing-project"
         workspace_name = "test-workspace"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(billing_project_name, workspace_name),
             status=500,
@@ -3492,7 +3397,7 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         """No workspaces are created if there is some other error from the AnVIL API for the workspace call."""
         billing_project_name = "test-billing-project"
         workspace_name = "test-workspace"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(billing_project_name, workspace_name),
             status=499,
@@ -3512,14 +3417,14 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         """No workspaces are created if there is an internal error from the AnVIL API for the billing project call."""
         billing_project_name = "test-billing-project"
         workspace_name = "test-workspace"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(billing_project_name, workspace_name),
             status=200,  # successful response code.
             json=self.get_api_json_response(billing_project_name, workspace_name),
         )
         # Error in billing project call.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_billing_project_api_url(billing_project_name),
             status=500,  # error
@@ -3539,14 +3444,14 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         """No workspaces are created if there is another error from the AnVIL API for the billing project call."""
         billing_project_name = "test-billing-project"
         workspace_name = "test-workspace"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(billing_project_name, workspace_name),
             status=200,  # successful response code.
             json=self.get_api_json_response(billing_project_name, workspace_name),
         )
         # Error in billing project call.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_billing_project_api_url(billing_project_name),
             status=499,
@@ -3597,12 +3502,12 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             billing_project=other_billing_project, name=workspace_name
         )
         billing_project_name = "billing-project-2"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_billing_project_api_url(billing_project_name),
             status=200,  # successful response code.
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(billing_project_name, workspace_name),
             status=200,  # successful response code.
@@ -3630,7 +3535,7 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             billing_project=billing_project, name="test-workspace-1"
         )
         # No billing project API calls.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(billing_project.name, workspace_name),
             status=200,  # successful response code.
@@ -3656,7 +3561,7 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_name = "test-workspace"
         # Response for workspace query.
         workspace_url = self.get_api_url(billing_project.name, workspace_name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_url,
             status=200,  # successful response code.
@@ -3666,7 +3571,7 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         # Response for group query.
         group_url = self.api_client.sam_entry_point + "/api/groups/v1"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             group_url,
             status=200,
@@ -3697,8 +3602,6 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         # The group was marked as an auth group of the workspace.
         self.assertEqual(workspace.authorization_domains.count(), 1)
         self.assertEqual(workspace.authorization_domains.get(), group)
-        responses.assert_call_count(workspace_url, 1)
-        responses.assert_call_count(group_url, 1)
 
     def test_anvil_import_one_auth_group_exists_in_django(self):
         """Imports a workspace with an auth group that already exists in the app with app as member."""
@@ -3709,7 +3612,7 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         group = factories.ManagedGroupFactory.create(name="auth-group")
         # Response for workspace query.
         workspace_url = self.get_api_url(billing_project.name, workspace_name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_url,
             status=200,  # successful response code.
@@ -3734,7 +3637,6 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         # The group was marked as an auth group of the workspace.
         self.assertEqual(workspace.authorization_domains.count(), 1)
         self.assertEqual(workspace.authorization_domains.get(), group)
-        responses.assert_call_count(workspace_url, 1)
 
     def test_anvil_import_one_auth_group_admin_does_not_exist_in_django(self):
         """Imports a workspace with an auth group that the app is a member."""
@@ -3744,7 +3646,7 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_name = "test-workspace"
         # Response for workspace query.
         workspace_url = self.get_api_url(billing_project.name, workspace_name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_url,
             status=200,  # successful response code.
@@ -3754,7 +3656,7 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         # Response for group query.
         group_url = self.api_client.sam_entry_point + "/api/groups/v1"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             group_url,
             status=200,
@@ -3785,8 +3687,6 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         # The group was marked as an auth group of the workspace.
         self.assertEqual(workspace.authorization_domains.count(), 1)
         self.assertEqual(workspace.authorization_domains.get(), group)
-        responses.assert_call_count(workspace_url, 1)
-        responses.assert_call_count(group_url, 1)
 
     def test_anvil_import_two_auth_groups(self):
         """Imports two auth groups for a workspace."""
@@ -3796,7 +3696,7 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_name = "test-workspace"
         # Response for workspace query.
         workspace_url = self.get_api_url(billing_project.name, workspace_name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_url,
             status=200,  # successful response code.
@@ -3808,7 +3708,7 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         # Response for group query.
         group_url = self.api_client.sam_entry_point + "/api/groups/v1"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             group_url,
             status=200,
@@ -3846,8 +3746,6 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(workspace.authorization_domains.count(), 2)
         self.assertIn(member_group, workspace.authorization_domains.all())
         self.assertIn(admin_group, workspace.authorization_domains.all())
-        responses.assert_call_count(workspace_url, 1)
-        responses.assert_call_count(group_url, 2)
 
     def test_api_internal_error_group_call(self):
         """Nothing is added when there is an API error on the /api/groups call."""
@@ -3855,12 +3753,12 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_name = "test-workspace"
         # Response for billing project query.
         billing_project_url = self.get_billing_project_api_url(billing_project_name)
-        responses.add(
+        self.response_mock.add(
             responses.GET, billing_project_url, status=200  # successful response code.
         )
         # Response for workspace query.
         workspace_url = self.get_api_url(billing_project_name, workspace_name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_url,
             status=200,  # successful response code.
@@ -3870,7 +3768,7 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         # Response for group query.
         group_url = self.api_client.sam_entry_point + "/api/groups/v1"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             group_url,
             status=500,
@@ -3892,9 +3790,6 @@ class WorkspaceAnVILImportAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(models.ManagedGroup.objects.count(), 0)
         # No auth domains were recorded.
         self.assertEqual(models.WorkspaceAuthorizationDomain.objects.count(), 0)
-        responses.assert_call_count(billing_project_url, 1)
-        responses.assert_call_count(workspace_url, 1)
-        responses.assert_call_count(group_url, 1)
 
 
 class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
@@ -3949,7 +3844,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
     def test_anvil_audit_no_workspaces(self):
         """anvil_audit works correct if there are no Workspaces in the app."""
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -3961,14 +3856,12 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(audit_results.get_verified(), set())
         self.assertEqual(audit_results.get_errors(), {})
         self.assertEqual(audit_results.get_not_in_app(), set())
-        # This does not work with query parameters. I would need to construct the full url to check.
-        # responses.assert_call_count(api_url, 1)
 
     def test_anvil_audit_one_workspace_no_errors(self):
         """anvil_audit works correct if there is one workspace in the app and it exists on AnVIL."""
         workspace = factories.WorkspaceFactory.create()
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -3982,7 +3875,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_acl_url = self.get_api_workspace_acl_url(
             workspace.billing_project.name, workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_acl_url,
             status=200,
@@ -3999,7 +3892,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         """anvil_audit raises exception if one group exists in the app but not on AnVIL."""
         workspace = factories.WorkspaceFactory.create()
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4019,7 +3912,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         """anvil_audit raises exception if one workspace exists in the app but the access on AnVIL is READER."""
         workspace = factories.WorkspaceFactory.create()
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4043,7 +3936,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         """anvil_audit raises exception if one workspace exists in the app but the access on AnVIL is WRITER."""
         workspace = factories.WorkspaceFactory.create()
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4068,7 +3961,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_1 = factories.WorkspaceFactory.create()
         workspace_2 = factories.WorkspaceFactory.create()
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4085,7 +3978,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_acl_url_1 = self.get_api_workspace_acl_url(
             workspace_1.billing_project.name, workspace_1.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_acl_url_1,
             status=200,
@@ -4095,7 +3988,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_acl_url_2 = self.get_api_workspace_acl_url(
             workspace_2.billing_project.name, workspace_2.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_acl_url_2,
             status=200,
@@ -4113,7 +4006,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_1 = factories.WorkspaceFactory.create()
         workspace_2 = factories.WorkspaceFactory.create()
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4130,7 +4023,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_acl_url_1 = self.get_api_workspace_acl_url(
             workspace_1.billing_project.name, workspace_1.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_acl_url_1,
             status=200,
@@ -4140,7 +4033,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_acl_url_2 = self.get_api_workspace_acl_url(
             workspace_2.billing_project.name, workspace_2.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_acl_url_2,
             status=200,
@@ -4158,7 +4051,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_1 = factories.WorkspaceFactory.create()
         workspace_2 = factories.WorkspaceFactory.create()
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4172,7 +4065,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_acl_url_2 = self.get_api_workspace_acl_url(
             workspace_2.billing_project.name, workspace_2.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_acl_url_2,
             status=200,
@@ -4193,7 +4086,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_1 = factories.WorkspaceFactory.create()
         workspace_2 = factories.WorkspaceFactory.create()
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4210,7 +4103,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_acl_url_2 = self.get_api_workspace_acl_url(
             workspace_2.billing_project.name, workspace_2.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_acl_url_2,
             status=200,
@@ -4231,7 +4124,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_1 = factories.WorkspaceFactory.create()
         workspace_2 = factories.WorkspaceFactory.create()
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4253,7 +4146,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
     def test_anvil_audit_one_workspace_missing_in_app(self):
         """anvil_audit returns not_in_app info if a workspace exists on AnVIL but not in the app."""
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4268,7 +4161,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_anvil_audit_two_workspaces_missing_in_app(self):
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4293,7 +4186,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             billing_project__name="test-bp-app", name="test-ws"
         )
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4311,7 +4204,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
     def test_ignores_workspaces_where_app_is_reader_on_anvil(self):
         """Audit ignores workspaces on AnVIL where app is a READER on AnVIL."""
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4327,7 +4220,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
     def test_ignores_workspaces_where_app_is_writer_on_anvil(self):
         """Audit ignores workspaces on AnVIL where app is a WRITER on AnVIL."""
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4344,7 +4237,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         """anvil_audit works properly when there is one workspace with one auth domain."""
         auth_domain = factories.WorkspaceAuthorizationDomainFactory.create()
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4361,7 +4254,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_acl_url = self.get_api_workspace_acl_url(
             auth_domain.workspace.billing_project.name, auth_domain.workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_acl_url,
             status=200,
@@ -4384,7 +4277,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             workspace=workspace
         )
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4401,7 +4294,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_acl_url = self.get_api_workspace_acl_url(
             workspace.billing_project.name, workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_acl_url,
             status=200,
@@ -4426,7 +4319,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             workspace=workspace, group__name="zz"
         )
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4443,7 +4336,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_acl_url = self.get_api_workspace_acl_url(
             workspace.billing_project.name, workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_acl_url,
             status=200,
@@ -4462,7 +4355,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         """anvil_audit works properly when there is one workspace with no auth domain in the app but one on AnVIL."""
         workspace = factories.WorkspaceFactory.create()
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4479,7 +4372,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_acl_url = self.get_api_workspace_acl_url(
             workspace.billing_project.name, workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_acl_url,
             status=200,
@@ -4499,7 +4392,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         """anvil_audit works properly when there is one workspace with one auth domain in the app but none on AnVIL."""
         auth_domain = factories.WorkspaceAuthorizationDomainFactory.create()
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4516,7 +4409,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_acl_url = self.get_api_workspace_acl_url(
             auth_domain.workspace.billing_project.name, auth_domain.workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_acl_url,
             status=200,
@@ -4536,7 +4429,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         """anvil_audit works properly when there is one workspace with no auth domain in the app but two on AnVIL."""
         workspace = factories.WorkspaceFactory.create()
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4553,7 +4446,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_acl_url = self.get_api_workspace_acl_url(
             workspace.billing_project.name, workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_acl_url,
             status=200,
@@ -4575,7 +4468,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         factories.WorkspaceAuthorizationDomainFactory.create(workspace=workspace)
         factories.WorkspaceAuthorizationDomainFactory.create(workspace=workspace)
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4592,7 +4485,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_acl_url = self.get_api_workspace_acl_url(
             workspace.billing_project.name, workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_acl_url,
             status=200,
@@ -4616,7 +4509,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         factories.WorkspaceAuthorizationDomainFactory.create(workspace=workspace)
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4633,7 +4526,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_acl_url = self.get_api_workspace_acl_url(
             workspace.billing_project.name, workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_acl_url,
             status=200,
@@ -4655,7 +4548,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             group__name="app"
         )
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4672,7 +4565,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_acl_url = self.get_api_workspace_acl_url(
             auth_domain.workspace.billing_project.name, auth_domain.workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_acl_url,
             status=200,
@@ -4693,7 +4586,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_1 = factories.WorkspaceFactory.create()
         workspace_2 = factories.WorkspaceFactory.create()
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4716,7 +4609,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_acl_url_1 = self.get_api_workspace_acl_url(
             workspace_1.billing_project.name, workspace_1.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_acl_url_1,
             status=200,
@@ -4726,7 +4619,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_acl_url_2 = self.get_api_workspace_acl_url(
             workspace_2.billing_project.name, workspace_2.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_acl_url_2,
             status=200,
@@ -4747,7 +4640,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_1 = factories.WorkspaceFactory.create()
         workspace_2 = factories.WorkspaceFactory.create()
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4770,7 +4663,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_acl_url_1 = self.get_api_workspace_acl_url(
             workspace_1.billing_project.name, workspace_1.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_acl_url_1,
             status=200,
@@ -4780,7 +4673,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_acl_url_2 = self.get_api_workspace_acl_url(
             workspace_2.billing_project.name, workspace_2.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_acl_url_2,
             status=200,
@@ -4804,7 +4697,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace = factories.WorkspaceFactory.create()
         factories.WorkspaceAuthorizationDomainFactory.create(workspace=workspace)
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4835,7 +4728,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         factories.WorkspaceGroupSharingFactory.create(workspace=workspace)
         # Response for the main call about workspaces.
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4851,7 +4744,7 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         workspace_acl_url = self.get_api_workspace_acl_url(
             workspace.billing_project.name, workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_acl_url,
             status=200,
@@ -4865,7 +4758,6 @@ class WorkspaceAnVILAuditAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             {workspace: [audit_results.ERROR_WORKSPACE_SHARING]},
         )
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(workspace_acl_url, 1)
 
 
 class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
@@ -4907,7 +4799,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
 
     def test_no_access(self):
         """anvil_audit works correctly if this workspace is not shared with any groups."""
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -4921,13 +4813,12 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
         self.assertEqual(audit_results.get_verified(), set())
         self.assertEqual(audit_results.get_errors(), {})
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(self.api_url, 1)
 
     def test_one_group_reader(self):
         """anvil_audit works correctly if this group has one group member."""
         access = factories.WorkspaceGroupSharingFactory.create(workspace=self.workspace)
         self.update_api_response(access.group.get_email(), access.access)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -4938,7 +4829,6 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
         self.assertEqual(audit_results.get_verified(), set([access]))
         self.assertEqual(audit_results.get_errors(), {})
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(self.api_url, 1)
 
     def test_two_group_readers(self):
         """anvil_audit works correctly if this workspace has two group readers."""
@@ -4950,7 +4840,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
         )
         self.update_api_response(access_1.group.get_email(), "READER")
         self.update_api_response(access_2.group.get_email(), "READER")
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -4965,7 +4855,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
     def test_one_group_reader_not_in_anvil(self):
         """anvil_audit works correctly if this workspace has one group reader not in anvil."""
         access = factories.WorkspaceGroupSharingFactory.create(workspace=self.workspace)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -4988,7 +4878,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
         access_2 = factories.WorkspaceGroupSharingFactory.create(
             workspace=self.workspace
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5009,7 +4899,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
     def test_one_group_readers_not_in_app(self):
         """anvil_audit works correctly if this workspace has one group reader not in the app."""
         self.update_api_response("test-member@firecloud.org", "READER")
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5027,7 +4917,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
         """anvil_audit works correctly if this workspace has two group readers not in the app."""
         self.update_api_response("test-member-1@firecloud.org", "READER")
         self.update_api_response("test-member-2@firecloud.org", "READER")
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5053,7 +4943,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
             workspace=self.workspace, group__name="tEsT-mEmBeR"
         )
         self.update_api_response("Test-Member@firecloud.org", "READER")
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5071,7 +4961,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
             workspace=self.workspace, access=models.WorkspaceGroupSharing.WRITER
         )
         self.update_api_response(access.group.get_email(), "WRITER")
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5093,7 +4983,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
         )
         self.update_api_response(access_1.group.get_email(), "WRITER")
         self.update_api_response(access_2.group.get_email(), "WRITER")
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5110,7 +5000,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
         access = factories.WorkspaceGroupSharingFactory.create(
             workspace=self.workspace, access=models.WorkspaceGroupSharing.WRITER
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5135,7 +5025,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
         access_2 = factories.WorkspaceGroupSharingFactory.create(
             workspace=self.workspace, access=models.WorkspaceGroupSharing.WRITER
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5156,7 +5046,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
     def test_one_group_writer_not_in_app(self):
         """anvil_audit works correctly if this workspace has one group writer not in the app."""
         self.update_api_response("test-writer@firecloud.org", "WRITER")
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5174,7 +5064,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
         """anvil_audit works correctly if this workspace has two group writers not in the app."""
         self.update_api_response("test-writer-1@firecloud.org", "WRITER")
         self.update_api_response("test-writer-2@firecloud.org", "WRITER")
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5202,7 +5092,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
             access=models.WorkspaceGroupSharing.WRITER,
         )
         self.update_api_response("Test-Writer@firecloud.org", "WRITER")
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5220,7 +5110,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
             workspace=self.workspace, access=models.WorkspaceGroupSharing.OWNER
         )
         self.update_api_response(access.group.get_email(), "OWNER", can_share=True)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5242,7 +5132,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
         )
         self.update_api_response(access_1.group.get_email(), "OWNER", can_share=True)
         self.update_api_response(access_2.group.get_email(), "OWNER", can_share=True)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5259,7 +5149,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
         access = factories.WorkspaceGroupSharingFactory.create(
             workspace=self.workspace, access=models.WorkspaceGroupSharing.OWNER
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5284,7 +5174,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
         access_2 = factories.WorkspaceGroupSharingFactory.create(
             workspace=self.workspace, access=models.WorkspaceGroupSharing.OWNER
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5305,7 +5195,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
     def test_one_group_owner_not_in_app(self):
         """anvil_audit works correctly if this workspace has one group owner not in the app."""
         self.update_api_response("test-writer@firecloud.org", "OWNER")
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5323,7 +5213,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
         """anvil_audit works correctly if this workspace has two group owners not in the app."""
         self.update_api_response("test-writer-1@firecloud.org", "OWNER")
         self.update_api_response("test-writer-2@firecloud.org", "OWNER")
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5351,7 +5241,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
             access=models.WorkspaceGroupSharing.OWNER,
         )
         self.update_api_response("Test-Owner@firecloud.org", "OWNER", can_share=True)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5369,7 +5259,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
             workspace=self.workspace, access=models.WorkspaceGroupSharing.READER
         )
         self.update_api_response(access.group.get_email(), "WRITER")
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5391,7 +5281,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
         self.update_api_response(
             access.group.get_email(), "OWNER", can_compute=True, can_share=True
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5419,7 +5309,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
             can_compute=True,
         )
         self.update_api_response(access.group.get_email(), "WRITER", can_compute=False)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5439,7 +5329,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
             workspace=self.workspace, access=models.WorkspaceGroupSharing.WRITER
         )
         self.update_api_response(access.group.get_email(), "WRITER", can_share=True)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5458,7 +5348,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
         self.update_api_response(
             self.service_account_email, "OWNER", can_compute=True, can_share=True
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5469,7 +5359,6 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
         self.assertEqual(audit_results.get_verified(), set([]))
         self.assertEqual(audit_results.get_errors(), {})
         self.assertEqual(audit_results.get_not_in_app(), set())
-        responses.assert_call_count(self.api_url, 1)
 
     def test_group_owner_can_share_true(self):
         """Owners must have can_share=True."""
@@ -5481,7 +5370,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
         self.update_api_response(
             access.group.get_email(), "OWNER", can_compute=True, can_share=True
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5503,7 +5392,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
         self.update_api_response(
             access.group.get_email(), "WRITER", can_compute=True, can_share=True
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5528,7 +5417,7 @@ class WorkspaceAnVILAuditSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase
         self.update_api_response(
             access.group.get_email(), "READER", can_compute=False, can_share=True
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -5564,12 +5453,11 @@ class GroupGroupMembershipAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
 
     def test_anvil_create_successful(self):
-        responses.add(responses.PUT, self.api_url_create, status=204)
+        self.response_mock.add(responses.PUT, self.api_url_create, status=204)
         self.object.anvil_create()
-        responses.assert_call_count(self.api_url_create, 1)
 
     def test_anvil_create_unsuccessful_403(self):
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             self.api_url_create,
             status=403,
@@ -5577,10 +5465,9 @@ class GroupGroupMembershipAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError403):
             self.object.anvil_create()
-        responses.assert_call_count(self.api_url_create, 1)
 
     def test_anvil_create_unsuccessful_404(self):
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             self.api_url_create,
             status=404,
@@ -5588,10 +5475,9 @@ class GroupGroupMembershipAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError404):
             self.object.anvil_create()
-        responses.assert_call_count(self.api_url_create, 1)
 
     def test_anvil_create_unsuccessful_500(self):
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             self.api_url_create,
             status=500,
@@ -5599,10 +5485,9 @@ class GroupGroupMembershipAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError500):
             self.object.anvil_create()
-        responses.assert_call_count(self.api_url_create, 1)
 
     def test_anvil_create_unsuccessful_other(self):
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             self.api_url_create,
             status=499,
@@ -5610,15 +5495,13 @@ class GroupGroupMembershipAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError):
             self.object.anvil_create()
-        responses.assert_call_count(self.api_url_create, 1)
 
     def test_anvil_delete_successful(self):
-        responses.add(responses.DELETE, self.api_url_delete, status=204)
+        self.response_mock.add(responses.DELETE, self.api_url_delete, status=204)
         self.object.anvil_delete()
-        responses.assert_call_count(self.api_url_delete, 1)
 
     def test_anvil_delete_unsuccessful_403(self):
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             self.api_url_delete,
             status=403,
@@ -5626,10 +5509,9 @@ class GroupGroupMembershipAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError403):
             self.object.anvil_delete()
-        responses.assert_call_count(self.api_url_delete, 1)
 
     def test_anvil_delete_unsuccessful_404(self):
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             self.api_url_delete,
             status=404,
@@ -5637,10 +5519,9 @@ class GroupGroupMembershipAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError404):
             self.object.anvil_delete()
-        responses.assert_call_count(self.api_url_delete, 1)
 
     def test_anvil_delete_unsuccessful_500(self):
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             self.api_url_delete,
             status=500,
@@ -5648,10 +5529,9 @@ class GroupGroupMembershipAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError500):
             self.object.anvil_delete()
-        responses.assert_call_count(self.api_url_delete, 1)
 
     def test_anvil_delete_unsuccessful_other(self):
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             self.api_url_delete,
             status=499,
@@ -5659,7 +5539,6 @@ class GroupGroupMembershipAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError):
             self.object.anvil_delete()
-        responses.assert_call_count(self.api_url_delete, 1)
 
 
 class GroupAccountMembershipAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
@@ -5680,12 +5559,11 @@ class GroupAccountMembershipAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
 
     def test_anvil_create_successful(self):
-        responses.add(responses.PUT, self.api_url_create, status=204)
+        self.response_mock.add(responses.PUT, self.api_url_create, status=204)
         self.object.anvil_create()
-        responses.assert_call_count(self.api_url_create, 1)
 
     def test_anvil_create_unsuccessful_403(self):
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             self.api_url_create,
             status=403,
@@ -5693,10 +5571,9 @@ class GroupAccountMembershipAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError403):
             self.object.anvil_create()
-        responses.assert_call_count(self.api_url_create, 1)
 
     def test_anvil_create_unsuccessful_404(self):
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             self.api_url_create,
             status=404,
@@ -5704,10 +5581,9 @@ class GroupAccountMembershipAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError404):
             self.object.anvil_create()
-        responses.assert_call_count(self.api_url_create, 1)
 
     def test_anvil_create_unsuccessful_500(self):
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             self.api_url_create,
             status=500,
@@ -5715,10 +5591,9 @@ class GroupAccountMembershipAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError500):
             self.object.anvil_create()
-        responses.assert_call_count(self.api_url_create, 1)
 
     def test_anvil_create_unsuccessful_other(self):
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             self.api_url_create,
             status=499,
@@ -5726,20 +5601,18 @@ class GroupAccountMembershipAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError):
             self.object.anvil_create()
-        responses.assert_call_count(self.api_url_create, 1)
 
     def test_anvil_delete_successful(self):
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             self.api_url_delete,
             status=204,
             json={"message": "mock message"},
         )
         self.object.anvil_delete()
-        responses.assert_call_count(self.api_url_delete, 1)
 
     def test_anvil_delete_unsuccessful_403(self):
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             self.api_url_delete,
             status=403,
@@ -5747,10 +5620,9 @@ class GroupAccountMembershipAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError403):
             self.object.anvil_delete()
-        responses.assert_call_count(self.api_url_delete, 1)
 
     def test_anvil_delete_unsuccessful_404(self):
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             self.api_url_delete,
             status=404,
@@ -5758,10 +5630,9 @@ class GroupAccountMembershipAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError404):
             self.object.anvil_delete()
-        responses.assert_call_count(self.api_url_delete, 1)
 
     def test_anvil_delete_unsuccessful_500(self):
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             self.api_url_delete,
             status=500,
@@ -5769,10 +5640,9 @@ class GroupAccountMembershipAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError500):
             self.object.anvil_delete()
-        responses.assert_call_count(self.api_url_delete, 1)
 
     def test_anvil_delete_unsuccessful_other(self):
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             self.api_url_delete,
             status=499,
@@ -5780,7 +5650,6 @@ class GroupAccountMembershipAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError):
             self.object.anvil_delete()
-        responses.assert_call_count(self.api_url_delete, 1)
 
 
 class WorkspaceGroupSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
@@ -5828,7 +5697,7 @@ class WorkspaceGroupSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         }
 
     def test_anvil_create_or_update_successful(self):
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             self.url,
             status=200,
@@ -5836,14 +5705,13 @@ class WorkspaceGroupSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             json=self.get_api_json_response(users_updated=self.data_add),
         )
         self.object.anvil_create_or_update()
-        responses.assert_call_count(self.url, 1)
 
     def test_create_can_compute(self):
         """The correct API call is made when creating the object if can_compute is True."""
         self.object.can_compute = True
         self.object.save()
         self.data_add[0]["canCompute"] = True
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             self.url,
             status=200,
@@ -5851,10 +5719,9 @@ class WorkspaceGroupSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             json=self.get_api_json_response(users_updated=self.data_add),
         )
         self.object.anvil_create_or_update()
-        responses.assert_call_count(self.url, 1)
 
     def test_anvil_create_or_update_unsuccessful_400(self):
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             self.url,
             status=400,
@@ -5863,10 +5730,9 @@ class WorkspaceGroupSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError400):
             self.object.anvil_create_or_update()
-        responses.assert_call_count(self.url, 1)
 
     def test_anvil_create_or_update_unsuccessful_403(self):
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             self.url,
             status=403,
@@ -5875,10 +5741,9 @@ class WorkspaceGroupSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError403):
             self.object.anvil_create_or_update()
-        responses.assert_call_count(self.url, 1)
 
     def test_anvil_create_or_update_unsuccessful_workspace_not_found(self):
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             self.url,
             status=404,
@@ -5887,10 +5752,9 @@ class WorkspaceGroupSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError404):
             self.object.anvil_create_or_update()
-        responses.assert_call_count(self.url, 1)
 
     def test_anvil_create_or_update_unsuccessful_internal_error(self):
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             self.url,
             status=500,
@@ -5899,10 +5763,9 @@ class WorkspaceGroupSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError500):
             self.object.anvil_create_or_update()
-        responses.assert_call_count(self.url, 1)
 
     def test_anvil_create_or_update_unsuccessful_other(self):
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             self.url,
             status=499,
@@ -5911,10 +5774,9 @@ class WorkspaceGroupSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError):
             self.object.anvil_create_or_update()
-        responses.assert_call_count(self.url, 1)
 
     def test_anvil_create_or_update_group_not_found_on_anvil(self):
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             self.url,
             status=200,
@@ -5924,24 +5786,22 @@ class WorkspaceGroupSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(exceptions.AnVILGroupNotFound):
             self.object.anvil_create_or_update()
-        responses.assert_call_count(self.url, 1)
 
     def test_anvil_delete_successful(self):
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             self.url,
             status=200,
             match=[responses.matchers.json_params_matcher(self.data_delete)],
         )
         self.object.anvil_delete()
-        responses.assert_call_count(self.url, 1)
 
     def test_delete_can_compute(self):
         """The correct API call is made when deleting an object if can_compute is True."""
         self.object.can_compute = True
         self.object.save()
         self.data_delete[0]["canCompute"] = True
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             self.url,
             status=200,
@@ -5949,10 +5809,9 @@ class WorkspaceGroupSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             json=self.get_api_json_response(users_updated=self.data_delete),
         )
         self.object.anvil_delete()
-        responses.assert_call_count(self.url, 1)
 
     def test_anvil_delete_unsuccessful_400(self):
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             self.url,
             status=400,
@@ -5961,10 +5820,9 @@ class WorkspaceGroupSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError400):
             self.object.anvil_delete()
-        responses.assert_call_count(self.url, 1)
 
     def test_anvil_delete_unsuccessful_workspace_not_found(self):
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             self.url,
             status=404,
@@ -5973,10 +5831,9 @@ class WorkspaceGroupSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError404):
             self.object.anvil_delete()
-        responses.assert_call_count(self.url, 1)
 
     def test_anvil_delete_unsuccessful_internal_error(self):
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             self.url,
             status=500,
@@ -5985,10 +5842,9 @@ class WorkspaceGroupSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError500):
             self.object.anvil_delete()
-        responses.assert_call_count(self.url, 1)
 
     def test_anvil_delete_unsuccessful_other(self):
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             self.url,
             status=499,
@@ -5997,4 +5853,3 @@ class WorkspaceGroupSharingAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
         )
         with self.assertRaises(anvil_api.AnVILAPIError):
             self.object.anvil_delete()
-        responses.assert_call_count(self.url, 1)

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -257,9 +257,11 @@ class AnVILStatusTest(AnVILAPIMockTestMixin, TestCase):
     def test_status_code_with_user_permission(self):
         """Returns successful response code."""
         url_me = self.api_client.firecloud_entry_point + "/me?userDetailsOnly=true"
-        responses.add(responses.GET, url_me, status=200, json=self.get_json_me_data())
+        self.response_mock.add(
+            responses.GET, url_me, status=200, json=self.get_json_me_data()
+        )
         url_status = self.api_client.firecloud_entry_point + "/status"
-        responses.add(
+        self.response_mock.add(
             responses.GET, url_status, status=200, json=self.get_json_status_data()
         )
         self.client.force_login(self.user)
@@ -279,9 +281,11 @@ class AnVILStatusTest(AnVILAPIMockTestMixin, TestCase):
     def test_context_data_anvil_status_ok(self):
         """Context data contains anvil_status."""
         url_me = self.api_client.firecloud_entry_point + "/me?userDetailsOnly=true"
-        responses.add(responses.GET, url_me, status=200, json=self.get_json_me_data())
+        self.response_mock.add(
+            responses.GET, url_me, status=200, json=self.get_json_me_data()
+        )
         url_status = self.api_client.firecloud_entry_point + "/status"
-        responses.add(
+        self.response_mock.add(
             responses.GET, url_status, status=200, json=self.get_json_status_data()
         )
         self.client.force_login(self.user)
@@ -290,15 +294,15 @@ class AnVILStatusTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIn("anvil_status", response.context_data)
         self.assertEqual(response.context_data["anvil_status"], {"ok": True})
         self.assertIn("anvil_systems_status", response.context_data)
-        responses.assert_call_count(url_me, 1)
-        responses.assert_call_count(url_status, 1)
 
     def test_context_data_anvil_status_not_ok(self):
         """Context data contains anvil_status."""
         url_me = self.api_client.firecloud_entry_point + "/me?userDetailsOnly=true"
-        responses.add(responses.GET, url_me, status=200, json=self.get_json_me_data())
+        self.response_mock.add(
+            responses.GET, url_me, status=200, json=self.get_json_me_data()
+        )
         url_status = self.api_client.firecloud_entry_point + "/status"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             url_status,
             status=200,
@@ -310,16 +314,16 @@ class AnVILStatusTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIn("anvil_status", response.context_data)
         self.assertEqual(response.context_data["anvil_status"], {"ok": False})
         self.assertIn("anvil_systems_status", response.context_data)
-        responses.assert_call_count(url_me, 1)
-        responses.assert_call_count(url_status, 1)
 
     def test_context_data_status_api_error(self):
         """Page still loads if there is an AnVIL API error in the status call."""
         url_me = self.api_client.firecloud_entry_point + "/me?userDetailsOnly=true"
-        responses.add(responses.GET, url_me, status=200, json=self.get_json_me_data())
+        self.response_mock.add(
+            responses.GET, url_me, status=200, json=self.get_json_me_data()
+        )
         # Error in status API
         url_status = self.api_client.firecloud_entry_point + "/status"
-        responses.add(responses.GET, url_status, status=499)
+        self.response_mock.add(responses.GET, url_status, status=499)
         self.client.force_login(self.user)
         response = self.client.get(self.get_url())
         self.assertEqual(response.status_code, 200)
@@ -327,15 +331,13 @@ class AnVILStatusTest(AnVILAPIMockTestMixin, TestCase):
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertEqual("AnVIL API Error: error checking API status", str(messages[0]))
-        responses.assert_call_count(url_me, 1)
-        responses.assert_call_count(url_status, 1)
 
     def test_context_data_status_me_error(self):
         """Page still loads if there is an AnVIL API error in the me call."""
         url_me = self.api_client.firecloud_entry_point + "/me?userDetailsOnly=true"
-        responses.add(responses.GET, url_me, status=499)
+        self.response_mock.add(responses.GET, url_me, status=499)
         url_status = self.api_client.firecloud_entry_point + "/status"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             url_status,
             status=200,
@@ -348,16 +350,14 @@ class AnVILStatusTest(AnVILAPIMockTestMixin, TestCase):
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertEqual("AnVIL API Error: error checking API user", str(messages[0]))
-        responses.assert_call_count(url_me, 1)
-        responses.assert_call_count(url_status, 1)
 
     def test_context_data_both_api_error(self):
         """Page still loads if there is an AnVIL API error in both the status and me call."""
         url_me = self.api_client.firecloud_entry_point + "/me?userDetailsOnly=true"
-        responses.add(responses.GET, url_me, status=499)
+        self.response_mock.add(responses.GET, url_me, status=499)
         # Error in status API
         url_status = self.api_client.firecloud_entry_point + "/status"
-        responses.add(responses.GET, url_status, status=499)
+        self.response_mock.add(responses.GET, url_status, status=499)
         self.client.force_login(self.user)
         response = self.client.get(self.get_url())
         self.assertEqual(response.status_code, 200)
@@ -366,8 +366,6 @@ class AnVILStatusTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(len(messages), 2)
         self.assertEqual("AnVIL API Error: error checking API status", str(messages[0]))
         self.assertEqual("AnVIL API Error: error checking API user", str(messages[1]))
-        responses.assert_call_count(url_me, 1)
-        responses.assert_call_count(url_status, 1)
 
 
 class BillingProjectImportTest(AnVILAPIMockTestMixin, TestCase):
@@ -461,7 +459,9 @@ class BillingProjectImportTest(AnVILAPIMockTestMixin, TestCase):
         """Posting valid data to the form creates an object."""
         billing_project_name = "test-billing"
         url = self.get_api_url(billing_project_name)
-        responses.add(responses.GET, url, status=200, json=self.get_api_json_response())
+        self.response_mock.add(
+            responses.GET, url, status=200, json=self.get_api_json_response()
+        )
         # Need a client for messages.
         self.client.force_login(self.user)
         response = self.client.post(self.get_url(), {"name": billing_project_name})
@@ -478,7 +478,9 @@ class BillingProjectImportTest(AnVILAPIMockTestMixin, TestCase):
         """Can set the note when creating a billing project."""
         billing_project_name = "test-billing"
         url = self.get_api_url(billing_project_name)
-        responses.add(responses.GET, url, status=200, json=self.get_api_json_response())
+        self.response_mock.add(
+            responses.GET, url, status=200, json=self.get_api_json_response()
+        )
         # Need a client for messages.
         self.client.force_login(self.user)
         response = self.client.post(
@@ -492,7 +494,9 @@ class BillingProjectImportTest(AnVILAPIMockTestMixin, TestCase):
         """Response includes a success message if successful."""
         billing_project_name = "test-billing"
         url = self.get_api_url(billing_project_name)
-        responses.add(responses.GET, url, status=200, json=self.get_api_json_response())
+        self.response_mock.add(
+            responses.GET, url, status=200, json=self.get_api_json_response()
+        )
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(), {"name": billing_project_name}, follow=True
@@ -507,7 +511,9 @@ class BillingProjectImportTest(AnVILAPIMockTestMixin, TestCase):
         # This needs to use the client because the RequestFactory doesn't handle redirects.
         billing_project_name = "test-billing"
         url = self.get_api_url(billing_project_name)
-        responses.add(responses.GET, url, status=200, json=self.get_api_json_response())
+        self.response_mock.add(
+            responses.GET, url, status=200, json=self.get_api_json_response()
+        )
         self.client.force_login(self.user)
         response = self.client.post(self.get_url(), {"name": billing_project_name})
         new_object = models.BillingProject.objects.latest("pk")
@@ -570,7 +576,9 @@ class BillingProjectImportTest(AnVILAPIMockTestMixin, TestCase):
         """Posting valid data to the form does not create an object if we are not users on AnVIL."""
         billing_project_name = "test-billing"
         url = self.get_api_url(billing_project_name)
-        responses.add(responses.GET, url, status=404, json={"message": "other"})
+        self.response_mock.add(
+            responses.GET, url, status=404, json={"message": "other"}
+        )
         # Need a client to check messages.
         self.client.force_login(self.user)
         response = self.client.post(self.get_url(), {"name": billing_project_name})
@@ -595,7 +603,7 @@ class BillingProjectImportTest(AnVILAPIMockTestMixin, TestCase):
     def test_api_error(self):
         """Does not create a new Account if the API returns some other error."""
         billing_project_name = "test-billing"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(billing_project_name),
             status=500,
@@ -1111,7 +1119,7 @@ class BillingProjectAuditTest(AnVILAPIMockTestMixin, TestCase):
         """audit_verified with one verified record."""
         billing_project = factories.BillingProjectFactory.create()
         api_url = self.get_api_url(billing_project.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -1133,7 +1141,7 @@ class BillingProjectAuditTest(AnVILAPIMockTestMixin, TestCase):
         """audit_errors with one verified record."""
         billing_project = factories.BillingProjectFactory.create()
         api_url = self.get_api_url(billing_project.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=404,
@@ -1155,7 +1163,7 @@ class BillingProjectAuditTest(AnVILAPIMockTestMixin, TestCase):
         """audit_ok when audit_results.ok() is True."""
         billing_project = factories.BillingProjectFactory.create()
         api_url = self.get_api_url(billing_project.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -1169,7 +1177,7 @@ class BillingProjectAuditTest(AnVILAPIMockTestMixin, TestCase):
         """audit_ok when audit_results.ok() is True."""
         billing_project = factories.BillingProjectFactory.create()
         api_url = self.get_api_url(billing_project.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=404,
@@ -1485,7 +1493,7 @@ class AccountImportTest(AnVILAPIMockTestMixin, TestCase):
     def test_can_create_an_object(self):
         """Posting valid data to the form creates an object."""
         email = "test@example.com"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(email),
             status=200,
@@ -1505,7 +1513,7 @@ class AccountImportTest(AnVILAPIMockTestMixin, TestCase):
     def test_can_create_an_object_with_note(self):
         """Posting valid data with a note field to the form creates an object."""
         email = "test@example.com"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(email),
             status=200,
@@ -1524,7 +1532,7 @@ class AccountImportTest(AnVILAPIMockTestMixin, TestCase):
     def test_success_message(self):
         """Response includes a success message if successful."""
         email = "test@example.com"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(email),
             status=200,
@@ -1541,7 +1549,7 @@ class AccountImportTest(AnVILAPIMockTestMixin, TestCase):
         """After successfully creating an object, view redirects to the object's detail page."""
         # This needs to use the client because the RequestFactory doesn't handle redirects.
         email = "test@example.com"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(email),
             status=200,
@@ -1611,7 +1619,7 @@ class AccountImportTest(AnVILAPIMockTestMixin, TestCase):
     def test_can_create_service_account(self):
         """Can create a service account."""
         email = "test@example.com"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(email),
             status=200,
@@ -1633,7 +1641,7 @@ class AccountImportTest(AnVILAPIMockTestMixin, TestCase):
     def test_does_not_exist_on_anvil(self):
         """Does not create a new Account when it doesn't exist on AnVIL."""
         email = "test@example.com"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(email),
             status=404,
@@ -1659,7 +1667,7 @@ class AccountImportTest(AnVILAPIMockTestMixin, TestCase):
     def test_email_is_associated_with_group(self):
         """Does not create a new Account if the API returns a code associated with a group."""
         email = "test@example.com"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(email),
             status=204,
@@ -1684,7 +1692,7 @@ class AccountImportTest(AnVILAPIMockTestMixin, TestCase):
     def test_api_error(self):
         """Does not create a new Account if the API returns some other error."""
         email = "test@example.com"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(email),
             status=500,
@@ -1874,7 +1882,7 @@ class AccountLinkTest(AnVILAPIMockTestMixin, TestCase):
         """Posting valid data to the form works as expected."""
         email = "test@example.com"
         api_url = self.get_api_url(email)
-        responses.add(
+        self.response_mock.add(
             responses.GET, api_url, status=200, json=self.get_api_json_response(email)
         )
         timestamp_lower_limit = timezone.now()
@@ -1901,13 +1909,12 @@ class AccountLinkTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(new_object.history.count(), 1)
         self.assertEqual(new_object.history.latest().history_type, "+")
         # API call to AnVIL is made.
-        responses.assert_call_count(api_url, 1)
 
     def test_success_message(self):
         """A success message is added."""
         email = "test@example.com"
         api_url = self.get_api_url(email)
-        responses.add(
+        self.response_mock.add(
             responses.GET, api_url, status=200, json=self.get_api_json_response(email)
         )
         # Need a client because messages are added.
@@ -1922,7 +1929,7 @@ class AccountLinkTest(AnVILAPIMockTestMixin, TestCase):
         """View redirects to the correct URL."""
         email = "test@example.com"
         api_url = self.get_api_url(email)
-        responses.add(
+        self.response_mock.add(
             responses.GET, api_url, status=200, json=self.get_api_json_response(email)
         )
         # Need a client because messages are added.
@@ -1938,7 +1945,7 @@ class AccountLinkTest(AnVILAPIMockTestMixin, TestCase):
         """An email is sent when the form is submitted correctly."""
         email = "test@example.com"
         api_url = self.get_api_url(email)
-        responses.add(
+        self.response_mock.add(
             responses.GET, api_url, status=200, json=self.get_api_json_response(email)
         )
         # Need a client because messages are added.
@@ -2010,7 +2017,7 @@ class AccountLinkTest(AnVILAPIMockTestMixin, TestCase):
             user=self.user, email=email, date_verification_email_sent=original_date
         )
         api_url = self.get_api_url(email)
-        responses.add(
+        self.response_mock.add(
             responses.GET, api_url, status=200, json=self.get_api_json_response(email)
         )
         # Need a client because messages are added.
@@ -2036,7 +2043,6 @@ class AccountLinkTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(email_entry.history.count(), 2)
         self.assertEqual(email_entry.history.latest().history_type, "~")
         # API call to AnVIL is made.
-        responses.assert_call_count(api_url, 1)
 
     def test_account_already_linked_to_different_user_and_verified(self):
         """A different user already has already verified this email."""
@@ -2068,7 +2074,7 @@ class AccountLinkTest(AnVILAPIMockTestMixin, TestCase):
         """Page is reloaded with a message if the account does not exist on AnVIL."""
         email = "test@example.com"
         api_url = self.get_api_url(email)
-        responses.add(
+        self.response_mock.add(
             responses.GET, api_url, status=404, json={"message": "mock message"}
         )
         # Need a client because messages are added.
@@ -2091,7 +2097,6 @@ class AccountLinkTest(AnVILAPIMockTestMixin, TestCase):
         # No new Accounts are created.
         self.assertEqual(models.Account.objects.count(), 0)
         # API call to AnVIL was made.
-        responses.assert_call_count(api_url, 1)
 
     def test_invalid_email(self):
         """Posting invalid data to email field returns a form error."""
@@ -2150,7 +2155,7 @@ class AccountLinkTest(AnVILAPIMockTestMixin, TestCase):
         )
         email = "test@example.com"
         api_url = self.get_api_url(email)
-        responses.add(
+        self.response_mock.add(
             responses.GET, api_url, status=200, json=self.get_api_json_response(email)
         )
         timestamp_lower_limit = timezone.now()
@@ -2193,7 +2198,6 @@ class AccountLinkTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(new_object.history.count(), 1)
         self.assertEqual(new_object.history.latest().history_type, "+")
         # API call to AnVIL is made.
-        responses.assert_call_count(api_url, 1)
 
     # This test occasionally fails if the time flips one second between sending the email and
     # regenerating the token. Use freezegun's freeze_time decorator to fix the time and avoid
@@ -2208,7 +2212,7 @@ class AccountLinkTest(AnVILAPIMockTestMixin, TestCase):
             user=other_user, email=email, date_verification_email_sent=other_timestamp
         )
         api_url = self.get_api_url(email)
-        responses.add(
+        self.response_mock.add(
             responses.GET, api_url, status=200, json=self.get_api_json_response(email)
         )
         timestamp_lower_limit = timezone.now()
@@ -2252,8 +2256,6 @@ class AccountLinkTest(AnVILAPIMockTestMixin, TestCase):
         # History is added.
         self.assertEqual(new_object.history.count(), 1)
         self.assertEqual(new_object.history.latest().history_type, "+")
-        # API call to AnVIL is made.
-        responses.assert_call_count(api_url, 1)
 
     # This test occasionally fails if the time flips one second between sending the email and
     # regenerating the token. Use freezegun's freeze_time decorator to fix the time and avoid
@@ -2270,7 +2272,7 @@ class AccountLinkTest(AnVILAPIMockTestMixin, TestCase):
         )
         # API call will be made with the existing entry.
         api_url = self.get_api_url(email_entry.email)
-        responses.add(
+        self.response_mock.add(
             responses.GET, api_url, status=200, json=self.get_api_json_response(email)
         )
         # Need a client because messages are added.
@@ -2300,13 +2302,11 @@ class AccountLinkTest(AnVILAPIMockTestMixin, TestCase):
         # History is added.
         self.assertEqual(email_entry.history.count(), 2)
         self.assertEqual(email_entry.history.latest().history_type, "~")
-        # API call to AnVIL is made.
-        responses.assert_call_count(api_url, 1)
 
     def test_api_error(self):
         """Does not create a new entry or send email if the API returns some other error."""
         email = "test@example.com"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(email),
             status=500,
@@ -2332,7 +2332,7 @@ class AccountLinkTest(AnVILAPIMockTestMixin, TestCase):
     def test_email_associated_with_group(self):
         """Does not create a new entry or send email if the email is associated with a group."""
         email = "test@example.com"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(email),
             status=204,
@@ -2404,7 +2404,7 @@ class AccountLinkVerifyTest(AnVILAPIMockTestMixin, TestCase):
         )
         token = account_verification_token.make_token(email_entry)
         api_url = self.get_api_url(email)
-        responses.add(
+        self.response_mock.add(
             responses.GET, api_url, status=200, json=self.get_api_json_response(email)
         )
         timestamp_threshold = timezone.now()
@@ -2433,8 +2433,6 @@ class AccountLinkVerifyTest(AnVILAPIMockTestMixin, TestCase):
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertEqual(str(messages[0]), views.AccountLinkVerify.message_success)
-        # API call to AnVIL is made.
-        responses.assert_call_count(api_url, 1)
 
     def test_user_email_entry_does_not_exist(self):
         """ "There is no UserEmailEntry with the uuid."""
@@ -2574,7 +2572,7 @@ class AccountLinkVerifyTest(AnVILAPIMockTestMixin, TestCase):
         """The email no longer has an associated AnVIL account."""
         email_entry = factories.UserEmailEntryFactory.create()
         api_url = self.get_api_url(email_entry.email)
-        responses.add(
+        self.response_mock.add(
             responses.GET, api_url, status=404, json={"message": "mock message"}
         )
         token = account_verification_token.make_token(email_entry)
@@ -2597,14 +2595,12 @@ class AccountLinkVerifyTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(
             str(messages[0]), views.AccountLinkVerify.message_account_does_not_exist
         )
-        # API call to AnVIL was made.
-        responses.assert_call_count(api_url, 1)
 
     def test_email_associated_with_group(self):
         """The email is associated with a group on AnVIL."""
         email_entry = factories.UserEmailEntryFactory.create()
         api_url = self.get_api_url(email_entry.email)
-        responses.add(responses.GET, api_url, status=204)
+        self.response_mock.add(responses.GET, api_url, status=204)
         token = account_verification_token.make_token(email_entry)
         # No API calls are made, so do not add a mocked response.
         # Need a client because messages are added.
@@ -2625,14 +2621,12 @@ class AccountLinkVerifyTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(
             str(messages[0]), views.AccountLinkVerify.message_account_does_not_exist
         )
-        # API call to AnVIL was made.
-        responses.assert_call_count(api_url, 1)
 
     def test_api_call_fails(self):
         """The API call to AnVIL fails."""
         email_entry = factories.UserEmailEntryFactory.create()
         api_url = self.get_api_url(email_entry.email)
-        responses.add(
+        self.response_mock.add(
             responses.GET, api_url, status=500, json={"message": "other error"}
         )
         token = account_verification_token.make_token(email_entry)
@@ -2653,8 +2647,6 @@ class AccountLinkVerifyTest(AnVILAPIMockTestMixin, TestCase):
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertEqual("AnVIL API Error: other error", str(messages[0]))
-        # API call to AnVIL was made.
-        responses.assert_call_count(api_url, 1)
 
     def test_no_notification_email(self):
         """Notification email is not sent if ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL is not set"""
@@ -2664,7 +2656,7 @@ class AccountLinkVerifyTest(AnVILAPIMockTestMixin, TestCase):
         )
         token = account_verification_token.make_token(email_entry)
         api_url = self.get_api_url(email)
-        responses.add(
+        self.response_mock.add(
             responses.GET, api_url, status=200, json=self.get_api_json_response(email)
         )
         self.client.force_login(self.user)
@@ -2682,7 +2674,7 @@ class AccountLinkVerifyTest(AnVILAPIMockTestMixin, TestCase):
         )
         token = account_verification_token.make_token(email_entry)
         api_url = self.get_api_url(email)
-        responses.add(
+        self.response_mock.add(
             responses.GET, api_url, status=200, json=self.get_api_json_response(email)
         )
         self.client.force_login(self.user)
@@ -2702,7 +2694,7 @@ class AccountLinkVerifyTest(AnVILAPIMockTestMixin, TestCase):
         )
         token = account_verification_token.make_token(email_entry)
         api_url = self.get_api_url(email)
-        responses.add(
+        self.response_mock.add(
             responses.GET, api_url, status=200, json=self.get_api_json_response(email)
         )
         self.client.force_login(self.user)
@@ -3196,14 +3188,13 @@ class AccountDeleteTest(AnVILAPIMockTestMixin, TestCase):
         remove_from_group_url = self.get_api_remove_from_group_url(
             group.name, object.email
         )
-        responses.add(responses.DELETE, remove_from_group_url, status=204)
+        self.response_mock.add(responses.DELETE, remove_from_group_url, status=204)
         self.client.force_login(self.user)
         response = self.client.post(self.get_url(object.uuid), {"submit": ""})
         self.assertEqual(response.status_code, 302)
         self.assertEqual(models.Account.objects.count(), 0)
         # Also removes the user from groups.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
-        responses.assert_call_count(remove_from_group_url, 1)
 
     def test_removes_account_from_all_groups(self):
         """Deleting an account from the app also removes it from all groups that it is in."""
@@ -3216,19 +3207,17 @@ class AccountDeleteTest(AnVILAPIMockTestMixin, TestCase):
         remove_from_group_url_1 = self.get_api_remove_from_group_url(
             group_1.name, object.email
         )
-        responses.add(responses.DELETE, remove_from_group_url_1, status=204)
+        self.response_mock.add(responses.DELETE, remove_from_group_url_1, status=204)
         remove_from_group_url_2 = self.get_api_remove_from_group_url(
             group_2.name, object.email
         )
-        responses.add(responses.DELETE, remove_from_group_url_2, status=204)
+        self.response_mock.add(responses.DELETE, remove_from_group_url_2, status=204)
         self.client.force_login(self.user)
         response = self.client.post(self.get_url(object.uuid), {"submit": ""})
         self.assertEqual(response.status_code, 302)
         self.assertEqual(models.Account.objects.count(), 0)
         # Also removes the user from groups.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
-        responses.assert_call_count(remove_from_group_url_1, 1)
-        responses.assert_call_count(remove_from_group_url_2, 1)
 
     def test_api_error_when_removing_account_from_groups(self):
         """Message when an API error occurred when removing a user from a group."""
@@ -3241,11 +3230,11 @@ class AccountDeleteTest(AnVILAPIMockTestMixin, TestCase):
         remove_from_group_url_1 = self.get_api_remove_from_group_url(
             group_1.name, object.email
         )
-        responses.add(responses.DELETE, remove_from_group_url_1, status=204)
+        self.response_mock.add(responses.DELETE, remove_from_group_url_1, status=204)
         remove_from_group_url_2 = self.get_api_remove_from_group_url(
             group_2.name, object.email
         )
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             remove_from_group_url_2,
             status=409,
@@ -3271,9 +3260,6 @@ class AccountDeleteTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(models.GroupAccountMembership.objects.count(), 2)
         models.GroupAccountMembership.objects.get(pk=memberships[0].pk)
         models.GroupAccountMembership.objects.get(pk=memberships[1].pk)
-        # The API was called.
-        responses.assert_call_count(remove_from_group_url_1, 1)
-        responses.assert_call_count(remove_from_group_url_2, 1)
 
 
 class AccountDeactivateTest(AnVILAPIMockTestMixin, TestCase):
@@ -3446,13 +3432,12 @@ class AccountDeactivateTest(AnVILAPIMockTestMixin, TestCase):
         remove_from_group_url = self.get_api_remove_from_group_url(
             group.name, object.email
         )
-        responses.add(responses.DELETE, remove_from_group_url, status=204)
+        self.response_mock.add(responses.DELETE, remove_from_group_url, status=204)
         self.client.force_login(self.user)
         response = self.client.post(self.get_url(object.uuid), {"submit": ""})
         self.assertEqual(response.status_code, 302)
         # Memberships are *not* deleted from the app.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 1)
-        responses.assert_call_count(remove_from_group_url, 1)
         # History for group-account membership is *not* added.
         self.assertEqual(models.GroupAccountMembership.history.count(), 1)
 
@@ -3467,11 +3452,11 @@ class AccountDeactivateTest(AnVILAPIMockTestMixin, TestCase):
         remove_from_group_url_1 = self.get_api_remove_from_group_url(
             group_1.name, object.email
         )
-        responses.add(responses.DELETE, remove_from_group_url_1, status=204)
+        self.response_mock.add(responses.DELETE, remove_from_group_url_1, status=204)
         remove_from_group_url_2 = self.get_api_remove_from_group_url(
             group_2.name, object.email
         )
-        responses.add(responses.DELETE, remove_from_group_url_2, status=204)
+        self.response_mock.add(responses.DELETE, remove_from_group_url_2, status=204)
         self.client.force_login(self.user)
         response = self.client.post(self.get_url(object.uuid), {"submit": ""})
         self.assertEqual(response.status_code, 302)
@@ -3480,8 +3465,6 @@ class AccountDeactivateTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(object.status, object.INACTIVE_STATUS)
         # Memberships are *not* deleted from the app.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 2)
-        responses.assert_call_count(remove_from_group_url_1, 1)
-        responses.assert_call_count(remove_from_group_url_2, 1)
 
     def test_api_error_when_removing_account_from_groups(self):
         """Message when an API error occurred when removing a user from a group."""
@@ -3494,11 +3477,11 @@ class AccountDeactivateTest(AnVILAPIMockTestMixin, TestCase):
         remove_from_group_url_1 = self.get_api_remove_from_group_url(
             group_1.name, object.email
         )
-        responses.add(responses.DELETE, remove_from_group_url_1, status=204)
+        self.response_mock.add(responses.DELETE, remove_from_group_url_1, status=204)
         remove_from_group_url_2 = self.get_api_remove_from_group_url(
             group_2.name, object.email
         )
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             remove_from_group_url_2,
             status=409,
@@ -3526,9 +3509,6 @@ class AccountDeactivateTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(models.GroupAccountMembership.objects.count(), 2)
         models.GroupAccountMembership.objects.get(pk=memberships[0].pk)
         models.GroupAccountMembership.objects.get(pk=memberships[1].pk)
-        # The API was called.
-        responses.assert_call_count(remove_from_group_url_1, 1)
-        responses.assert_call_count(remove_from_group_url_2, 1)
 
     def test_account_already_inactive_get(self):
         """Redirects with a message if account is already deactivated."""
@@ -3765,11 +3745,10 @@ class AccountReactivateTest(AnVILAPIMockTestMixin, TestCase):
         object.status = object.INACTIVE_STATUS
         object.save()
         add_to_group_url = self.get_api_add_to_group_url(group.name, object.email)
-        responses.add(responses.PUT, add_to_group_url, status=204)
+        self.response_mock.add(responses.PUT, add_to_group_url, status=204)
         self.client.force_login(self.user)
         response = self.client.post(self.get_url(object.uuid), {"submit": ""})
         self.assertEqual(response.status_code, 302)
-        responses.assert_call_count(add_to_group_url, 1)
         # History is not added for the GroupAccountMembership.
         self.assertEqual(models.GroupAccountMembership.history.count(), 1)
 
@@ -3784,17 +3763,15 @@ class AccountReactivateTest(AnVILAPIMockTestMixin, TestCase):
         group_1 = memberships[0].group
         group_2 = memberships[1].group
         add_to_group_url_1 = self.get_api_add_to_group_url(group_1.name, object.email)
-        responses.add(responses.PUT, add_to_group_url_1, status=204)
+        self.response_mock.add(responses.PUT, add_to_group_url_1, status=204)
         add_to_group_url_2 = self.get_api_add_to_group_url(group_2.name, object.email)
-        responses.add(responses.PUT, add_to_group_url_2, status=204)
+        self.response_mock.add(responses.PUT, add_to_group_url_2, status=204)
         self.client.force_login(self.user)
         response = self.client.post(self.get_url(object.uuid), {"submit": ""})
         self.assertEqual(response.status_code, 302)
         # Status was updated.
         object.refresh_from_db()
         self.assertEqual(object.status, object.ACTIVE_STATUS)
-        responses.assert_call_count(add_to_group_url_1, 1)
-        responses.assert_call_count(add_to_group_url_2, 1)
 
     def test_api_error_when_adding_account_to_groups(self):
         """Message when an API error occurred when adding a user to a group."""
@@ -3807,9 +3784,9 @@ class AccountReactivateTest(AnVILAPIMockTestMixin, TestCase):
         group_1 = memberships[0].group
         group_2 = memberships[1].group
         add_to_group_url_1 = self.get_api_add_to_group_url(group_1.name, object.email)
-        responses.add(responses.PUT, add_to_group_url_1, status=204)
+        self.response_mock.add(responses.PUT, add_to_group_url_1, status=204)
         add_to_group_url_2 = self.get_api_add_to_group_url(group_2.name, object.email)
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             add_to_group_url_2,
             status=409,
@@ -3835,9 +3812,6 @@ class AccountReactivateTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(models.GroupAccountMembership.objects.count(), 2)
         models.GroupAccountMembership.objects.get(pk=memberships[0].pk)
         models.GroupAccountMembership.objects.get(pk=memberships[1].pk)
-        # The API was called.
-        responses.assert_call_count(add_to_group_url_1, 1)
-        responses.assert_call_count(add_to_group_url_2, 1)
 
     def test_account_already_active_get(self):
         """Redirects with a message if account is already active."""
@@ -4106,7 +4080,7 @@ class AccountAuditTest(AnVILAPIMockTestMixin, TestCase):
         """audit_verified with one verified record."""
         account = factories.AccountFactory.create()
         api_url = self.get_api_url(account.email)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4128,7 +4102,7 @@ class AccountAuditTest(AnVILAPIMockTestMixin, TestCase):
         """audit_errors with one verified record."""
         account = factories.AccountFactory.create()
         api_url = self.get_api_url(account.email)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=404,
@@ -4150,7 +4124,7 @@ class AccountAuditTest(AnVILAPIMockTestMixin, TestCase):
         """audit_ok when audit_results.ok() is True."""
         account = factories.AccountFactory.create()
         api_url = self.get_api_url(account.email)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -4165,7 +4139,7 @@ class AccountAuditTest(AnVILAPIMockTestMixin, TestCase):
         """audit_ok when audit_results.ok() is True."""
         account = factories.AccountFactory.create()
         api_url = self.get_api_url(account.email)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=404,
@@ -4649,14 +4623,13 @@ class ManagedGroupCreateTest(AnVILAPIMockTestMixin, TestCase):
     def test_can_create_an_object(self):
         """Posting valid data to the form creates an object."""
         api_url = self.get_api_url("test-group")
-        responses.add(responses.POST, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.POST, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(self.get_url(), {"name": "test-group"})
         self.assertEqual(response.status_code, 302)
         new_object = models.ManagedGroup.objects.latest("pk")
         self.assertIsInstance(new_object, models.ManagedGroup)
         self.assertEqual(new_object.name, "test-group")
-        responses.assert_call_count(api_url, 1)
         # History is added.
         self.assertEqual(new_object.history.count(), 1)
         self.assertEqual(new_object.history.latest().history_type, "+")
@@ -4664,7 +4637,7 @@ class ManagedGroupCreateTest(AnVILAPIMockTestMixin, TestCase):
     def test_can_create_an_object_with_note(self):
         """Posting valid data including note to the form creates an object."""
         api_url = self.get_api_url("test-group")
-        responses.add(responses.POST, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.POST, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(), {"name": "test-group", "note": "test note"}
@@ -4673,12 +4646,11 @@ class ManagedGroupCreateTest(AnVILAPIMockTestMixin, TestCase):
         new_object = models.ManagedGroup.objects.latest("pk")
         self.assertIsInstance(new_object, models.ManagedGroup)
         self.assertEqual(new_object.note, "test note")
-        responses.assert_call_count(api_url, 1)
 
     def test_success_message(self):
         """Response includes a success message if successful."""
         api_url = self.get_api_url("test-group")
-        responses.add(responses.POST, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.POST, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(self.get_url(), {"name": "test-group"}, follow=True)
         self.assertIn("messages", response.context)
@@ -4690,12 +4662,11 @@ class ManagedGroupCreateTest(AnVILAPIMockTestMixin, TestCase):
         """After successfully creating an object, view redirects to the object's detail page."""
         # This needs to use the client because the RequestFactory doesn't handle redirects.
         api_url = self.get_api_url("test-group")
-        responses.add(responses.POST, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.POST, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(self.get_url(), {"name": "test-group"})
         new_object = models.ManagedGroup.objects.latest("pk")
         self.assertRedirects(response, new_object.get_absolute_url())
-        responses.assert_call_count(api_url, 1)
 
     def test_cannot_create_duplicate_object(self):
         """Cannot create two groups with the same name."""
@@ -4756,7 +4727,7 @@ class ManagedGroupCreateTest(AnVILAPIMockTestMixin, TestCase):
     def test_api_error_message(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("test-group")
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             api_url,
             status=500,
@@ -4771,13 +4742,12 @@ class ManagedGroupCreateTest(AnVILAPIMockTestMixin, TestCase):
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertEqual("AnVIL API Error: group create test error", str(messages[0]))
-        responses.assert_call_count(api_url, 1)
         # Make sure that no object is created.
         self.assertEqual(models.ManagedGroup.objects.count(), 0)
 
     def test_api_group_already_exists(self):
         api_url = self.get_api_url("test-group")
-        responses.add(
+        self.response_mock.add(
             responses.POST, api_url, status=409, json={"message": "other error"}
         )
         # Need a client to check messages.
@@ -4789,7 +4759,6 @@ class ManagedGroupCreateTest(AnVILAPIMockTestMixin, TestCase):
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertEqual("AnVIL API Error: other error", str(messages[0]))
-        responses.assert_call_count(api_url, 1)
         # Make sure that no object is created.
         self.assertEqual(models.ManagedGroup.objects.count(), 0)
 
@@ -5065,12 +5034,11 @@ class ManagedGroupDeleteTest(AnVILAPIMockTestMixin, TestCase):
         """Posting submit to the form successfully deletes the object."""
         object = factories.ManagedGroupFactory.create(name="test-group")
         api_url = self.get_api_url(object.name)
-        responses.add(responses.DELETE, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.DELETE, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(self.get_url(object.name), {"submit": ""})
         self.assertEqual(response.status_code, 302)
         self.assertEqual(models.ManagedGroup.objects.count(), 0)
-        responses.assert_call_count(api_url, 1)
         # History is added.
         self.assertEqual(object.history.count(), 2)
         self.assertEqual(object.history.latest().history_type, "-")
@@ -5079,7 +5047,7 @@ class ManagedGroupDeleteTest(AnVILAPIMockTestMixin, TestCase):
         """Response includes a success message if successful."""
         object = factories.ManagedGroupFactory.create(name="test-group")
         api_url = self.get_api_url(object.name)
-        responses.add(responses.DELETE, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.DELETE, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(object.name), {"submit": ""}, follow=True
@@ -5094,7 +5062,7 @@ class ManagedGroupDeleteTest(AnVILAPIMockTestMixin, TestCase):
         object = factories.ManagedGroupFactory.create()
         other_object = factories.ManagedGroupFactory.create()
         api_url = self.get_api_url(object.name)
-        responses.add(responses.DELETE, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.DELETE, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(self.get_url(object.name), {"submit": ""})
         self.assertEqual(response.status_code, 302)
@@ -5103,13 +5071,12 @@ class ManagedGroupDeleteTest(AnVILAPIMockTestMixin, TestCase):
             models.ManagedGroup.objects.all(),
             models.ManagedGroup.objects.filter(pk=other_object.pk),
         )
-        responses.assert_call_count(api_url, 1)
 
     def test_success_url(self):
         """Redirects to the expected page."""
         object = factories.ManagedGroupFactory.create()
         api_url = self.get_api_url(object.name)
-        responses.add(responses.DELETE, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.DELETE, api_url, status=self.api_success_code)
         # Need to use the client instead of RequestFactory to check redirection url.
         self.client.force_login(self.user)
         response = self.client.post(self.get_url(object.name), {"submit": ""})
@@ -5117,7 +5084,6 @@ class ManagedGroupDeleteTest(AnVILAPIMockTestMixin, TestCase):
         self.assertRedirects(
             response, reverse("anvil_consortium_manager:managed_groups:list")
         )
-        responses.assert_call_count(api_url, 1)
 
     def test_get_redirect_group_is_a_member_of_another_group(self):
         """Redirect get request when trying to delete a group that is a member of another group.
@@ -5277,7 +5243,7 @@ class ManagedGroupDeleteTest(AnVILAPIMockTestMixin, TestCase):
             parent_group=parent, child_group=child
         )
         api_url = self.get_api_url(parent.name)
-        responses.add(responses.DELETE, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.DELETE, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(self.get_url(parent.name), {"submit": ""})
         self.assertEqual(response.status_code, 302)
@@ -5289,7 +5255,6 @@ class ManagedGroupDeleteTest(AnVILAPIMockTestMixin, TestCase):
         models.ManagedGroup.objects.get(pk=child.pk)
         # The group membership was deleted.
         self.assertEqual(models.GroupGroupMembership.objects.count(), 0)
-        responses.assert_call_count(api_url, 1)
         # History is added for the GroupGroupMembership.
         self.assertEqual(models.GroupGroupMembership.history.count(), 2)
         self.assertEqual(models.GroupGroupMembership.history.latest().history_type, "-")
@@ -5300,7 +5265,7 @@ class ManagedGroupDeleteTest(AnVILAPIMockTestMixin, TestCase):
         account = factories.AccountFactory.create()
         factories.GroupAccountMembershipFactory.create(group=group, account=account)
         api_url = self.get_api_url(group.name)
-        responses.add(responses.DELETE, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.DELETE, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(self.get_url(group.name), {"submit": ""})
         self.assertEqual(response.status_code, 302)
@@ -5310,7 +5275,6 @@ class ManagedGroupDeleteTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
         # The account still exists.
         models.Account.objects.get(pk=account.pk)
-        responses.assert_call_count(api_url, 1)
         # History is added for GroupAccountMemberships.
         self.assertEqual(models.GroupAccountMembership.history.count(), 2)
         self.assertEqual(
@@ -5322,7 +5286,7 @@ class ManagedGroupDeleteTest(AnVILAPIMockTestMixin, TestCase):
         # Need a client to check messages.
         object = factories.ManagedGroupFactory.create()
         api_url = self.get_api_url(object.name)
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             api_url,
             status=500,
@@ -5335,7 +5299,6 @@ class ManagedGroupDeleteTest(AnVILAPIMockTestMixin, TestCase):
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertEqual("AnVIL API Error: group delete test error", str(messages[0]))
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object still exists.
         self.assertEqual(models.ManagedGroup.objects.count(), 1)
 
@@ -5593,7 +5556,7 @@ class ManagedGroupAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_status_code_with_user_permission(self):
         """Returns successful response code."""
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -5616,7 +5579,7 @@ class ManagedGroupAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_template(self):
         """Template loads successfully."""
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -5629,7 +5592,7 @@ class ManagedGroupAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_audit_verified(self):
         """audit_verified is in the context data."""
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -5644,7 +5607,7 @@ class ManagedGroupAuditTest(AnVILAPIMockTestMixin, TestCase):
         """audit_verified with one verified record."""
         group = factories.ManagedGroupFactory.create()
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -5652,14 +5615,14 @@ class ManagedGroupAuditTest(AnVILAPIMockTestMixin, TestCase):
         )
         # Group membership API call.
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -5673,7 +5636,7 @@ class ManagedGroupAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_audit_errors(self):
         """audit_errors is in the context data."""
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -5688,7 +5651,7 @@ class ManagedGroupAuditTest(AnVILAPIMockTestMixin, TestCase):
         """audit_errors with one error record."""
         group = factories.ManagedGroupFactory.create()
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -5703,7 +5666,7 @@ class ManagedGroupAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_audit_not_in_app(self):
         """audit_not_in_app is in the context data."""
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -5717,7 +5680,7 @@ class ManagedGroupAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_audit_not_in_app_one_record(self):
         """audit_not_in_app with one record not in app."""
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -5732,7 +5695,7 @@ class ManagedGroupAuditTest(AnVILAPIMockTestMixin, TestCase):
         """audit_ok when audit_results.ok() is True."""
         group = factories.ManagedGroupFactory.create()
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -5740,14 +5703,14 @@ class ManagedGroupAuditTest(AnVILAPIMockTestMixin, TestCase):
         )
         # Group membership API call.
         api_url_members = self.get_api_url_members(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -5762,7 +5725,7 @@ class ManagedGroupAuditTest(AnVILAPIMockTestMixin, TestCase):
         """audit_ok when audit_results.ok() is False."""
         group = factories.ManagedGroupFactory.create()
         api_url = self.get_api_groups_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -5838,14 +5801,14 @@ class ManagedGroupMembershipAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_status_code_with_user_permission(self):
         """Returns successful response code."""
         api_url_members = self.get_api_url_members(self.group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(self.group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -5868,14 +5831,14 @@ class ManagedGroupMembershipAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_template(self):
         """Template loads successfully."""
         api_url_members = self.get_api_url_members(self.group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(self.group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -5888,14 +5851,14 @@ class ManagedGroupMembershipAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_audit_verified(self):
         """audit_verified is in the context data."""
         api_url_members = self.get_api_url_members(self.group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(self.group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -5910,14 +5873,14 @@ class ManagedGroupMembershipAuditTest(AnVILAPIMockTestMixin, TestCase):
         """audit_verified with one verified record."""
         membership = factories.GroupAccountMembershipFactory.create(group=self.group)
         api_url_members = self.get_api_url_members(self.group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[membership.account.email]),
         )
         api_url_admins = self.get_api_url_admins(self.group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -5931,14 +5894,14 @@ class ManagedGroupMembershipAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_audit_errors(self):
         """audit_errors is in the context data."""
         api_url_members = self.get_api_url_members(self.group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(self.group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -5954,14 +5917,14 @@ class ManagedGroupMembershipAuditTest(AnVILAPIMockTestMixin, TestCase):
         membership = factories.GroupAccountMembershipFactory.create(group=self.group)
         # Group membership API call.
         api_url_members = self.get_api_url_members(self.group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(self.group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -5975,14 +5938,14 @@ class ManagedGroupMembershipAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_audit_not_in_app(self):
         """audit_not_in_app is in the context data."""
         api_url_members = self.get_api_url_members(self.group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(self.group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -5996,14 +5959,14 @@ class ManagedGroupMembershipAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_audit_not_in_app_one_record(self):
         """audit_not_in_app with one record not in app."""
         api_url_members = self.get_api_url_members(self.group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=["foo@bar.com"]),
         )
         api_url_admins = self.get_api_url_admins(self.group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -6017,14 +5980,14 @@ class ManagedGroupMembershipAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_audit_ok_is_ok(self):
         """audit_ok when audit_results.ok() is True."""
         api_url_members = self.get_api_url_members(self.group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=[]),
         )
         api_url_admins = self.get_api_url_admins(self.group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -6038,14 +6001,14 @@ class ManagedGroupMembershipAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_audit_ok_is_not_ok(self):
         """audit_ok when audit_results.ok() is False."""
         api_url_members = self.get_api_url_members(self.group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_members,
             status=200,
             json=self.get_api_json_response_members(emails=["foo@bar.com"]),
         )
         api_url_admins = self.get_api_url_admins(self.group.name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url_admins,
             status=200,
@@ -6465,7 +6428,7 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
             "name": "test-workspace",
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=self.api_success_code,
@@ -6491,7 +6454,6 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
             new_object.workspace_type,
             DefaultWorkspaceAdapter().get_type(),
         )
-        responses.assert_call_count(self.api_url, 1)
         # History is added.
         self.assertEqual(new_object.history.count(), 1)
         self.assertEqual(new_object.history.latest().history_type, "+")
@@ -6506,7 +6468,7 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
             "name": "test-workspace",
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=self.api_success_code,
@@ -6530,7 +6492,6 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
         new_object = models.Workspace.objects.latest("pk")
         self.assertIsInstance(new_object, models.Workspace)
         self.assertEqual(new_object.note, "test note")
-        responses.assert_call_count(self.api_url, 1)
 
     def test_creates_default_workspace_data(self):
         """Posting valid data to the form creates the default workspace data object."""
@@ -6542,7 +6503,7 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
             "name": "test-workspace",
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=self.api_success_code,
@@ -6577,7 +6538,7 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
             "name": "test-workspace",
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=self.api_success_code,
@@ -6611,7 +6572,7 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
             "name": "test-workspace",
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=self.api_success_code,
@@ -6632,7 +6593,6 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
         )
         new_object = models.Workspace.objects.latest("pk")
         self.assertRedirects(response, new_object.get_absolute_url())
-        responses.assert_call_count(self.api_url, 1)
 
     def test_cannot_create_duplicate_object(self):
         """Cannot create two workspaces with the same billing project and name."""
@@ -6670,7 +6630,7 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
             "name": "test-name-2",
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=self.api_success_code,
@@ -6695,7 +6655,6 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
         models.Workspace.objects.get(
             billing_project=billing_project, name="test-name-2"
         )
-        responses.assert_call_count(self.api_url, 1)
 
     def test_can_create_workspace_with_same_name_different_billing_project(self):
         """Can create a workspace with the same name in a different billing project."""
@@ -6710,7 +6669,7 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
             "name": "test-name",
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=self.api_success_code,
@@ -6735,7 +6694,6 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
         models.Workspace.objects.get(
             billing_project=billing_project_2, name=workspace_name
         )
-        responses.assert_call_count(self.api_url, 1)
 
     def test_invalid_input_name(self):
         """Posting invalid data to name field does not create an object."""
@@ -6820,7 +6778,7 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
             "name": "test-workspace",
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=500,
@@ -6847,7 +6805,6 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertIn("AnVIL API Error: workspace create test error", str(messages[0]))
-        responses.assert_call_count(self.api_url, 1)
         # Make sure that no object is created.
         self.assertEqual(models.Workspace.objects.count(), 0)
 
@@ -6863,7 +6820,7 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
             "attributes": {},
             "authorizationDomain": [{"membersGroupName": auth_domain.name}],
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=self.api_success_code,
@@ -6888,7 +6845,6 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIsInstance(new_object, models.Workspace)
         self.assertEqual(len(new_object.authorization_domains.all()), 1)
         self.assertIn(auth_domain, new_object.authorization_domains.all())
-        responses.assert_call_count(self.api_url, 1)
         # History is added.
         self.assertEqual(new_object.history.count(), 1)
         self.assertEqual(new_object.history.latest().history_type, "+")
@@ -6914,7 +6870,7 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
                 {"membersGroupName": auth_domain_2.name},
             ],
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=self.api_success_code,
@@ -6940,7 +6896,6 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(len(new_object.authorization_domains.all()), 2)
         self.assertIn(auth_domain_1, new_object.authorization_domains.all())
         self.assertIn(auth_domain_2, new_object.authorization_domains.all())
-        responses.assert_call_count(self.api_url, 1)
 
     def test_invalid_auth_domain(self):
         """Does not create a workspace when an invalid authorization domain is specified."""
@@ -6970,7 +6925,6 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
         # No object was created.
         self.assertEqual(len(models.Workspace.objects.all()), 0)
         # No API calls made.
-        responses.assert_call_count(self.api_url, 0)
 
     def test_one_valid_one_invalid_auth_domain(self):
         billing_project = factories.BillingProjectFactory.create(
@@ -6999,8 +6953,6 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIn("valid choice", form.errors["authorization_domains"][0])
         # No object was created.
         self.assertEqual(len(models.Workspace.objects.all()), 0)
-        # No API calls made.
-        responses.assert_call_count(self.api_url, 0)
 
     def test_auth_domain_does_not_exist_on_anvil(self):
         """No workspace is displayed if the auth domain group doesn't exist on AnVIL."""
@@ -7016,7 +6968,7 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
                 {"membersGroupName": auth_domain.name},
             ],
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=400,
@@ -7049,7 +7001,6 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual("AnVIL API Error: api error", str(messages[0]))
         # Did not create any new Workspaces.
         self.assertEqual(models.Workspace.objects.count(), 0)
-        responses.assert_call_count(self.api_url, 1)
 
     def test_not_admin_of_auth_domain_on_anvil(self):
         """No workspace is displayed if we are not the admins of the auth domain on AnVIL."""
@@ -7065,7 +7016,7 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
                 {"membersGroupName": auth_domain.name},
             ],
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=400,
@@ -7098,7 +7049,6 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual("AnVIL API Error: api error", str(messages[0]))
         # Did not create any new Workspaces.
         self.assertEqual(models.Workspace.objects.count(), 0)
-        responses.assert_call_count(self.api_url, 1)
 
     def test_not_user_of_billing_project(self):
         """Posting a billing project where we are not users does not create an object."""
@@ -7159,7 +7109,7 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
             "name": "test-workspace",
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=self.api_success_code,
@@ -7192,7 +7142,6 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
         new_workspace_data = app_models.TestWorkspaceData.objects.latest("pk")
         self.assertEqual(new_workspace_data.workspace, new_workspace)
         self.assertEqual(new_workspace_data.study_name, "test study")
-        responses.assert_call_count(self.api_url, 1)
 
     def test_adapter_does_not_create_objects_if_workspace_data_form_invalid(self):
         """Posting invalid data to the workspace_data_form form does not create a workspace when using an adapter."""
@@ -7203,17 +7152,6 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
         workspace_adapter_registry.register(TestWorkspaceAdapter)
         self.workspace_type = "test"
         billing_project = factories.BillingProjectFactory.create()
-        json_data = {
-            "namespace": "test-billing-project",
-            "name": "test-workspace",
-            "attributes": {},
-        }
-        responses.add(
-            responses.POST,
-            self.api_url,
-            status=self.api_success_code,
-            match=[responses.matchers.json_params_matcher(json_data)],
-        )
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.workspace_type),
@@ -7326,7 +7264,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_status_code_with_user_permission(self):
         """Returns successful response code."""
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -7384,7 +7322,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         """Response includes a form."""
         billing_project_name = "test-billing-project"
         workspace_name = "test-workspace"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -7404,7 +7342,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         """Response includes a formset for the workspace_data model."""
         billing_project_name = "test-billing-project"
         workspace_name = "test-workspace"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -7425,7 +7363,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_form_choices_no_available_workspaces(self):
         """Choices are populated correctly with one available workspace."""
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -7453,7 +7391,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_form_choices_one_available_workspace(self):
         """Choices are populated correctly with one available workspace."""
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -7476,7 +7414,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_form_choices_two_available_workspaces(self):
         """Choices are populated correctly with two available workspaces."""
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -7507,7 +7445,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         factories.WorkspaceFactory.create(
             billing_project=billing_project, name="ws-imported"
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -7538,7 +7476,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_form_does_not_show_workspaces_not_owner(self):
         """The form does not show workspaces where we aren't owners in the choices."""
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -7567,7 +7505,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         billing_project_name = "billing-project"
         workspace_name = "workspace"
         # Available workspaces API call.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -7584,9 +7522,9 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
             + "/api/billing/v2/"
             + billing_project_name
         )
-        responses.add(responses.GET, billing_project_url, status=200)
+        self.response_mock.add(responses.GET, billing_project_url, status=200)
         url = self.get_api_url(billing_project_name, workspace_name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             url,
             status=self.api_success_code,
@@ -7618,8 +7556,6 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
             new_workspace.workspace_type,
             DefaultWorkspaceAdapter().get_type(),
         )
-        responses.assert_call_count(billing_project_url, 1)
-        responses.assert_call_count(url, 1)
         # History is added for the workspace.
         self.assertEqual(new_workspace.history.count(), 1)
         self.assertEqual(new_workspace.history.latest().history_type, "+")
@@ -7635,7 +7571,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         )
         workspace_name = "workspace"
         # Available workspaces API call.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -7647,7 +7583,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
             json=[self.get_api_json_response(billing_project_name, workspace_name)],
         )
         url = self.get_api_url(billing_project_name, workspace_name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             url,
             status=self.api_success_code,
@@ -7681,7 +7617,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         billing_project = factories.BillingProjectFactory.create()
         workspace_name = "workspace"
         # Available workspaces API call.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -7693,7 +7629,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
             json=[self.get_api_json_response(billing_project.name, workspace_name)],
         )
         url = self.get_api_url(billing_project.name, workspace_name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             url,
             status=self.api_success_code,
@@ -7724,7 +7660,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         billing_project = factories.BillingProjectFactory.create()
         workspace_name = "workspace"
         # Available workspaces API call.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -7736,7 +7672,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
             json=[self.get_api_json_response(billing_project.name, workspace_name)],
         )
         url = self.get_api_url(billing_project.name, workspace_name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             url,
             status=self.api_success_code,
@@ -7765,7 +7701,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         billing_project_name = "billing-project"
         workspace_name = "workspace"
         # Available workspaces API call.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -7782,11 +7718,11 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
             + "/api/billing/v2/"
             + billing_project_name
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET, billing_project_url, status=404, json={"message": "other"}
         )
         url = self.get_api_url(billing_project_name, workspace_name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             url,
             status=self.api_success_code,
@@ -7814,8 +7750,6 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(models.Workspace.objects.count(), 1)
         new_workspace = models.Workspace.objects.latest("pk")
         self.assertEqual(new_workspace.name, workspace_name)
-        responses.assert_call_count(billing_project_url, 1)
-        responses.assert_call_count(url, 1)
         # History is added for the workspace.
         self.assertEqual(new_workspace.history.count(), 1)
         self.assertEqual(new_workspace.history.latest().history_type, "+")
@@ -7828,7 +7762,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         billing_project = factories.BillingProjectFactory.create(name="billing-project")
         workspace_name = "workspace"
         # Available workspaces API call.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -7840,7 +7774,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
             json=[self.get_api_json_response(billing_project.name, workspace_name)],
         )
         url = self.get_api_url(billing_project.name, workspace_name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             url,
             status=self.api_success_code,
@@ -7863,7 +7797,6 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(models.Workspace.objects.count(), 1)
         new_workspace = models.Workspace.objects.latest("pk")
         self.assertEqual(new_workspace.name, workspace_name)
-        responses.assert_call_count(url, 1)
         # History is added for the workspace.
         self.assertEqual(new_workspace.history.count(), 1)
         self.assertEqual(new_workspace.history.latest().history_type, "+")
@@ -7882,7 +7815,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
             workspace_name,
             authorization_domains=[auth_domain.name],
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -7895,7 +7828,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
             json=[workspace_json],
         )
         url = self.get_api_url(billing_project.name, workspace_name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             url,
             status=self.api_success_code,
@@ -7918,7 +7851,6 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(models.Workspace.objects.count(), 1)
         new_workspace = models.Workspace.objects.latest("pk")
         self.assertEqual(new_workspace.name, workspace_name)
-        responses.assert_call_count(url, 1)
         # History is added for the workspace.
         self.assertEqual(new_workspace.history.count(), 1)
         self.assertEqual(new_workspace.history.latest().history_type, "+")
@@ -7934,7 +7866,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         workspace_name = "workspace"
         auth_domain_name = "auth-group"
         # Available workspaces API call.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -7952,7 +7884,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
             ],
         )
         url = self.get_api_url(billing_project.name, workspace_name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             url,
             status=self.api_success_code,
@@ -7964,7 +7896,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         )
         # Add Response for the auth domain group.
         group_url = self.api_client.sam_entry_point + "/api/groups/v1"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             group_url,
             status=200,
@@ -7994,7 +7926,6 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(models.Workspace.objects.count(), 1)
         new_workspace = models.Workspace.objects.latest("pk")
         self.assertEqual(new_workspace.name, workspace_name)
-        responses.assert_call_count(url, 1)
         # History is added for the workspace.
         self.assertEqual(new_workspace.history.count(), 1)
         self.assertEqual(new_workspace.history.latest().history_type, "+")
@@ -8020,7 +7951,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         billing_project = factories.BillingProjectFactory.create(name="billing-project")
         workspace_name = "workspace"
         # Available workspaces API call.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -8032,7 +7963,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
             json=[self.get_api_json_response(billing_project.name, workspace_name)],
         )
         url = self.get_api_url(billing_project.name, workspace_name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             url,
             status=self.api_success_code,
@@ -8052,13 +7983,12 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         )
         new_object = models.Workspace.objects.latest("pk")
         self.assertRedirects(response, new_object.get_absolute_url())
-        responses.assert_call_count(url, 1)
 
     def test_workspace_already_imported(self):
         """Does not import a workspace that already exists in Django."""
         workspace = factories.WorkspaceFactory.create()
         # Available workspaces API call.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -8100,7 +8030,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
     def test_invalid_workspace_name(self):
         """Does not create an object if workspace name is invalid."""
         # Available workspaces API call.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -8137,7 +8067,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
     def test_post_blank_data(self):
         """Posting blank data does not create an object."""
         # Available workspaces API call.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -8165,13 +8095,12 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIn("workspace", form.errors.keys())
         self.assertIn("required", form.errors["workspace"][0])
         self.assertEqual(models.Workspace.objects.count(), 0)
-        self.assertEqual(len(responses.calls), 1)  # just the workspace list.
 
     def test_other_anvil_api_error(self):
         billing_project_name = "billing-project"
         workspace_name = "workspace"
         # Available workspaces API call.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -8182,8 +8111,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
             status=200,
             json=[self.get_api_json_response(billing_project_name, workspace_name)],
         )
-        url = self.get_api_url(billing_project_name, workspace_name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.get_api_url(billing_project_name, workspace_name),
             status=500,
@@ -8213,11 +8141,10 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         # Did not create any objects.
         self.assertEqual(models.BillingProject.objects.count(), 0)
         self.assertEqual(models.Workspace.objects.count(), 0)
-        responses.assert_call_count(url, 1)
 
     def test_anvil_api_error_workspace_list_get(self):
         # Available workspaces API call.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -8245,7 +8172,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_anvil_api_error_workspace_list_post(self):
         # Available workspaces API call.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -8293,7 +8220,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         self.workspace_type = TestWorkspaceAdapter().get_type()
         billing_project_name = "test-billing-project"
         workspace_name = "test-workspace"
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -8323,7 +8250,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         billing_project = factories.BillingProjectFactory.create(name="billing-project")
         workspace_name = "workspace"
         # Available workspaces API call.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -8335,7 +8262,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
             json=[self.get_api_json_response(billing_project.name, workspace_name)],
         )
         url = self.get_api_url(billing_project.name, workspace_name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             url,
             status=self.api_success_code,
@@ -8366,7 +8293,6 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         new_workspace_data = app_models.TestWorkspaceData.objects.latest("pk")
         self.assertEqual(new_workspace_data.workspace, new_workspace)
         self.assertEqual(new_workspace_data.study_name, "test study")
-        responses.assert_call_count(url, 1)
 
     def test_adapter_does_not_create_objects_if_workspace_data_form_invalid(self):
         """Posting invalid data to the workspace_data_form form does not create a workspace when using an adapter."""
@@ -8379,7 +8305,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         billing_project = factories.BillingProjectFactory.create(name="billing-project")
         workspace_name = "workspace"
         # Available workspaces API call.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.workspace_list_url,
             match=[
@@ -8391,7 +8317,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
             json=[self.get_api_json_response(billing_project.name, workspace_name)],
         )
         url = self.get_api_url(billing_project.name, workspace_name)
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             url,
             status=self.api_success_code,
@@ -8425,7 +8351,6 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIn("required", workspace_data_form.errors["study_name"][0])
         self.assertEqual(models.Workspace.objects.count(), 0)
         self.assertEqual(app_models.TestWorkspaceData.objects.count(), 0)
-        self.assertEqual(len(responses.calls), 2)
 
 
 class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
@@ -8644,7 +8569,7 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
             "name": "test-workspace",
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=self.api_success_code,
@@ -8674,7 +8599,6 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
             new_object.workspace_type,
             DefaultWorkspaceAdapter().get_type(),
         )
-        responses.assert_call_count(self.api_url, 1)
         # History is added.
         self.assertEqual(new_object.history.count(), 1)
         self.assertEqual(new_object.history.latest().history_type, "+")
@@ -8692,7 +8616,7 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
             "attributes": {},
             "authorizationDomain": [{"membersGroupName": auth_domain.name}],
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=self.api_success_code,
@@ -8722,7 +8646,6 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
         # Has an auth domain.
         self.assertEqual(new_object.authorization_domains.count(), 1)
         self.assertIn(auth_domain, new_object.authorization_domains.all())
-        responses.assert_call_count(self.api_url, 1)
         # History is added.
         self.assertEqual(new_object.history.count(), 1)
         self.assertEqual(new_object.history.latest().history_type, "+")
@@ -8744,7 +8667,7 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
                 {"membersGroupName": new_auth_domain.name},
             ],
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=self.api_success_code,
@@ -8775,7 +8698,6 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(new_object.authorization_domains.count(), 2)
         self.assertIn(auth_domain, new_object.authorization_domains.all())
         self.assertIn(new_auth_domain, new_object.authorization_domains.all())
-        responses.assert_call_count(self.api_url, 1)
 
     def test_creates_default_workspace_data(self):
         """Posting valid data to the form creates the default workspace data object."""
@@ -8787,7 +8709,7 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
             "name": "test-workspace",
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=self.api_success_code,
@@ -8826,7 +8748,7 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
             "name": "test-workspace",
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=self.api_success_code,
@@ -8864,7 +8786,7 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
             "name": "test-workspace",
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=self.api_success_code,
@@ -8889,7 +8811,6 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
         )
         new_object = models.Workspace.objects.latest("pk")
         self.assertRedirects(response, new_object.get_absolute_url())
-        responses.assert_call_count(self.api_url, 1)
 
     def test_cannot_create_duplicate_object(self):
         """Cannot create two workspaces with the same billing project and name."""
@@ -8930,7 +8851,7 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
             "name": "test-name-2",
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=self.api_success_code,
@@ -8959,7 +8880,6 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
         models.Workspace.objects.get(
             billing_project=billing_project, name="test-name-2"
         )
-        responses.assert_call_count(self.api_url, 1)
 
     def test_can_create_workspace_with_same_name_different_billing_project(self):
         """Can create a workspace with the same name in a different billing project."""
@@ -8974,7 +8894,7 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
             "name": "test-name",
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=self.api_success_code,
@@ -9003,7 +8923,6 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
         models.Workspace.objects.get(
             billing_project=billing_project_2, name=workspace_name
         )
-        responses.assert_call_count(self.api_url, 1)
 
     def test_invalid_input_name(self):
         """Posting invalid data to name field does not create an object."""
@@ -9104,7 +9023,6 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIn("required", form.errors["name"][0])
         self.assertEqual(models.Workspace.objects.count(), 1)
         self.assertIn(self.workspace_to_clone, models.Workspace.objects.all())
-        self.assertEqual(len(responses.calls), 0)
 
     def test_api_error_message(self):
         """Shows a method if an AnVIL API error occurs."""
@@ -9114,7 +9032,7 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
             "name": "test-workspace",
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=500,
@@ -9145,7 +9063,6 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertIn("AnVIL API Error: workspace create test error", str(messages[0]))
-        responses.assert_call_count(self.api_url, 1)
         # Make sure that no object is created.
         self.assertEqual(models.Workspace.objects.count(), 1)
         self.assertIn(self.workspace_to_clone, models.Workspace.objects.all())
@@ -9182,8 +9099,6 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
         # No object was created.
         self.assertEqual(models.Workspace.objects.count(), 1)
         self.assertIn(self.workspace_to_clone, models.Workspace.objects.all())
-        # No API calls made.
-        responses.assert_call_count(self.api_url, 0)
 
     def test_one_valid_one_invalid_auth_domain(self):
         billing_project = factories.BillingProjectFactory.create(
@@ -9217,8 +9132,6 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
         # No object was created.
         self.assertEqual(len(models.Workspace.objects.all()), 1)
         self.assertIn(self.workspace_to_clone, models.Workspace.objects.all())
-        # No API calls made.
-        responses.assert_call_count(self.api_url, 0)
 
     def test_auth_domain_does_not_exist_on_anvil(self):
         """No workspace is displayed if the auth domain group doesn't exist on AnVIL."""
@@ -9234,7 +9147,7 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
                 {"membersGroupName": auth_domain.name},
             ],
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=400,
@@ -9272,7 +9185,6 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
         # Did not create any new Workspaces.
         self.assertEqual(models.Workspace.objects.count(), 1)
         self.assertIn(self.workspace_to_clone, models.Workspace.objects.all())
-        responses.assert_call_count(self.api_url, 1)
 
     def test_not_admin_of_auth_domain_on_anvil(self):
         """No workspace is displayed if we are not the admins of the auth domain on AnVIL."""
@@ -9288,7 +9200,7 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
                 {"membersGroupName": auth_domain.name},
             ],
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=400,
@@ -9326,7 +9238,6 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
         # Did not create any new Workspaces.
         self.assertEqual(models.Workspace.objects.count(), 1)
         self.assertIn(self.workspace_to_clone, models.Workspace.objects.all())
-        responses.assert_call_count(self.api_url, 1)
 
     def test_not_user_of_billing_project(self):
         """Posting a billing project where we are not users does not create an object."""
@@ -9398,7 +9309,7 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
             "name": "test-workspace",
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=self.api_success_code,
@@ -9435,7 +9346,6 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
         new_workspace_data = app_models.TestWorkspaceData.objects.latest("pk")
         self.assertEqual(new_workspace_data.workspace, new_workspace)
         self.assertEqual(new_workspace_data.study_name, "test study")
-        responses.assert_call_count(self.api_url, 1)
 
     def test_adapter_does_not_create_objects_if_workspace_data_form_invalid(self):
         """Posting invalid data to the workspace_data_form form does not create a workspace when using an adapter."""
@@ -9446,18 +9356,6 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
         workspace_adapter_registry.register(TestWorkspaceAdapter)
         self.workspace_type = "test"
         billing_project = factories.BillingProjectFactory.create()
-        url = self.api_client.firecloud_entry_point + "/api/workspaces"
-        json_data = {
-            "namespace": "test-billing-project",
-            "name": "test-workspace",
-            "attributes": {},
-        }
-        responses.add(
-            responses.POST,
-            url,
-            status=self.api_success_code,
-            match=[responses.matchers.json_params_matcher(json_data)],
-        )
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(
@@ -9492,7 +9390,6 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(models.Workspace.objects.count(), 1)
         self.assertIn(self.workspace_to_clone, models.Workspace.objects.all())
         self.assertEqual(app_models.TestWorkspaceData.objects.count(), 0)
-        self.assertEqual(len(responses.calls), 0)
 
     def test_workspace_to_clone_does_not_exist_on_anvil(self):
         """Shows a method if an AnVIL API 404 error occurs."""
@@ -9502,7 +9399,7 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
             "name": "test-workspace",
             "attributes": {},
         }
-        responses.add(
+        self.response_mock.add(
             responses.POST,
             self.api_url,
             status=404,
@@ -9533,7 +9430,6 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertIn("AnVIL API Error: workspace create test error", str(messages[0]))
-        responses.assert_call_count(self.api_url, 1)
         # Make sure that no object is created.
         self.assertEqual(models.Workspace.objects.count(), 1)
         self.assertIn(self.workspace_to_clone, models.Workspace.objects.all())
@@ -10119,14 +10015,13 @@ class WorkspaceDeleteTest(AnVILAPIMockTestMixin, TestCase):
             billing_project=billing_project, name="test-workspace"
         )
         api_url = self.get_api_url(object.billing_project.name, object.name)
-        responses.add(responses.DELETE, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.DELETE, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(object.billing_project.name, object.name), {"submit": ""}
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(models.Workspace.objects.count(), 0)
-        responses.assert_call_count(api_url, 1)
         # History is added.
         self.assertEqual(object.history.count(), 2)
         self.assertEqual(object.history.latest().history_type, "-")
@@ -10140,7 +10035,7 @@ class WorkspaceDeleteTest(AnVILAPIMockTestMixin, TestCase):
             billing_project=billing_project, name="test-workspace"
         )
         api_url = self.get_api_url(object.billing_project.name, object.name)
-        responses.add(responses.DELETE, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.DELETE, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(object.billing_project.name, object.name),
@@ -10157,7 +10052,7 @@ class WorkspaceDeleteTest(AnVILAPIMockTestMixin, TestCase):
         object = factories.WorkspaceFactory.create()
         other_object = factories.WorkspaceFactory.create()
         api_url = self.get_api_url(object.billing_project.name, object.name)
-        responses.add(responses.DELETE, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.DELETE, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(object.billing_project.name, object.name), {"submit": ""}
@@ -10168,7 +10063,6 @@ class WorkspaceDeleteTest(AnVILAPIMockTestMixin, TestCase):
             models.Workspace.objects.all(),
             models.Workspace.objects.filter(pk=other_object.pk),
         )
-        responses.assert_call_count(api_url, 1)
 
     def test_can_delete_workspace_with_auth_domain(self):
         """A workspace can be deleted if it has an auth domain, and the auth domain group is not deleted."""
@@ -10184,7 +10078,7 @@ class WorkspaceDeleteTest(AnVILAPIMockTestMixin, TestCase):
         )
         # object.authorization_domains.add(auth_domain)
         api_url = self.get_api_url(object.billing_project.name, object.name)
-        responses.add(responses.DELETE, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.DELETE, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(object.billing_project.name, object.name), {"submit": ""}
@@ -10195,7 +10089,6 @@ class WorkspaceDeleteTest(AnVILAPIMockTestMixin, TestCase):
         # The auth domain group still exists.
         self.assertEqual(models.ManagedGroup.objects.count(), 1)
         models.ManagedGroup.objects.get(pk=auth_domain.pk)
-        responses.assert_call_count(api_url, 1)
         # History is added for workspace.
         self.assertEqual(object.history.count(), 2)
         self.assertEqual(object.history.latest().history_type, "-")
@@ -10214,7 +10107,7 @@ class WorkspaceDeleteTest(AnVILAPIMockTestMixin, TestCase):
         group = factories.ManagedGroupFactory.create(name="test-group")
         factories.WorkspaceGroupSharingFactory.create(workspace=object, group=group)
         api_url = self.get_api_url(object.billing_project.name, object.name)
-        responses.add(responses.DELETE, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.DELETE, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(object.billing_project.name, object.name), {"submit": ""}
@@ -10225,7 +10118,6 @@ class WorkspaceDeleteTest(AnVILAPIMockTestMixin, TestCase):
         # The group still exists.
         self.assertEqual(models.ManagedGroup.objects.count(), 1)
         models.ManagedGroup.objects.get(pk=group.pk)
-        responses.assert_call_count(api_url, 1)
         # History is added for workspace.
         self.assertEqual(object.history.count(), 2)
         self.assertEqual(object.history.latest().history_type, "-")
@@ -10240,7 +10132,7 @@ class WorkspaceDeleteTest(AnVILAPIMockTestMixin, TestCase):
         object = factories.WorkspaceFactory.create()
         # Need to use the client instead of RequestFactory to check redirection url.
         api_url = self.get_api_url(object.billing_project.name, object.name)
-        responses.add(responses.DELETE, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.DELETE, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(object.billing_project.name, object.name), {"submit": ""}
@@ -10253,7 +10145,6 @@ class WorkspaceDeleteTest(AnVILAPIMockTestMixin, TestCase):
                 args=[DefaultWorkspaceAdapter().get_type()],
             ),
         )
-        responses.assert_call_count(api_url, 1)
 
     def test_adapter_success_url(self):
         """Redirects to the expected page."""
@@ -10264,7 +10155,7 @@ class WorkspaceDeleteTest(AnVILAPIMockTestMixin, TestCase):
         )
         # Need to use the client instead of RequestFactory to check redirection url.
         api_url = self.get_api_url(object.billing_project.name, object.name)
-        responses.add(responses.DELETE, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.DELETE, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(object.billing_project.name, object.name), {"submit": ""}
@@ -10277,14 +10168,13 @@ class WorkspaceDeleteTest(AnVILAPIMockTestMixin, TestCase):
                 args=[TestWorkspaceAdapter().get_type()],
             ),
         )
-        responses.assert_call_count(api_url, 1)
 
     def test_api_error(self):
         """Shows a message if an AnVIL API error occurs."""
         # Need a client to check messages.
         object = factories.WorkspaceFactory.create()
         api_url = self.get_api_url(object.billing_project.name, object.name)
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             api_url,
             status=500,
@@ -10299,7 +10189,6 @@ class WorkspaceDeleteTest(AnVILAPIMockTestMixin, TestCase):
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertIn("AnVIL API Error: workspace delete test error", str(messages[0]))
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object still exists.
         self.assertEqual(models.Workspace.objects.count(), 1)
 
@@ -10534,7 +10423,7 @@ class WorkspaceAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_status_code_with_user_permission(self):
         """Returns successful response code."""
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -10557,7 +10446,7 @@ class WorkspaceAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_template(self):
         """Template loads successfully."""
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -10570,7 +10459,7 @@ class WorkspaceAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_audit_verified(self):
         """audit_verified is in the context data."""
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -10585,7 +10474,7 @@ class WorkspaceAuditTest(AnVILAPIMockTestMixin, TestCase):
         """audit_verified with one verified record."""
         workspace = factories.WorkspaceFactory.create()
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -10599,7 +10488,7 @@ class WorkspaceAuditTest(AnVILAPIMockTestMixin, TestCase):
         workspace_acl_url = self.get_api_workspace_acl_url(
             workspace.billing_project.name, workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             workspace_acl_url,
             status=200,
@@ -10613,7 +10502,7 @@ class WorkspaceAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_audit_errors(self):
         """audit_errors is in the context data."""
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -10628,7 +10517,7 @@ class WorkspaceAuditTest(AnVILAPIMockTestMixin, TestCase):
         """audit_errors with one error record."""
         workspace = factories.WorkspaceFactory.create()
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -10647,7 +10536,7 @@ class WorkspaceAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_audit_not_in_app(self):
         """audit_not_in_app is in the context data."""
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -10661,7 +10550,7 @@ class WorkspaceAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_audit_not_in_app_one_record(self):
         """audit_not_in_app with one record not in app."""
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -10675,7 +10564,7 @@ class WorkspaceAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_audit_ok_is_ok(self):
         """audit_ok when audit_results.ok() is True."""
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -10690,7 +10579,7 @@ class WorkspaceAuditTest(AnVILAPIMockTestMixin, TestCase):
         """audit_ok when audit_results.ok() is False."""
         workspace = factories.WorkspaceFactory.create()
         api_url = self.get_api_url()
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             api_url,
             status=200,
@@ -10776,7 +10665,7 @@ class WorkspaceSharingAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_status_code_with_user_permission(self):
         """Returns successful response code."""
         # Group membership API call.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -10800,7 +10689,7 @@ class WorkspaceSharingAuditTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_template(self):
         """Template loads successfully."""
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -10815,7 +10704,7 @@ class WorkspaceSharingAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_audit_verified(self):
         """audit_verified is in the context data."""
         # Group membership API call.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -10833,7 +10722,7 @@ class WorkspaceSharingAuditTest(AnVILAPIMockTestMixin, TestCase):
         access = factories.WorkspaceGroupSharingFactory.create(workspace=self.workspace)
         self.update_api_response(access.group.get_email(), "READER")
         # Group membership API call.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -10849,7 +10738,7 @@ class WorkspaceSharingAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_audit_errors(self):
         """audit_errors is in the context data."""
         # Group membership API call.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -10868,7 +10757,7 @@ class WorkspaceSharingAuditTest(AnVILAPIMockTestMixin, TestCase):
         # Different access recorded.
         self.update_api_response(access.group.get_email(), "WRITER")
         # Group membership API call.
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -10883,7 +10772,7 @@ class WorkspaceSharingAuditTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_audit_not_in_app(self):
         """audit_not_in_app is in the context data."""
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -10901,7 +10790,7 @@ class WorkspaceSharingAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_audit_not_in_app_one_record(self):
         """audit_not_in_app with one record not in app."""
         self.update_api_response("foo@bar.com", "READER")
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -10916,7 +10805,7 @@ class WorkspaceSharingAuditTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_audit_ok_is_ok(self):
         """audit_ok when audit_results.ok() is True."""
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -10934,7 +10823,7 @@ class WorkspaceSharingAuditTest(AnVILAPIMockTestMixin, TestCase):
     def test_audit_ok_is_not_ok(self):
         """audit_ok when audit_results.ok() is False."""
         self.update_api_response("foo@bar.com", "READER")
-        responses.add(
+        self.response_mock.add(
             responses.GET,
             self.api_url,
             status=200,
@@ -11184,7 +11073,7 @@ class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         parent_group = factories.ManagedGroupFactory.create(name="group-1")
         child_group = factories.ManagedGroupFactory.create(name="group-2")
         api_url = self.get_api_url(parent_group.name, "member", child_group.get_email())
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(),
@@ -11198,7 +11087,6 @@ class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         new_object = models.GroupGroupMembership.objects.latest("pk")
         self.assertIsInstance(new_object, models.GroupGroupMembership)
         self.assertEqual(new_object.role, models.GroupGroupMembership.MEMBER)
-        responses.assert_call_count(api_url, 1)
         # History is added.
         self.assertEqual(new_object.history.count(), 1)
         self.assertEqual(new_object.history.latest().history_type, "+")
@@ -11208,7 +11096,7 @@ class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         parent_group = factories.ManagedGroupFactory.create(name="group-1")
         child_group = factories.ManagedGroupFactory.create(name="group-2")
         api_url = self.get_api_url(parent_group.name, "member", child_group.get_email())
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(),
@@ -11229,7 +11117,7 @@ class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         parent_group = factories.ManagedGroupFactory.create(name="group-1")
         child_group = factories.ManagedGroupFactory.create(name="group-2")
         api_url = self.get_api_url(parent_group.name, "admin", child_group.get_email())
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(),
@@ -11243,7 +11131,6 @@ class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         new_object = models.GroupGroupMembership.objects.latest("pk")
         self.assertIsInstance(new_object, models.GroupGroupMembership)
         self.assertEqual(new_object.role, models.GroupGroupMembership.ADMIN)
-        responses.assert_call_count(api_url, 1)
 
     def test_redirects_to_list(self):
         """After successfully creating an object, view redirects to the model's list view."""
@@ -11251,7 +11138,7 @@ class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         parent_group = factories.ManagedGroupFactory.create(name="group-1")
         child_group = factories.ManagedGroupFactory.create(name="group-2")
         api_url = self.get_api_url(parent_group.name, "member", child_group.get_email())
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(),
@@ -11264,7 +11151,6 @@ class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         self.assertRedirects(
             response, reverse("anvil_consortium_manager:group_group_membership:list")
         )
-        responses.assert_call_count(api_url, 1)
 
     def test_cannot_create_duplicate_object_with_same_role(self):
         """Cannot create a second GroupGroupMembership object for the same parent and child with the same role."""
@@ -11324,7 +11210,7 @@ class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
             parent_group=parent, child_group=group_1
         )
         api_url = self.get_api_url(parent.name, "member", group_2.get_email())
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(),
@@ -11336,7 +11222,6 @@ class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(models.GroupGroupMembership.objects.count(), 2)
-        responses.assert_call_count(api_url, 1)
 
     def test_can_add_a_child_group_to_two_parents(self):
         group_1 = factories.ManagedGroupFactory.create(name="test-group-1")
@@ -11346,7 +11231,7 @@ class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
             parent_group=group_1, child_group=child
         )
         api_url = self.get_api_url(group_2.name, "member", child.get_email())
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(),
@@ -11358,7 +11243,6 @@ class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(models.GroupGroupMembership.objects.count(), 2)
-        responses.assert_call_count(api_url, 1)
 
     def test_invalid_input_child(self):
         """Posting invalid data to child_group field does not create an object."""
@@ -11570,7 +11454,7 @@ class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         parent_group = factories.ManagedGroupFactory.create()
         child_group = factories.ManagedGroupFactory.create()
         api_url = self.get_api_url(parent_group.name, "member", child_group.get_email())
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=500,
@@ -11593,7 +11477,6 @@ class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: group group membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupGroupMembership.objects.count(), 0)
 
@@ -11601,7 +11484,7 @@ class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         parent_group = factories.ManagedGroupFactory.create()
         child_group = factories.ManagedGroupFactory.create()
         api_url = self.get_api_url(parent_group.name, "member", child_group.get_email())
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=403,
@@ -11624,7 +11507,6 @@ class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupGroupMembership.objects.count(), 0)
 
@@ -11632,7 +11514,7 @@ class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         parent_group = factories.ManagedGroupFactory.create()
         child_group = factories.ManagedGroupFactory.create()
         api_url = self.get_api_url(parent_group.name, "member", child_group.get_email())
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=404,
@@ -11655,7 +11537,6 @@ class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupGroupMembership.objects.count(), 0)
 
@@ -11663,7 +11544,7 @@ class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         parent_group = factories.ManagedGroupFactory.create()
         child_group = factories.ManagedGroupFactory.create()
         api_url = self.get_api_url(parent_group.name, "member", child_group.get_email())
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=404,
@@ -11686,7 +11567,6 @@ class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupGroupMembership.objects.count(), 0)
 
@@ -11694,7 +11574,7 @@ class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         parent_group = factories.ManagedGroupFactory.create()
         child_group = factories.ManagedGroupFactory.create()
         api_url = self.get_api_url(parent_group.name, "member", child_group.get_email())
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=400,
@@ -11717,7 +11597,6 @@ class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupGroupMembership.objects.count(), 0)
 
@@ -11831,7 +11710,7 @@ class GroupGroupMembershipCreateByParentTest(AnVILAPIMockTestMixin, TestCase):
     def test_can_create_an_object_member(self):
         """Posting valid data to the form creates an object."""
         api_url = self.get_api_url("member")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.parent_group.name),
@@ -11847,7 +11726,6 @@ class GroupGroupMembershipCreateByParentTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(new_object.role, models.GroupGroupMembership.MEMBER)
         self.assertEqual(new_object.parent_group, self.parent_group)
         self.assertEqual(new_object.child_group, self.child_group)
-        responses.assert_call_count(api_url, 1)
         # History is added.
         self.assertEqual(new_object.history.count(), 1)
         self.assertEqual(new_object.history.latest().history_type, "+")
@@ -11855,7 +11733,7 @@ class GroupGroupMembershipCreateByParentTest(AnVILAPIMockTestMixin, TestCase):
     def test_success_message(self):
         """Response includes a success message if successful."""
         api_url = self.get_api_url("member")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.parent_group.name),
@@ -11876,7 +11754,7 @@ class GroupGroupMembershipCreateByParentTest(AnVILAPIMockTestMixin, TestCase):
     def test_can_create_an_object_admin(self):
         """Posting valid data to the form creates an object."""
         api_url = self.get_api_url("admin")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.parent_group.name),
@@ -11890,12 +11768,11 @@ class GroupGroupMembershipCreateByParentTest(AnVILAPIMockTestMixin, TestCase):
         new_object = models.GroupGroupMembership.objects.latest("pk")
         self.assertIsInstance(new_object, models.GroupGroupMembership)
         self.assertEqual(new_object.role, models.GroupGroupMembership.ADMIN)
-        responses.assert_call_count(api_url, 1)
 
     def test_redirects_to_detail(self):
         """After successfully creating an object, view redirects to the object's detail page."""
         api_url = self.get_api_url("member")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.parent_group.name),
@@ -11909,7 +11786,6 @@ class GroupGroupMembershipCreateByParentTest(AnVILAPIMockTestMixin, TestCase):
             response,
             models.GroupGroupMembership.objects.latest("pk").get_absolute_url(),
         )
-        responses.assert_call_count(api_url, 1)
 
     def test_cannot_create_duplicate_object(self):
         """Cannot create a second GroupGroupMembership object for the same parent and child with the same role."""
@@ -12141,7 +12017,7 @@ class GroupGroupMembershipCreateByParentTest(AnVILAPIMockTestMixin, TestCase):
     def test_api_error_500(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=500,
@@ -12164,14 +12040,13 @@ class GroupGroupMembershipCreateByParentTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: group group membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupGroupMembership.objects.count(), 0)
 
     def test_api_error_400(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=400,
@@ -12194,14 +12069,13 @@ class GroupGroupMembershipCreateByParentTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: group group membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupGroupMembership.objects.count(), 0)
 
     def test_api_error_403(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=403,
@@ -12224,14 +12098,13 @@ class GroupGroupMembershipCreateByParentTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: group group membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupGroupMembership.objects.count(), 0)
 
     def test_api_error_404(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=404,
@@ -12254,7 +12127,6 @@ class GroupGroupMembershipCreateByParentTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: group group membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupGroupMembership.objects.count(), 0)
 
@@ -12368,7 +12240,7 @@ class GroupGroupMembershipCreateByChildTest(AnVILAPIMockTestMixin, TestCase):
     def test_can_create_an_object_member(self):
         """Posting valid data to the form creates an object."""
         api_url = self.get_api_url("member")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.child_group.name),
@@ -12384,7 +12256,6 @@ class GroupGroupMembershipCreateByChildTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(new_object.role, models.GroupGroupMembership.MEMBER)
         self.assertEqual(new_object.parent_group, self.parent_group)
         self.assertEqual(new_object.child_group, self.child_group)
-        responses.assert_call_count(api_url, 1)
         # History is added.
         self.assertEqual(new_object.history.count(), 1)
         self.assertEqual(new_object.history.latest().history_type, "+")
@@ -12392,7 +12263,7 @@ class GroupGroupMembershipCreateByChildTest(AnVILAPIMockTestMixin, TestCase):
     def test_success_message(self):
         """Response includes a success message if successful."""
         api_url = self.get_api_url("member")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.child_group.name),
@@ -12413,7 +12284,7 @@ class GroupGroupMembershipCreateByChildTest(AnVILAPIMockTestMixin, TestCase):
     def test_can_create_an_object_admin(self):
         """Posting valid data to the form creates an object."""
         api_url = self.get_api_url("admin")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.child_group.name),
@@ -12427,12 +12298,11 @@ class GroupGroupMembershipCreateByChildTest(AnVILAPIMockTestMixin, TestCase):
         new_object = models.GroupGroupMembership.objects.latest("pk")
         self.assertIsInstance(new_object, models.GroupGroupMembership)
         self.assertEqual(new_object.role, models.GroupGroupMembership.ADMIN)
-        responses.assert_call_count(api_url, 1)
 
     def test_redirects_to_detail(self):
         """After successfully creating an object, view redirects to the object's detail page."""
         api_url = self.get_api_url("member")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.child_group.name),
@@ -12446,7 +12316,6 @@ class GroupGroupMembershipCreateByChildTest(AnVILAPIMockTestMixin, TestCase):
             response,
             models.GroupGroupMembership.objects.latest("pk").get_absolute_url(),
         )
-        responses.assert_call_count(api_url, 1)
 
     def test_cannot_create_duplicate_object(self):
         """Cannot create a second GroupGroupMembership object for the same parent and child with the same role."""
@@ -12637,7 +12506,7 @@ class GroupGroupMembershipCreateByChildTest(AnVILAPIMockTestMixin, TestCase):
     def test_api_error_500(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=500,
@@ -12660,14 +12529,13 @@ class GroupGroupMembershipCreateByChildTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: group group membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupGroupMembership.objects.count(), 0)
 
     def test_api_error_400(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=400,
@@ -12690,14 +12558,13 @@ class GroupGroupMembershipCreateByChildTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: group group membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupGroupMembership.objects.count(), 0)
 
     def test_api_error_403(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=403,
@@ -12720,14 +12587,13 @@ class GroupGroupMembershipCreateByChildTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: group group membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupGroupMembership.objects.count(), 0)
 
     def test_api_error_404(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=404,
@@ -12750,7 +12616,6 @@ class GroupGroupMembershipCreateByChildTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: group group membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupGroupMembership.objects.count(), 0)
 
@@ -12888,7 +12753,7 @@ class GroupGroupMembershipCreateByParentChildTest(AnVILAPIMockTestMixin, TestCas
     def test_can_create_an_object_member(self):
         """Posting valid data to the form creates an object."""
         api_url = self.get_api_url("member")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         self.client.force_login(self.user)
         response = self.client.post(
@@ -12905,7 +12770,6 @@ class GroupGroupMembershipCreateByParentChildTest(AnVILAPIMockTestMixin, TestCas
         self.assertEqual(new_object.role, models.GroupGroupMembership.MEMBER)
         self.assertEqual(new_object.parent_group, self.parent_group)
         self.assertEqual(new_object.child_group, self.child_group)
-        responses.assert_call_count(api_url, 1)
         # History is added.
         self.assertEqual(new_object.history.count(), 1)
         self.assertEqual(new_object.history.latest().history_type, "+")
@@ -12913,7 +12777,7 @@ class GroupGroupMembershipCreateByParentChildTest(AnVILAPIMockTestMixin, TestCas
     def test_success_message(self):
         """Response includes a success message if successful."""
         api_url = self.get_api_url("member")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.parent_group.name, self.child_group.name),
@@ -12934,7 +12798,7 @@ class GroupGroupMembershipCreateByParentChildTest(AnVILAPIMockTestMixin, TestCas
     def test_can_create_an_object_admin(self):
         """Posting valid data to the form creates an object."""
         api_url = self.get_api_url("admin")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.parent_group.name, self.child_group.name),
@@ -12948,12 +12812,11 @@ class GroupGroupMembershipCreateByParentChildTest(AnVILAPIMockTestMixin, TestCas
         new_object = models.GroupGroupMembership.objects.latest("pk")
         self.assertIsInstance(new_object, models.GroupGroupMembership)
         self.assertEqual(new_object.role, models.GroupGroupMembership.ADMIN)
-        responses.assert_call_count(api_url, 1)
 
     def test_redirects_to_detail(self):
         """After successfully creating an object, view redirects to the object's detail page."""
         api_url = self.get_api_url("member")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.parent_group.name, self.child_group.name),
@@ -12967,7 +12830,6 @@ class GroupGroupMembershipCreateByParentChildTest(AnVILAPIMockTestMixin, TestCas
             response,
             models.GroupGroupMembership.objects.latest("pk").get_absolute_url(),
         )
-        responses.assert_call_count(api_url, 1)
 
     def test_get_duplicate_object_redirect_cannot_create_duplicate_object(self):
         """Cannot create a second GroupGroupMembership object for the same parent and child with the same role."""
@@ -13267,7 +13129,7 @@ class GroupGroupMembershipCreateByParentChildTest(AnVILAPIMockTestMixin, TestCas
     def test_api_error_500(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=500,
@@ -13290,14 +13152,13 @@ class GroupGroupMembershipCreateByParentChildTest(AnVILAPIMockTestMixin, TestCas
             "AnVIL API Error: group group membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupGroupMembership.objects.count(), 0)
 
     def test_api_error_400(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=400,
@@ -13320,14 +13181,13 @@ class GroupGroupMembershipCreateByParentChildTest(AnVILAPIMockTestMixin, TestCas
             "AnVIL API Error: group group membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupGroupMembership.objects.count(), 0)
 
     def test_api_error_403(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=403,
@@ -13350,14 +13210,13 @@ class GroupGroupMembershipCreateByParentChildTest(AnVILAPIMockTestMixin, TestCas
             "AnVIL API Error: group group membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupGroupMembership.objects.count(), 0)
 
     def test_api_error_404(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=404,
@@ -13380,7 +13239,6 @@ class GroupGroupMembershipCreateByParentChildTest(AnVILAPIMockTestMixin, TestCas
             "AnVIL API Error: group group membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupGroupMembership.objects.count(), 0)
 
@@ -13572,14 +13430,13 @@ class GroupGroupMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             obj.parent_group.name, obj.role.lower(), obj.child_group.get_email()
         )
-        responses.add(responses.DELETE, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.DELETE, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(obj.parent_group.name, obj.child_group.name), {"submit": ""}
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(models.GroupGroupMembership.objects.count(), 0)
-        responses.assert_call_count(api_url, 1)
         # History is added.
         self.assertEqual(obj.history.count(), 2)
         self.assertEqual(obj.history.latest().history_type, "-")
@@ -13592,7 +13449,7 @@ class GroupGroupMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             obj.parent_group.name, obj.role.lower(), obj.child_group.get_email()
         )
-        responses.add(responses.DELETE, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.DELETE, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(obj.parent_group.name, obj.child_group.name),
@@ -13611,7 +13468,7 @@ class GroupGroupMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             obj.parent_group.name, obj.role.lower(), obj.child_group.get_email()
         )
-        responses.add(responses.DELETE, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.DELETE, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(obj.parent_group.name, obj.child_group.name), {"submit": ""}
@@ -13622,7 +13479,6 @@ class GroupGroupMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
             models.GroupGroupMembership.objects.all(),
             models.GroupGroupMembership.objects.filter(pk=other_object.pk),
         )
-        responses.assert_call_count(api_url, 1)
 
     def test_success_url(self):
         """Redirects to the expected page."""
@@ -13631,7 +13487,7 @@ class GroupGroupMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             obj.parent_group.name, obj.role.lower(), obj.child_group.get_email()
         )
-        responses.add(responses.DELETE, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.DELETE, api_url, status=self.api_success_code)
         # Need to use the client instead of RequestFactory to check redirection url.
         self.client.force_login(self.user)
         response = self.client.post(
@@ -13639,7 +13495,6 @@ class GroupGroupMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
         )
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, parent_group.get_absolute_url())
-        responses.assert_call_count(api_url, 1)
 
     def test_api_error(self):
         """Shows a message if an AnVIL API error occurs."""
@@ -13648,7 +13503,7 @@ class GroupGroupMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             obj.parent_group.name, obj.role.lower(), obj.child_group.get_email()
         )
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             api_url,
             status=500,
@@ -13666,7 +13521,6 @@ class GroupGroupMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: group group membership delete test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object still exists.
         self.assertEqual(models.GroupGroupMembership.objects.count(), 1)
 
@@ -13723,7 +13577,7 @@ class GroupGroupMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             obj.parent_group.name, obj.role.lower(), obj.child_group.get_email()
         )
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             api_url,
             status=400,
@@ -13741,7 +13595,6 @@ class GroupGroupMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: group group membership delete test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object still exists.
         self.assertEqual(models.GroupGroupMembership.objects.count(), 1)
 
@@ -13750,7 +13603,7 @@ class GroupGroupMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             obj.parent_group.name, obj.role.lower(), obj.child_group.get_email()
         )
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             api_url,
             status=403,
@@ -13768,7 +13621,6 @@ class GroupGroupMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: group group membership delete test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object still exists.
         self.assertEqual(models.GroupGroupMembership.objects.count(), 1)
 
@@ -13777,7 +13629,7 @@ class GroupGroupMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             obj.parent_group.name, obj.role.lower(), obj.child_group.get_email()
         )
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             api_url,
             status=404,
@@ -13795,7 +13647,6 @@ class GroupGroupMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: group group membership delete test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object still exists.
         self.assertEqual(models.GroupGroupMembership.objects.count(), 1)
 
@@ -13804,7 +13655,7 @@ class GroupGroupMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             obj.parent_group.name, obj.role.lower(), obj.child_group.get_email()
         )
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             api_url,
             status=500,
@@ -13822,7 +13673,6 @@ class GroupGroupMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: group group membership delete test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object still exists.
         self.assertEqual(models.GroupGroupMembership.objects.count(), 1)
 
@@ -14034,7 +13884,7 @@ class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         group = factories.ManagedGroupFactory.create(name="test-group")
         account = factories.AccountFactory.create(email="email@example.com")
         api_url = self.get_api_url(group.name, "member", account.email)
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(),
@@ -14048,7 +13898,6 @@ class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         new_object = models.GroupAccountMembership.objects.latest("pk")
         self.assertIsInstance(new_object, models.GroupAccountMembership)
         self.assertEqual(new_object.role, models.GroupAccountMembership.MEMBER)
-        responses.assert_call_count(api_url, 1)
         # History is added.
         self.assertEqual(new_object.history.count(), 1)
         self.assertEqual(new_object.history.latest().history_type, "+")
@@ -14058,7 +13907,7 @@ class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         group = factories.ManagedGroupFactory.create(name="test-group")
         account = factories.AccountFactory.create(email="email@example.com")
         api_url = self.get_api_url(group.name, "member", account.email)
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(),
@@ -14081,7 +13930,7 @@ class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         group = factories.ManagedGroupFactory.create(name="test-group")
         account = factories.AccountFactory.create(email="email@example.com")
         api_url = self.get_api_url(group.name, "admin", account.email)
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(),
@@ -14095,7 +13944,6 @@ class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         new_object = models.GroupAccountMembership.objects.latest("pk")
         self.assertIsInstance(new_object, models.GroupAccountMembership)
         self.assertEqual(new_object.role, models.GroupAccountMembership.ADMIN)
-        responses.assert_call_count(api_url, 1)
 
     def test_redirects_to_list(self):
         """After successfully creating an object, view redirects to the model's list view."""
@@ -14103,7 +13951,7 @@ class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         group = factories.ManagedGroupFactory.create()
         account = factories.AccountFactory.create()
         api_url = self.get_api_url(group.name, "member", account.email)
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(),
@@ -14116,7 +13964,6 @@ class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         self.assertRedirects(
             response, reverse("anvil_consortium_manager:group_account_membership:list")
         )
-        responses.assert_call_count(api_url, 1)
 
     def test_cannot_create_duplicate_object_with_same_role(self):
         """Cannot create a second GroupAccountMembership object for the same account and group with the same role."""
@@ -14174,7 +14021,7 @@ class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         account = factories.AccountFactory.create()
         factories.GroupAccountMembershipFactory.create(group=group_1, account=account)
         api_url = self.get_api_url(group_2.name, "member", account.email)
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(),
@@ -14186,7 +14033,6 @@ class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(models.GroupAccountMembership.objects.count(), 2)
-        responses.assert_call_count(api_url, 1)
 
     def test_can_add_two_accounts_to_one_group(self):
         group = factories.ManagedGroupFactory.create()
@@ -14194,7 +14040,7 @@ class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         account_2 = factories.AccountFactory.create(email="test_2@example.com")
         factories.GroupAccountMembershipFactory.create(group=group, account=account_1)
         api_url = self.get_api_url(group.name, "member", account_2.email)
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(),
@@ -14206,7 +14052,6 @@ class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(models.GroupAccountMembership.objects.count(), 2)
-        responses.assert_call_count(api_url, 1)
 
     def test_invalid_input_account(self):
         """Posting invalid data to account field does not create an object."""
@@ -14349,7 +14194,7 @@ class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         group = factories.ManagedGroupFactory.create()
         account = factories.AccountFactory.create()
         api_url = self.get_api_url(group.name, "member", account.email)
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=500,
@@ -14372,7 +14217,6 @@ class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: other error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
 
@@ -14415,7 +14259,7 @@ class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         group = factories.ManagedGroupFactory.create()
         account = factories.AccountFactory.create()
         api_url = self.get_api_url(group.name, "member", account.email)
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=403,
@@ -14438,7 +14282,6 @@ class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: other error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
 
@@ -14446,7 +14289,7 @@ class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         group = factories.ManagedGroupFactory.create()
         account = factories.AccountFactory.create()
         api_url = self.get_api_url(group.name, "member", account.email)
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=404,
@@ -14469,7 +14312,6 @@ class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: other error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
 
@@ -14477,7 +14319,7 @@ class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         group = factories.ManagedGroupFactory.create()
         account = factories.AccountFactory.create()
         api_url = self.get_api_url(group.name, "member", account.email)
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=404,
@@ -14500,7 +14342,6 @@ class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: other error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
 
@@ -14508,7 +14349,7 @@ class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         group = factories.ManagedGroupFactory.create()
         account = factories.AccountFactory.create()
         api_url = self.get_api_url(group.name, "member", account.email)
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=400,
@@ -14531,7 +14372,6 @@ class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: other error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
 
@@ -14650,7 +14490,7 @@ class GroupAccountMembershipCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
     def test_can_create_an_object_member(self):
         """Posting valid data to the form creates an object."""
         api_url = self.get_api_url("member")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.group.name),
@@ -14666,12 +14506,11 @@ class GroupAccountMembershipCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(new_object.role, models.GroupAccountMembership.MEMBER)
         self.assertEqual(new_object.group, self.group)
         self.assertEqual(new_object.account, self.account)
-        responses.assert_call_count(api_url, 1)
 
     def test_success_message(self):
         """Response includes a success message if successful."""
         api_url = self.get_api_url("member")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.group.name),
@@ -14692,7 +14531,7 @@ class GroupAccountMembershipCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
     def test_can_create_an_object_admin(self):
         """Posting valid data to the form creates an object."""
         api_url = self.get_api_url("admin")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.group.name),
@@ -14708,13 +14547,12 @@ class GroupAccountMembershipCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(new_object.role, models.GroupAccountMembership.ADMIN)
         self.assertEqual(new_object.group, self.group)
         self.assertEqual(new_object.account, self.account)
-        responses.assert_call_count(api_url, 1)
 
     def test_success_redirect(self):
         """After successfully creating an object, view redirects to the model's list view."""
         # This needs to use the client because the RequestFactory doesn't handle redirects.
         api_url = self.get_api_url("member")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.group.name),
@@ -14726,7 +14564,6 @@ class GroupAccountMembershipCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
         )
         obj = models.GroupAccountMembership.objects.latest("pk")
         self.assertRedirects(response, obj.get_absolute_url())
-        responses.assert_call_count(api_url, 1)
 
     def test_cannot_create_duplicate_object_with_different_role(self):
         """Cannot create a second GroupAccountMembership object for the same account and group with a different role."""
@@ -14919,7 +14756,7 @@ class GroupAccountMembershipCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
     def test_api_error_500(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=500,
@@ -14942,14 +14779,13 @@ class GroupAccountMembershipCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: group account membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
 
     def test_api_error_400(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=400,
@@ -14972,14 +14808,13 @@ class GroupAccountMembershipCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: group account membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
 
     def test_api_error_403(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=403,
@@ -15002,14 +14837,13 @@ class GroupAccountMembershipCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: group account membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
 
     def test_api_error_404(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=404,
@@ -15032,7 +14866,6 @@ class GroupAccountMembershipCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: group account membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
 
@@ -15173,7 +15006,7 @@ class GroupAccountMembershipCreateByAccountTest(AnVILAPIMockTestMixin, TestCase)
     def test_can_create_an_object_member(self):
         """Posting valid data to the form creates an object."""
         api_url = self.get_api_url("member")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.account.uuid),
@@ -15189,12 +15022,11 @@ class GroupAccountMembershipCreateByAccountTest(AnVILAPIMockTestMixin, TestCase)
         self.assertEqual(new_object.role, models.GroupAccountMembership.MEMBER)
         self.assertEqual(new_object.group, self.group)
         self.assertEqual(new_object.account, self.account)
-        responses.assert_call_count(api_url, 1)
 
     def test_success_message(self):
         """Response includes a success message if successful."""
         api_url = self.get_api_url("member")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.account.uuid),
@@ -15215,7 +15047,7 @@ class GroupAccountMembershipCreateByAccountTest(AnVILAPIMockTestMixin, TestCase)
     def test_can_create_an_object_admin(self):
         """Posting valid data to the form creates an object."""
         api_url = self.get_api_url("admin")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.account.uuid),
@@ -15231,13 +15063,12 @@ class GroupAccountMembershipCreateByAccountTest(AnVILAPIMockTestMixin, TestCase)
         self.assertEqual(new_object.role, models.GroupAccountMembership.ADMIN)
         self.assertEqual(new_object.group, self.group)
         self.assertEqual(new_object.account, self.account)
-        responses.assert_call_count(api_url, 1)
 
     def test_success_redirect(self):
         """After successfully creating an object, view redirects to the model's list view."""
         # This needs to use the client because the RequestFactory doesn't handle redirects.
         api_url = self.get_api_url("member")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.account.uuid),
@@ -15249,7 +15080,6 @@ class GroupAccountMembershipCreateByAccountTest(AnVILAPIMockTestMixin, TestCase)
         )
         obj = models.GroupAccountMembership.objects.latest("pk")
         self.assertRedirects(response, obj.get_absolute_url())
-        responses.assert_call_count(api_url, 1)
 
     def test_cannot_create_duplicate_object_with_different_role(self):
         """Cannot create a second GroupAccountMembership object for the same account and group with a different role."""
@@ -15423,7 +15253,7 @@ class GroupAccountMembershipCreateByAccountTest(AnVILAPIMockTestMixin, TestCase)
     def test_api_error_500(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=500,
@@ -15446,14 +15276,13 @@ class GroupAccountMembershipCreateByAccountTest(AnVILAPIMockTestMixin, TestCase)
             "AnVIL API Error: group account membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
 
     def test_api_error_400(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=400,
@@ -15476,14 +15305,13 @@ class GroupAccountMembershipCreateByAccountTest(AnVILAPIMockTestMixin, TestCase)
             "AnVIL API Error: group account membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
 
     def test_api_error_403(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=403,
@@ -15506,14 +15334,13 @@ class GroupAccountMembershipCreateByAccountTest(AnVILAPIMockTestMixin, TestCase)
             "AnVIL API Error: group account membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
 
     def test_api_error_404(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=404,
@@ -15536,7 +15363,6 @@ class GroupAccountMembershipCreateByAccountTest(AnVILAPIMockTestMixin, TestCase)
             "AnVIL API Error: group account membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
 
@@ -15693,7 +15519,7 @@ class GroupAccountMembershipCreateByGroupAccountTest(AnVILAPIMockTestMixin, Test
     def test_can_create_an_object_member(self):
         """Posting valid data to the form creates an object."""
         api_url = self.get_api_url("member")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.group.name, self.account.uuid),
@@ -15709,12 +15535,11 @@ class GroupAccountMembershipCreateByGroupAccountTest(AnVILAPIMockTestMixin, Test
         self.assertEqual(new_object.role, models.GroupAccountMembership.MEMBER)
         self.assertEqual(new_object.group, self.group)
         self.assertEqual(new_object.account, self.account)
-        responses.assert_call_count(api_url, 1)
 
     def test_success_message(self):
         """Response includes a success message if successful."""
         api_url = self.get_api_url("member")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.group.name, self.account.uuid),
@@ -15735,7 +15560,7 @@ class GroupAccountMembershipCreateByGroupAccountTest(AnVILAPIMockTestMixin, Test
     def test_can_create_an_object_admin(self):
         """Posting valid data to the form creates an object."""
         api_url = self.get_api_url("admin")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.group.name, self.account.uuid),
@@ -15751,13 +15576,12 @@ class GroupAccountMembershipCreateByGroupAccountTest(AnVILAPIMockTestMixin, Test
         self.assertEqual(new_object.role, models.GroupAccountMembership.ADMIN)
         self.assertEqual(new_object.group, self.group)
         self.assertEqual(new_object.account, self.account)
-        responses.assert_call_count(api_url, 1)
 
     def test_success_redirect(self):
         """After successfully creating an object, view redirects to the model's list view."""
         # This needs to use the client because the RequestFactory doesn't handle redirects.
         api_url = self.get_api_url("member")
-        responses.add(responses.PUT, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.PUT, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(self.group.name, self.account.uuid),
@@ -15769,7 +15593,6 @@ class GroupAccountMembershipCreateByGroupAccountTest(AnVILAPIMockTestMixin, Test
         )
         obj = models.GroupAccountMembership.objects.latest("pk")
         self.assertRedirects(response, obj.get_absolute_url())
-        responses.assert_call_count(api_url, 1)
 
     def test_get_duplicate_object(self):
         """Redirects to detail view if object already exists."""
@@ -15984,7 +15807,7 @@ class GroupAccountMembershipCreateByGroupAccountTest(AnVILAPIMockTestMixin, Test
     def test_api_error_500(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=500,
@@ -16007,14 +15830,13 @@ class GroupAccountMembershipCreateByGroupAccountTest(AnVILAPIMockTestMixin, Test
             "AnVIL API Error: group account membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
 
     def test_api_error_400(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=400,
@@ -16037,14 +15859,13 @@ class GroupAccountMembershipCreateByGroupAccountTest(AnVILAPIMockTestMixin, Test
             "AnVIL API Error: group account membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
 
     def test_api_error_403(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=403,
@@ -16067,14 +15888,13 @@ class GroupAccountMembershipCreateByGroupAccountTest(AnVILAPIMockTestMixin, Test
             "AnVIL API Error: group account membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
 
     def test_api_error_404(self):
         """Shows a message if an AnVIL API error occurs."""
         api_url = self.get_api_url("member")
-        responses.add(
+        self.response_mock.add(
             responses.PUT,
             api_url,
             status=404,
@@ -16097,7 +15917,6 @@ class GroupAccountMembershipCreateByGroupAccountTest(AnVILAPIMockTestMixin, Test
             "AnVIL API Error: group account membership create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
 
@@ -16485,14 +16304,13 @@ class GroupAccountMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             object.group.name, object.role.lower(), object.account.email
         )
-        responses.add(responses.DELETE, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.DELETE, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(object.group.name, object.account.uuid), {"submit": ""}
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(models.GroupAccountMembership.objects.count(), 0)
-        responses.assert_call_count(api_url, 1)
         # History is added.
         self.assertEqual(object.history.count(), 2)
         self.assertEqual(object.history.latest().history_type, "-")
@@ -16503,7 +16321,7 @@ class GroupAccountMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             object.group.name, object.role.lower(), object.account.email
         )
-        responses.add(responses.DELETE, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.DELETE, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(object.group.name, object.account.uuid),
@@ -16524,7 +16342,7 @@ class GroupAccountMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             object.group.name, object.role.lower(), object.account.email
         )
-        responses.add(responses.DELETE, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.DELETE, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(object.group.name, object.account.uuid), {"submit": ""}
@@ -16535,7 +16353,6 @@ class GroupAccountMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
             models.GroupAccountMembership.objects.all(),
             models.GroupAccountMembership.objects.filter(pk=other_object.pk),
         )
-        responses.assert_call_count(api_url, 1)
 
     def test_success_url(self):
         """Redirects to the expected page."""
@@ -16544,14 +16361,13 @@ class GroupAccountMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             object.group.name, object.role.lower(), object.account.email
         )
-        responses.add(responses.DELETE, api_url, status=self.api_success_code)
+        self.response_mock.add(responses.DELETE, api_url, status=self.api_success_code)
         self.client.force_login(self.user)
         response = self.client.post(
             self.get_url(object.group.name, object.account.uuid), {"submit": ""}
         )
         self.assertEqual(response.status_code, 302)
         self.assertRedirects(response, group.get_absolute_url())
-        responses.assert_call_count(api_url, 1)
 
     def test_get_redirect_group_not_managed_by_app(self):
         """Redirect get when trying to delete GroupAccountMembership when the group is not managed by the app."""
@@ -16608,7 +16424,7 @@ class GroupAccountMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             object.group.name, object.role.lower(), object.account.email
         )
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             api_url,
             status=500,
@@ -16626,7 +16442,6 @@ class GroupAccountMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: group account membership delete test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object still exists.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 1)
 
@@ -16637,7 +16452,7 @@ class GroupAccountMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             object.group.name, object.role.lower(), object.account.email
         )
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             api_url,
             status=400,
@@ -16655,7 +16470,6 @@ class GroupAccountMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: group account membership delete test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object still exists.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 1)
 
@@ -16666,7 +16480,7 @@ class GroupAccountMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             object.group.name, object.role.lower(), object.account.email
         )
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             api_url,
             status=403,
@@ -16684,7 +16498,6 @@ class GroupAccountMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: group account membership delete test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object still exists.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 1)
 
@@ -16695,7 +16508,7 @@ class GroupAccountMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             object.group.name, object.role.lower(), object.account.email
         )
-        responses.add(
+        self.response_mock.add(
             responses.DELETE,
             api_url,
             status=404,
@@ -16713,7 +16526,6 @@ class GroupAccountMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: group account membership delete test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object still exists.
         self.assertEqual(models.GroupAccountMembership.objects.count(), 1)
 
@@ -16962,7 +16774,7 @@ class WorkspaceGroupSharingCreateTest(AnVILAPIMockTestMixin, TestCase):
             }
         ]
         api_url = self.get_api_url("test-billing-project", "test-workspace")
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -16983,7 +16795,6 @@ class WorkspaceGroupSharingCreateTest(AnVILAPIMockTestMixin, TestCase):
         new_object = models.WorkspaceGroupSharing.objects.latest("pk")
         self.assertIsInstance(new_object, models.WorkspaceGroupSharing)
         self.assertEqual(new_object.access, models.WorkspaceGroupSharing.READER)
-        responses.assert_call_count(api_url, 1)
         # History is added.
         self.assertEqual(new_object.history.count(), 1)
         self.assertEqual(new_object.history.latest().history_type, "+")
@@ -17006,7 +16817,7 @@ class WorkspaceGroupSharingCreateTest(AnVILAPIMockTestMixin, TestCase):
             }
         ]
         api_url = self.get_api_url("test-billing-project", "test-workspace")
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -17028,7 +16839,6 @@ class WorkspaceGroupSharingCreateTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIsInstance(new_object, models.WorkspaceGroupSharing)
         self.assertEqual(new_object.access, models.WorkspaceGroupSharing.WRITER)
         self.assertEqual(new_object.can_compute, True)
-        responses.assert_call_count(api_url, 1)
 
     def test_success_message(self):
         """Response includes a success message if successful."""
@@ -17048,7 +16858,7 @@ class WorkspaceGroupSharingCreateTest(AnVILAPIMockTestMixin, TestCase):
             }
         ]
         api_url = self.get_api_url("test-billing-project", "test-workspace")
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -17086,7 +16896,7 @@ class WorkspaceGroupSharingCreateTest(AnVILAPIMockTestMixin, TestCase):
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -17108,7 +16918,6 @@ class WorkspaceGroupSharingCreateTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIsInstance(new_object, models.WorkspaceGroupSharing)
         self.assertEqual(new_object.access, models.WorkspaceGroupSharing.WRITER)
         self.assertEqual(new_object.can_compute, False)
-        responses.assert_call_count(api_url, 1)
 
     def test_can_create_an_object_owner(self):
         """Posting valid data to the form creates an object."""
@@ -17123,7 +16932,7 @@ class WorkspaceGroupSharingCreateTest(AnVILAPIMockTestMixin, TestCase):
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -17144,7 +16953,6 @@ class WorkspaceGroupSharingCreateTest(AnVILAPIMockTestMixin, TestCase):
         new_object = models.WorkspaceGroupSharing.objects.latest("pk")
         self.assertIsInstance(new_object, models.WorkspaceGroupSharing)
         self.assertEqual(new_object.access, models.WorkspaceGroupSharing.OWNER)
-        responses.assert_call_count(api_url, 1)
 
     def test_redirects_to_list(self):
         """After successfully creating an object, view redirects to the model's list view."""
@@ -17160,7 +16968,7 @@ class WorkspaceGroupSharingCreateTest(AnVILAPIMockTestMixin, TestCase):
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -17180,7 +16988,6 @@ class WorkspaceGroupSharingCreateTest(AnVILAPIMockTestMixin, TestCase):
         self.assertRedirects(
             response, reverse("anvil_consortium_manager:workspace_group_sharing:list")
         )
-        responses.assert_call_count(api_url, 1)
 
     def test_cannot_create_duplicate_object_with_same_access(self):
         """Cannot create a second object for the same workspace and group with the same access level."""
@@ -17254,7 +17061,7 @@ class WorkspaceGroupSharingCreateTest(AnVILAPIMockTestMixin, TestCase):
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -17273,7 +17080,6 @@ class WorkspaceGroupSharingCreateTest(AnVILAPIMockTestMixin, TestCase):
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(models.WorkspaceGroupSharing.objects.count(), 2)
-        responses.assert_call_count(api_url, 1)
 
     def test_can_have_two_groups_for_one_workspace(self):
         group = factories.ManagedGroupFactory.create()
@@ -17291,7 +17097,7 @@ class WorkspaceGroupSharingCreateTest(AnVILAPIMockTestMixin, TestCase):
             }
         ]
         api_url = self.get_api_url(workspace_2.billing_project.name, workspace_2.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -17310,7 +17116,6 @@ class WorkspaceGroupSharingCreateTest(AnVILAPIMockTestMixin, TestCase):
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(models.WorkspaceGroupSharing.objects.count(), 2)
-        responses.assert_call_count(api_url, 1)
 
     def test_invalid_input_group(self):
         """Posting invalid data to group field does not create an object."""
@@ -17481,7 +17286,7 @@ class WorkspaceGroupSharingCreateTest(AnVILAPIMockTestMixin, TestCase):
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -17517,7 +17322,7 @@ class WorkspaceGroupSharingCreateTest(AnVILAPIMockTestMixin, TestCase):
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -17547,7 +17352,6 @@ class WorkspaceGroupSharingCreateTest(AnVILAPIMockTestMixin, TestCase):
             views.WorkspaceGroupSharingCreate.message_group_not_found,
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.WorkspaceGroupSharing.objects.count(), 0)
 
@@ -17557,7 +17361,7 @@ class WorkspaceGroupSharingCreateTest(AnVILAPIMockTestMixin, TestCase):
         group = factories.ManagedGroupFactory.create()
         workspace = factories.WorkspaceFactory.create()
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=500,
@@ -17580,7 +17384,6 @@ class WorkspaceGroupSharingCreateTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: workspace group access create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.WorkspaceGroupSharing.objects.count(), 0)
 
@@ -17779,7 +17582,7 @@ class WorkspaceGroupSharingCreateByWorkspaceTest(AnVILAPIMockTestMixin, TestCase
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -17803,7 +17606,6 @@ class WorkspaceGroupSharingCreateByWorkspaceTest(AnVILAPIMockTestMixin, TestCase
         new_object = models.WorkspaceGroupSharing.objects.latest("pk")
         self.assertIsInstance(new_object, models.WorkspaceGroupSharing)
         self.assertEqual(new_object.access, models.WorkspaceGroupSharing.READER)
-        responses.assert_call_count(api_url, 1)
         # History is added.
         self.assertEqual(new_object.history.count(), 1)
         self.assertEqual(new_object.history.latest().history_type, "+")
@@ -17826,7 +17628,7 @@ class WorkspaceGroupSharingCreateByWorkspaceTest(AnVILAPIMockTestMixin, TestCase
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -17851,7 +17653,6 @@ class WorkspaceGroupSharingCreateByWorkspaceTest(AnVILAPIMockTestMixin, TestCase
         self.assertIsInstance(new_object, models.WorkspaceGroupSharing)
         self.assertEqual(new_object.access, models.WorkspaceGroupSharing.WRITER)
         self.assertEqual(new_object.can_compute, True)
-        responses.assert_call_count(api_url, 1)
         # History is added.
         self.assertEqual(new_object.history.count(), 1)
         self.assertEqual(new_object.history.latest().history_type, "+")
@@ -17874,7 +17675,7 @@ class WorkspaceGroupSharingCreateByWorkspaceTest(AnVILAPIMockTestMixin, TestCase
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -17916,7 +17717,7 @@ class WorkspaceGroupSharingCreateByWorkspaceTest(AnVILAPIMockTestMixin, TestCase
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -17941,7 +17742,6 @@ class WorkspaceGroupSharingCreateByWorkspaceTest(AnVILAPIMockTestMixin, TestCase
         self.assertIsInstance(new_object, models.WorkspaceGroupSharing)
         self.assertEqual(new_object.access, models.WorkspaceGroupSharing.WRITER)
         self.assertEqual(new_object.can_compute, False)
-        responses.assert_call_count(api_url, 1)
 
     def test_can_create_an_object_owner(self):
         """Posting valid data to the form creates an object."""
@@ -17956,7 +17756,7 @@ class WorkspaceGroupSharingCreateByWorkspaceTest(AnVILAPIMockTestMixin, TestCase
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -17980,7 +17780,6 @@ class WorkspaceGroupSharingCreateByWorkspaceTest(AnVILAPIMockTestMixin, TestCase
         new_object = models.WorkspaceGroupSharing.objects.latest("pk")
         self.assertIsInstance(new_object, models.WorkspaceGroupSharing)
         self.assertEqual(new_object.access, models.WorkspaceGroupSharing.OWNER)
-        responses.assert_call_count(api_url, 1)
 
     def test_success_redirect(self):
         """After successfully creating an object, view redirects to the model's list view."""
@@ -17996,7 +17795,7 @@ class WorkspaceGroupSharingCreateByWorkspaceTest(AnVILAPIMockTestMixin, TestCase
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -18020,7 +17819,6 @@ class WorkspaceGroupSharingCreateByWorkspaceTest(AnVILAPIMockTestMixin, TestCase
             response,
             models.WorkspaceGroupSharing.objects.latest("pk").get_absolute_url(),
         )
-        responses.assert_call_count(api_url, 1)
 
     def test_cannot_create_duplicate_object_with_same_access(self):
         """Cannot create a second object for the same workspace and group with the same access level."""
@@ -18276,7 +18074,7 @@ class WorkspaceGroupSharingCreateByWorkspaceTest(AnVILAPIMockTestMixin, TestCase
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -18309,7 +18107,6 @@ class WorkspaceGroupSharingCreateByWorkspaceTest(AnVILAPIMockTestMixin, TestCase
             views.WorkspaceGroupSharingCreate.message_group_not_found,
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.WorkspaceGroupSharing.objects.count(), 0)
 
@@ -18319,7 +18116,7 @@ class WorkspaceGroupSharingCreateByWorkspaceTest(AnVILAPIMockTestMixin, TestCase
         group = factories.ManagedGroupFactory.create()
         workspace = factories.WorkspaceFactory.create()
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=500,
@@ -18345,7 +18142,6 @@ class WorkspaceGroupSharingCreateByWorkspaceTest(AnVILAPIMockTestMixin, TestCase
             "AnVIL API Error: workspace group access create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.WorkspaceGroupSharing.objects.count(), 0)
 
@@ -18534,7 +18330,7 @@ class WorkspaceGroupSharingCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -18559,7 +18355,6 @@ class WorkspaceGroupSharingCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(new_object.access, models.WorkspaceGroupSharing.READER)
         self.assertEqual(new_object.workspace, workspace)
         self.assertEqual(new_object.group, group)
-        responses.assert_call_count(api_url, 1)
         # History is added.
         self.assertEqual(new_object.history.count(), 1)
         self.assertEqual(new_object.history.latest().history_type, "+")
@@ -18582,7 +18377,7 @@ class WorkspaceGroupSharingCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -18604,7 +18399,6 @@ class WorkspaceGroupSharingCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIsInstance(new_object, models.WorkspaceGroupSharing)
         self.assertEqual(new_object.access, models.WorkspaceGroupSharing.WRITER)
         self.assertEqual(new_object.can_compute, True)
-        responses.assert_call_count(api_url, 1)
 
     def test_success_message(self):
         """Response includes a success message if successful."""
@@ -18624,7 +18418,7 @@ class WorkspaceGroupSharingCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -18663,7 +18457,7 @@ class WorkspaceGroupSharingCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -18687,7 +18481,6 @@ class WorkspaceGroupSharingCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIsInstance(new_object, models.WorkspaceGroupSharing)
         self.assertEqual(new_object.access, models.WorkspaceGroupSharing.WRITER)
         self.assertEqual(new_object.can_compute, False)
-        responses.assert_call_count(api_url, 1)
 
     def test_can_create_an_object_owner(self):
         """Posting valid data to the form creates an object."""
@@ -18702,7 +18495,7 @@ class WorkspaceGroupSharingCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -18725,7 +18518,6 @@ class WorkspaceGroupSharingCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
         new_object = models.WorkspaceGroupSharing.objects.latest("pk")
         self.assertIsInstance(new_object, models.WorkspaceGroupSharing)
         self.assertEqual(new_object.access, models.WorkspaceGroupSharing.OWNER)
-        responses.assert_call_count(api_url, 1)
 
     def test_success_redirect(self):
         """After successfully creating an object, view redirects to the model's list view."""
@@ -18741,7 +18533,7 @@ class WorkspaceGroupSharingCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -18764,7 +18556,6 @@ class WorkspaceGroupSharingCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
             response,
             models.WorkspaceGroupSharing.objects.latest("pk").get_absolute_url(),
         )
-        responses.assert_call_count(api_url, 1)
 
     def test_cannot_create_duplicate_object_with_same_access(self):
         """Cannot create a second object for the same workspace and group with the same access level."""
@@ -18978,7 +18769,7 @@ class WorkspaceGroupSharingCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -19010,7 +18801,6 @@ class WorkspaceGroupSharingCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
             views.WorkspaceGroupSharingCreate.message_group_not_found,
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.WorkspaceGroupSharing.objects.count(), 0)
 
@@ -19020,7 +18810,7 @@ class WorkspaceGroupSharingCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
         group = factories.ManagedGroupFactory.create()
         workspace = factories.WorkspaceFactory.create()
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=500,
@@ -19045,7 +18835,6 @@ class WorkspaceGroupSharingCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: workspace group access create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.WorkspaceGroupSharing.objects.count(), 0)
 
@@ -19272,7 +19061,7 @@ class WorkspaceGroupSharingCreateByWorkspaceGroupTest(AnVILAPIMockTestMixin, Tes
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -19297,7 +19086,6 @@ class WorkspaceGroupSharingCreateByWorkspaceGroupTest(AnVILAPIMockTestMixin, Tes
         new_object = models.WorkspaceGroupSharing.objects.latest("pk")
         self.assertIsInstance(new_object, models.WorkspaceGroupSharing)
         self.assertEqual(new_object.access, models.WorkspaceGroupSharing.READER)
-        responses.assert_call_count(api_url, 1)
         # History is added.
         self.assertEqual(new_object.history.count(), 1)
         self.assertEqual(new_object.history.latest().history_type, "+")
@@ -19320,7 +19108,7 @@ class WorkspaceGroupSharingCreateByWorkspaceGroupTest(AnVILAPIMockTestMixin, Tes
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -19346,7 +19134,6 @@ class WorkspaceGroupSharingCreateByWorkspaceGroupTest(AnVILAPIMockTestMixin, Tes
         self.assertIsInstance(new_object, models.WorkspaceGroupSharing)
         self.assertEqual(new_object.access, models.WorkspaceGroupSharing.WRITER)
         self.assertEqual(new_object.can_compute, True)
-        responses.assert_call_count(api_url, 1)
 
     def test_success_message(self):
         """Response includes a success message if successful."""
@@ -19366,7 +19153,7 @@ class WorkspaceGroupSharingCreateByWorkspaceGroupTest(AnVILAPIMockTestMixin, Tes
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -19409,7 +19196,7 @@ class WorkspaceGroupSharingCreateByWorkspaceGroupTest(AnVILAPIMockTestMixin, Tes
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -19435,7 +19222,6 @@ class WorkspaceGroupSharingCreateByWorkspaceGroupTest(AnVILAPIMockTestMixin, Tes
         self.assertIsInstance(new_object, models.WorkspaceGroupSharing)
         self.assertEqual(new_object.access, models.WorkspaceGroupSharing.WRITER)
         self.assertEqual(new_object.can_compute, False)
-        responses.assert_call_count(api_url, 1)
 
     def test_can_create_an_object_owner(self):
         """Posting valid data to the form creates an object."""
@@ -19450,7 +19236,7 @@ class WorkspaceGroupSharingCreateByWorkspaceGroupTest(AnVILAPIMockTestMixin, Tes
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -19475,7 +19261,6 @@ class WorkspaceGroupSharingCreateByWorkspaceGroupTest(AnVILAPIMockTestMixin, Tes
         new_object = models.WorkspaceGroupSharing.objects.latest("pk")
         self.assertIsInstance(new_object, models.WorkspaceGroupSharing)
         self.assertEqual(new_object.access, models.WorkspaceGroupSharing.OWNER)
-        responses.assert_call_count(api_url, 1)
 
     def test_success_redirect(self):
         """After successfully creating an object, view redirects to the model's list view."""
@@ -19491,7 +19276,7 @@ class WorkspaceGroupSharingCreateByWorkspaceGroupTest(AnVILAPIMockTestMixin, Tes
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -19516,7 +19301,6 @@ class WorkspaceGroupSharingCreateByWorkspaceGroupTest(AnVILAPIMockTestMixin, Tes
             response,
             models.WorkspaceGroupSharing.objects.latest("pk").get_absolute_url(),
         )
-        responses.assert_call_count(api_url, 1)
 
     def test_get_duplicate_object(self):
         """Redirects to detail view if object already exists."""
@@ -19808,7 +19592,7 @@ class WorkspaceGroupSharingCreateByWorkspaceGroupTest(AnVILAPIMockTestMixin, Tes
             }
         ]
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -19842,7 +19626,6 @@ class WorkspaceGroupSharingCreateByWorkspaceGroupTest(AnVILAPIMockTestMixin, Tes
             views.WorkspaceGroupSharingCreate.message_group_not_found,
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.WorkspaceGroupSharing.objects.count(), 0)
 
@@ -19852,7 +19635,7 @@ class WorkspaceGroupSharingCreateByWorkspaceGroupTest(AnVILAPIMockTestMixin, Tes
         group = factories.ManagedGroupFactory.create()
         workspace = factories.WorkspaceFactory.create()
         api_url = self.get_api_url(workspace.billing_project.name, workspace.name)
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=500,
@@ -19879,7 +19662,6 @@ class WorkspaceGroupSharingCreateByWorkspaceGroupTest(AnVILAPIMockTestMixin, Tes
             "AnVIL API Error: workspace group access create test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.WorkspaceGroupSharing.objects.count(), 0)
 
@@ -20052,7 +19834,7 @@ class WorkspaceGroupSharingUpdateTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             obj.workspace.billing_project.name, obj.workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -20098,7 +19880,7 @@ class WorkspaceGroupSharingUpdateTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             obj.workspace.billing_project.name, obj.workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -20172,7 +19954,7 @@ class WorkspaceGroupSharingUpdateTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             obj.workspace.billing_project.name, obj.workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -20213,7 +19995,7 @@ class WorkspaceGroupSharingUpdateTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             obj.workspace.billing_project.name, obj.workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -20230,7 +20012,6 @@ class WorkspaceGroupSharingUpdateTest(AnVILAPIMockTestMixin, TestCase):
             },
         )
         self.assertRedirects(response, obj.get_absolute_url())
-        responses.assert_call_count(api_url, 1)
 
     def test_post_blank_data_access(self):
         """Posting blank data to the access field does not update the object."""
@@ -20275,7 +20056,7 @@ class WorkspaceGroupSharingUpdateTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             obj.workspace.billing_project.name, obj.workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -20332,7 +20113,7 @@ class WorkspaceGroupSharingUpdateTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             obj.workspace.billing_project.name, obj.workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -20352,7 +20133,6 @@ class WorkspaceGroupSharingUpdateTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(response.status_code, 302)
         obj.refresh_from_db()
         self.assertEqual(obj.group, original_group)
-        responses.assert_call_count(api_url, 1)
 
     def test_post_workspace_pk(self):
         """Posting a workspace pk has no effect."""
@@ -20372,7 +20152,7 @@ class WorkspaceGroupSharingUpdateTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             obj.workspace.billing_project.name, obj.workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -20392,7 +20172,6 @@ class WorkspaceGroupSharingUpdateTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(response.status_code, 302)
         obj.refresh_from_db()
         self.assertEqual(obj.workspace, original_workspace)
-        responses.assert_call_count(api_url, 1)
 
     def test_api_error(self):
         """Shows a message if an AnVIL API error occurs."""
@@ -20403,7 +20182,7 @@ class WorkspaceGroupSharingUpdateTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             obj.workspace.billing_project.name, obj.workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=500,
@@ -20426,7 +20205,6 @@ class WorkspaceGroupSharingUpdateTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: workspace group access update test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.WorkspaceGroupSharing.objects.count(), 1)
         obj.refresh_from_db()
@@ -20660,7 +20438,7 @@ class WorkspaceGroupSharingDeleteTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             obj.workspace.billing_project.name, obj.workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -20675,7 +20453,6 @@ class WorkspaceGroupSharingDeleteTest(AnVILAPIMockTestMixin, TestCase):
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(models.WorkspaceGroupSharing.objects.count(), 0)
-        responses.assert_call_count(api_url, 1)
         # History is added.
         self.assertEqual(obj.history.count(), 2)
         self.assertEqual(obj.history.latest().history_type, "-")
@@ -20703,7 +20480,7 @@ class WorkspaceGroupSharingDeleteTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             obj.workspace.billing_project.name, obj.workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -20739,7 +20516,7 @@ class WorkspaceGroupSharingDeleteTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             obj.workspace.billing_project.name, obj.workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -20758,7 +20535,6 @@ class WorkspaceGroupSharingDeleteTest(AnVILAPIMockTestMixin, TestCase):
             models.WorkspaceGroupSharing.objects.all(),
             models.WorkspaceGroupSharing.objects.filter(pk=other_object.pk),
         )
-        responses.assert_call_count(api_url, 1)
 
     def test_delete_with_can_compute(self):
         """Can delete a record with can_compute=True."""
@@ -20785,7 +20561,7 @@ class WorkspaceGroupSharingDeleteTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             obj.workspace.billing_project.name, obj.workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -20800,7 +20576,6 @@ class WorkspaceGroupSharingDeleteTest(AnVILAPIMockTestMixin, TestCase):
         )
         self.assertEqual(response.status_code, 302)
         self.assertEqual(models.WorkspaceGroupSharing.objects.count(), 0)
-        responses.assert_call_count(api_url, 1)
 
     def test_success_url(self):
         """Redirects to the expected page."""
@@ -20816,7 +20591,7 @@ class WorkspaceGroupSharingDeleteTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             obj.workspace.billing_project.name, obj.workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=self.api_success_code,
@@ -20834,7 +20609,6 @@ class WorkspaceGroupSharingDeleteTest(AnVILAPIMockTestMixin, TestCase):
         self.assertRedirects(
             response, reverse("anvil_consortium_manager:workspace_group_sharing:list")
         )
-        responses.assert_call_count(api_url, 1)
 
     def test_api_error(self):
         """Shows a message if an AnVIL API error occurs."""
@@ -20843,7 +20617,7 @@ class WorkspaceGroupSharingDeleteTest(AnVILAPIMockTestMixin, TestCase):
         api_url = self.get_api_url(
             obj.workspace.billing_project.name, obj.workspace.name
         )
-        responses.add(
+        self.response_mock.add(
             responses.PATCH,
             api_url,
             status=500,
@@ -20864,7 +20638,6 @@ class WorkspaceGroupSharingDeleteTest(AnVILAPIMockTestMixin, TestCase):
             "AnVIL API Error: workspace group access delete test error",
             str(messages[0]),
         )
-        responses.assert_call_count(api_url, 1)
         # Make sure that the object was not created.
         self.assertEqual(models.WorkspaceGroupSharing.objects.count(), 1)
 

--- a/anvil_consortium_manager/tests/utils.py
+++ b/anvil_consortium_manager/tests/utils.py
@@ -27,11 +27,12 @@ class AnVILAPIMockTestMixin:
             mock.sentinel.credentials,
             mock.sentinel.project,
         )
-        responses.start()
+        self.response_mock = responses.RequestsMock(assert_all_requests_are_fired=True)
+        self.response_mock.start()
         # Get an instance of the API client to access entry points?
         self.api_client = AnVILAPIClient()
 
     def tearDown(self):
         super().tearDown()
-        responses.stop()
-        responses.reset()
+        self.response_mock.stop()
+        self.response_mock.reset()


### PR DESCRIPTION
Instead of adding directly to the `responses` package, set a `RequestMock` instance and add any request responses to that mock.

Closes #254