### PR TITLE
Support django 4.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,3 +81,34 @@ jobs:
     #       DBPASSWORD: rootpw
     #       DBHOST: 127.0.0.1
     #       DBBACKEND: mysql
+
+
+
+  coverage:
+    name: Check coverage.
+    runs-on: "ubuntu-latest"
+    needs: [sqlite]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          # Use latest, so it understands all syntax.
+          python-version: "3.10"
+
+      - run: python -m pip install --upgrade coverage[toml]
+
+      - name: Download coverage data.
+        uses: actions/download-artifact@v3
+        with:
+          name: coverage-data
+
+      - name: Combine coverage & check percentage
+        run: |
+          python -m coverage combine
+          python -m coverage xml
+          python -m coverage report
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,92 +16,76 @@ on:
 
 
 jobs:
-  linter:
+  mysql:
     runs-on: ubuntu-latest
-    steps:
-
-      - name: Checkout Code Repository
-        uses: actions/checkout@v3.1.0
-
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.9"
-          cache: pip
-          cache-dependency-path: |
-            requirements/base.txt
-            requirements/dev.txt
-
-      - name: Run pre-commit
-        uses: pre-commit/action@v3.0.0
-
-  test-sqlite:
-    name: "Python ${{ matrix.python-version }} - sqlite"
-    runs-on: "ubuntu-latest"
-    env:
-        BACKEND: sqlite
-
     strategy:
+      fail-fast: false
+      max-parallel: 5
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ['3.8', '3.9', '3.10']
+#         mariadb-version: ["10.3", "10.5"]
 
-    steps:
-      - uses: "actions/checkout@v3.1.0"
-      - uses: "actions/setup-python@v4"
-        with:
-          python-version: "${{ matrix.python-version }}"
-      - name: "Install dependencies"
-        run: |
-          python -VV
-          python -m site
-          python -m pip install --upgrade pip setuptools wheel
-          python -m pip install --upgrade coverage[toml] virtualenv tox tox-gh-actions
-
-      - name: "Run tox targets for ${{ matrix.python-version }}"
-        run: "python -m tox"
-
-      - if: ${{ matrix.python-version == '3.9' }}
-        name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-
-  test-mariadb:
-    name: "Python ${{ matrix.python-version }} - mariadb - ${{ matrix.mariadb-version }}"
-    runs-on: "ubuntu-latest"
-    env:
-      DBNAME: test
-      DBUSER: root
-      DBPASSWORD: rootpw
-      DBHOST: 127.0.0.1
-      BACKEND: mariadb
-
+  sqlite:
+    runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
+      max-parallel: 5
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
-        mariadb-version: ["10.3", "10.5"]
-
-    services:
-      database:
-        image: mariadb:${{ matrix.mariadb-version }}
-        env:
-          MYSQL_ROOT_PASSWORD: rootpw
-          MYSQL_DATABASE: test
-        ports:
-          - 3306:3306
-        options: --tmpfs /var/lib/mysql
+        python-version: ['3.8', '3.9', '3.10']
 
     steps:
-      - uses: "actions/checkout@v3.1.0"
-      - uses: "actions/setup-python@v4"
-        with:
-          python-version: "${{ matrix.python-version }}"
-      - name: "Install dependencies"
-        run: |
-          python -VV
-          python -m site
-          python -m pip install --upgrade pip setuptools wheel
-          python -m pip install --upgrade coverage[toml] virtualenv tox tox-gh-actions
+    - uses: actions/checkout@v3
 
-      - name: "Run tox targets for ${{ matrix.python-version }} and mariadb-${{ matrix.mariadb-version }}"
-        run: "python -m tox"
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade tox tox-gh-actions
+
+    - name: Test with tox
+      run: tox
+      env:
+        DBBACKEND: sqlite3
+        DBNAME: ":memory:"
+
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage-data
+        path: ".coverage.*"
+
+    # services:
+    #   mariadb:
+    #     image: mariadb:${{ matrix.mariadb-version }}
+    #     env:
+    #       MYSQL_ROOT_PASSWORD: rootpw
+    #       MYSQL_DATABASE: test
+    #     options: --tmpfs /var/lib/mysql
+    #     ports:
+    #     - 3306:3306
+    #
+    # steps:
+    #   - uses: "actions/checkout@v3.1.0"
+    #
+    #   - name: Set up Python ${{ matrix.python-version }}
+    #     uses: "actions/setup-python@v4"
+    #     with:
+    #       python-version: "${{ matrix.python-version }}"
+    #
+    #   - name: "Install dependencies"
+    #     run: |
+    #       python -m pip install --upgrade pip
+    #       python -m pip install --upgrade tox tox-gh-actions
+    #
+    #   - name: "Test with tox"
+    #     run: "tox"
+    #     env:
+    #       DBNAME: test
+    #       DBUSER: root
+    #       DBPASSWORD: rootpw
+    #       DBHOST: 127.0.0.1
+    #       DBBACKEND: mysql

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,7 +102,7 @@ jobs:
   coverage:
     name: Check coverage.
     runs-on: "ubuntu-latest"
-    needs: [sqlite, mariadb]
+    needs: [sqlite, mysql]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
           # Use latest, so it understands all syntax.
           python-version: "3.10"
 
-      - run: python -m pip install --upgrade coverage[toml] django-coverage-plugin
+      - run: python -m pip install --upgrade coverage[toml] django==3.2.16 django-coverage-plugin
 
 
       - name: Download coverage data.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,14 +16,6 @@ on:
 
 
 jobs:
-  mysql:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      max-parallel: 5
-      matrix:
-        python-version: ['3.8', '3.9', '3.10']
-#         mariadb-version: ["10.3", "10.5"]
 
   sqlite:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,44 +50,59 @@ jobs:
         name: coverage-data
         path: ".coverage.*"
 
-    # services:
-    #   mariadb:
-    #     image: mariadb:${{ matrix.mariadb-version }}
-    #     env:
-    #       MYSQL_ROOT_PASSWORD: rootpw
-    #       MYSQL_DATABASE: test
-    #     options: --tmpfs /var/lib/mysql
-    #     ports:
-    #     - 3306:3306
-    #
-    # steps:
-    #   - uses: "actions/checkout@v3.1.0"
-    #
-    #   - name: Set up Python ${{ matrix.python-version }}
-    #     uses: "actions/setup-python@v4"
-    #     with:
-    #       python-version: "${{ matrix.python-version }}"
-    #
-    #   - name: "Install dependencies"
-    #     run: |
-    #       python -m pip install --upgrade pip
-    #       python -m pip install --upgrade tox tox-gh-actions
-    #
-    #   - name: "Test with tox"
-    #     run: "tox"
-    #     env:
-    #       DBNAME: test
-    #       DBUSER: root
-    #       DBPASSWORD: rootpw
-    #       DBHOST: 127.0.0.1
-    #       DBBACKEND: mysql
 
+  mariadb:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 5
+      matrix:
+        python-version: ['3.8', '3.9', '3.10']
+        mariadb-version: ["10.3", "10.5"]
+
+    services:
+      database:
+        image: mariadb:${{ matrix.mariadb-version }}
+        env:
+          MYSQL_ROOT_PASSWORD: rootpw
+          MYSQL_DATABASE: test
+        ports:
+          - 3306:3306
+        options: --tmpfs /var/lib/mysql
+
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install --upgrade tox tox-gh-actions
+
+    - name: Test with tox
+      run: tox
+      env:
+        DBBACKEND: mysql
+        DBNAME: test
+        DBUSER: root
+        DBPASSWORD: rootpw
+        DBHOST: 127.0.0.1
+
+    - name: Upload coverage data
+      uses: actions/upload-artifact@v3
+      with:
+        name: coverage-data
+        path: ".coverage.*"
 
 
   coverage:
     name: Check coverage.
     runs-on: "ubuntu-latest"
-    needs: [sqlite]
+    needs: [sqlite, mariadb]
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,26 @@ on:
 
 jobs:
 
+  linter:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout Code Repository
+        uses: actions/checkout@v3.1.0
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+          cache: pip
+          cache-dependency-path: |
+            requirements/base.txt
+            requirements/dev.txt
+
+      - name: Run pre-commit
+        uses: pre-commit/action@v3.0.0
+
+
   sqlite:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.8']
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v3
@@ -57,8 +57,8 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.8']
-        mariadb-version: ["10.3"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        mariadb-version: ["10.3", "10.5"]
 
     services:
       database:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
+        python-version: ['3.8']
 
     steps:
     - uses: actions/checkout@v3
@@ -51,14 +51,14 @@ jobs:
         path: ".coverage.*"
 
 
-  mariadb:
+  mysql:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       max-parallel: 5
       matrix:
-        python-version: ['3.8', '3.9', '3.10']
-        mariadb-version: ["10.3", "10.5"]
+        python-version: ['3.8']
+        mariadb-version: ["10.3"]
 
     services:
       database:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,8 @@ jobs:
           # Use latest, so it understands all syntax.
           python-version: "3.10"
 
-      - run: python -m pip install --upgrade coverage[toml]
+      - run: python -m pip install --upgrade coverage[toml] django-coverage-plugin
+
 
       - name: Download coverage data.
         uses: actions/download-artifact@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -106,7 +106,6 @@ jobs:
         run: |
           python -m coverage combine
           python -m coverage xml
-          python -m coverage report
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log
 
+## Devel
+
+- Support Django 4.1.*
+
 ## 0.11 (2023-02-24)
 
 - Copy notebooks when cloning a workspace.

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.11"
+__version__ = "0.12dev1"

--- a/anvil_consortium_manager/forms.py
+++ b/anvil_consortium_manager/forms.py
@@ -147,7 +147,10 @@ class WorkspaceCreateForm(forms.ModelForm):
         # DJANGO <4.1 on mysql:
         # Check for the same case insensitive name in the same billing project.
         is_mysql = settings.DATABASES["default"]["ENGINE"] == "django.db.backends.mysql"
-        if not is_mysql or DJANGO_VERSION < (4, 1):
+        if is_mysql and DJANGO_VERSION >= (4, 1):
+            # This is handled by the model full_clean method with case-insensitive collation.
+            pass
+        else:
             billing_project = self.cleaned_data.get("billing_project", None)
             name = self.cleaned_data.get("name", None)
             if (

--- a/anvil_consortium_manager/forms.py
+++ b/anvil_consortium_manager/forms.py
@@ -236,7 +236,6 @@ class WorkspaceCloneForm(forms.ModelForm):
                     "name", flat=True
                 )
             )
-            print(auth_domain_names)
             extra_text = " You must also include the authorization domain(s) from the original workspace ({}).".format(
                 ", ".join(auth_domain_names)
             )

--- a/anvil_consortium_manager/models.py
+++ b/anvil_consortium_manager/models.py
@@ -940,7 +940,6 @@ class Workspace(TimeStampedModel):
                         except ManagedGroup.DoesNotExist:
                             # The group doesn't exist in the app - don't do anything.
                             pass
-                print(response.json()["acl"])
 
         except Exception:
             # If it fails for any reason we haven't already handled, we don't want the transaction to happen.

--- a/anvil_consortium_manager/tests/settings/test.py
+++ b/anvil_consortium_manager/tests/settings/test.py
@@ -1,6 +1,7 @@
 """
 Base test settings file.
 """
+import os
 
 # GENERAL
 # ------------------------------------------------------------------------------
@@ -20,17 +21,24 @@ SECRET_KEY = "w5S8S9eqW5ZqWXPnsCpgbOkcOtajCMmRDjakwXR39lbmVDSunZPwiSV80jSaVBdL"
 # https://docs.djangoproject.com/en/dev/ref/settings/#test-runner
 TEST_RUNNER = "django.test.runner.DiscoverRunner"
 
+INTERNAL_IPS = ["127.0.0.1"]
 # DATABASES
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#databases
 
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.sqlite3",
-        "NAME": "db.sqlite3",
+        "ENGINE": "django.db.backends.{}".format(
+            os.getenv("DBBACKEND", default="sqlite3")
+        ),
+        "NAME": os.getenv("DBNAME", default="anvil_consortium_manager"),
+        "USER": os.getenv("DBUSER", default="django"),
+        "PASSWORD": os.getenv("DBPASSWORD", default="password"),
+        "HOST": os.getenv("DBHOST", default="127.0.0.1"),
+        "PORT": os.getenv("DBPORT", default="3306"),
     }
 }
-
+print(DATABASES["default"]["ENGINE"])
 # URLS
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#root-urlconf

--- a/anvil_consortium_manager/tests/test_anvil_audit.py
+++ b/anvil_consortium_manager/tests/test_anvil_audit.py
@@ -71,7 +71,6 @@ class AnVILAuditTest(TestCase):
         with self.assertRaises(ValueError) as e:
             self.audit_results.add_error(obj, self.audit_results.TEST_ERROR_1)
         self.assertIn("already verified", str(e.exception))
-        print(self.audit_results.get_verified())
         self.assertEqual(self.audit_results.get_verified(), set([obj]))
         self.assertEqual(self.audit_results.get_errors(), {})
 

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -504,7 +504,7 @@ class BillingProjectImportTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIn("messages", response.context)
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
-        self.assertEqual(views.BillingProjectImport.success_msg, str(messages[0]))
+        self.assertEqual(views.BillingProjectImport.success_message, str(messages[0]))
 
     def test_redirects_to_new_object_detail(self):
         """After successfully creating an object, view redirects to the object's detail page."""
@@ -726,7 +726,7 @@ class BillingProjectUpdateTest(TestCase):
         self.assertIn("messages", response.context)
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
-        self.assertEqual(views.BillingProjectUpdate.success_msg, str(messages[0]))
+        self.assertEqual(views.BillingProjectUpdate.success_message, str(messages[0]))
 
     def test_redirects_to_object_detail(self):
         """After successfully creating an object, view redirects to the object's detail page."""
@@ -1636,7 +1636,7 @@ class AccountImportTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIn("messages", response.context)
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
-        self.assertEqual(views.AccountImport.success_msg, str(messages[0]))
+        self.assertEqual(views.AccountImport.success_message, str(messages[0]))
 
     def test_redirects_to_new_object_detail(self):
         """After successfully creating an object, view redirects to the object's detail page."""
@@ -1910,7 +1910,7 @@ class AccountUpdateTest(TestCase):
         self.assertIn("messages", response.context)
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
-        self.assertEqual(views.AccountUpdate.success_msg, str(messages[0]))
+        self.assertEqual(views.AccountUpdate.success_message, str(messages[0]))
 
     def test_redirects_to_object_detail(self):
         """After successfully creating an object, view redirects to the object's detail page."""
@@ -2016,7 +2016,7 @@ class AccountLinkTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIn("messages", response.context)
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
-        self.assertEqual(str(messages[0]), views.AccountLink.success_msg)
+        self.assertEqual(str(messages[0]), views.AccountLink.success_message)
 
     def test_redirect(self):
         """View redirects to the correct URL."""
@@ -3239,7 +3239,7 @@ class AccountDeleteTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIn("messages", response.context)
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
-        self.assertEqual(views.AccountDelete.success_msg, str(messages[0]))
+        self.assertEqual(views.AccountDelete.success_message, str(messages[0]))
 
     def test_view_deletes_object_service_account(self):
         """Posting submit to the form successfully deletes the service account object."""
@@ -3490,7 +3490,7 @@ class AccountDeactivateTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIn("messages", response.context)
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
-        self.assertEqual(views.AccountDeactivate.success_msg, str(messages[0]))
+        self.assertEqual(views.AccountDeactivate.success_message, str(messages[0]))
 
     def test_view_deactivates_object_service_account(self):
         """Posting submit to the form successfully deactivates a service account object."""
@@ -3804,7 +3804,7 @@ class AccountReactivateTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIn("messages", response.context)
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
-        self.assertEqual(views.AccountReactivate.success_msg, str(messages[0]))
+        self.assertEqual(views.AccountReactivate.success_message, str(messages[0]))
 
     def test_view_reactivates_object_service_account(self):
         """Posting submit to the form successfully reactivates a service account object."""
@@ -4771,7 +4771,7 @@ class ManagedGroupCreateTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIn("messages", response.context)
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
-        self.assertEqual(views.ManagedGroupCreate.success_msg, str(messages[0]))
+        self.assertEqual(views.ManagedGroupCreate.success_message, str(messages[0]))
 
     def test_redirects_to_new_object_detail(self):
         """After successfully creating an object, view redirects to the object's detail page."""
@@ -4981,7 +4981,7 @@ class ManagedGroupUpdateTest(TestCase):
         self.assertIn("messages", response.context)
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
-        self.assertEqual(views.ManagedGroupUpdate.success_msg, str(messages[0]))
+        self.assertEqual(views.ManagedGroupUpdate.success_message, str(messages[0]))
 
     def test_redirects_to_object_detail(self):
         """After successfully creating an object, view redirects to the object's detail page."""
@@ -5176,7 +5176,7 @@ class ManagedGroupDeleteTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIn("messages", response.context)
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
-        self.assertEqual(views.ManagedGroupDelete.success_msg, str(messages[0]))
+        self.assertEqual(views.ManagedGroupDelete.success_message, str(messages[0]))
 
     def test_only_deletes_specified_pk(self):
         """View only deletes the specified pk."""
@@ -6682,7 +6682,7 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIn("messages", response.context)
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
-        self.assertEqual(views.WorkspaceCreate.success_msg, str(messages[0]))
+        self.assertEqual(views.WorkspaceCreate.success_message, str(messages[0]))
 
     def test_redirects_to_new_object_detail(self):
         """After successfully creating an object, view redirects to the object's detail page."""
@@ -7869,7 +7869,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIn("messages", response.context)
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
-        self.assertEqual(views.WorkspaceImport.success_msg, str(messages[0]))
+        self.assertEqual(views.WorkspaceImport.success_message, str(messages[0]))
 
     def test_can_import_workspace_and_billing_project_as_not_user(self):
         """Can import a workspace from AnVIL when the billing project does not exist in Django and we are not users."""
@@ -9117,7 +9117,7 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIn("messages", response.context)
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
-        self.assertEqual(views.WorkspaceCreate.success_msg, str(messages[0]))
+        self.assertEqual(views.WorkspaceCreate.success_message, str(messages[0]))
 
     def test_redirects_to_new_object_detail(self):
         """After successfully creating an object, view redirects to the object's detail page."""
@@ -9934,7 +9934,7 @@ class WorkspaceUpdateTest(TestCase):
         self.assertIn("messages", response.context)
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
-        self.assertEqual(views.WorkspaceUpdate.success_msg, str(messages[0]))
+        self.assertEqual(views.WorkspaceUpdate.success_message, str(messages[0]))
 
     def test_redirects_to_object_detail(self):
         """After successfully creating an object, view redirects to the object's detail page."""
@@ -10399,7 +10399,7 @@ class WorkspaceDeleteTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIn("messages", response.context)
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
-        self.assertEqual(views.WorkspaceDelete.success_msg, str(messages[0]))
+        self.assertEqual(views.WorkspaceDelete.success_message, str(messages[0]))
 
     def test_only_deletes_specified_pk(self):
         """View only deletes the specified pk."""
@@ -11468,7 +11468,9 @@ class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIn("messages", response.context)
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
-        self.assertEqual(views.GroupGroupMembershipCreate.success_msg, str(messages[0]))
+        self.assertEqual(
+            views.GroupGroupMembershipCreate.success_message, str(messages[0])
+        )
 
     def test_can_create_an_object_admin(self):
         """Posting valid data to the form creates an object."""
@@ -12118,7 +12120,7 @@ class GroupGroupMembershipCreateByParentTest(AnVILAPIMockTestMixin, TestCase):
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertEqual(
-            views.GroupGroupMembershipCreateByParent.success_msg, str(messages[0])
+            views.GroupGroupMembershipCreateByParent.success_message, str(messages[0])
         )
 
     def test_can_create_an_object_admin(self):
@@ -12656,7 +12658,7 @@ class GroupGroupMembershipCreateByChildTest(AnVILAPIMockTestMixin, TestCase):
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertEqual(
-            views.GroupGroupMembershipCreateByParent.success_msg, str(messages[0])
+            views.GroupGroupMembershipCreateByParent.success_message, str(messages[0])
         )
 
     def test_can_create_an_object_admin(self):
@@ -13178,7 +13180,8 @@ class GroupGroupMembershipCreateByParentChildTest(AnVILAPIMockTestMixin, TestCas
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertEqual(
-            views.GroupGroupMembershipCreateByParentChild.success_msg, str(messages[0])
+            views.GroupGroupMembershipCreateByParentChild.success_message,
+            str(messages[0]),
         )
 
     def test_can_create_an_object_admin(self):
@@ -13853,7 +13856,9 @@ class GroupGroupMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
         self.assertIn("messages", response.context)
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
-        self.assertEqual(views.GroupGroupMembershipDelete.success_msg, str(messages[0]))
+        self.assertEqual(
+            views.GroupGroupMembershipDelete.success_message, str(messages[0])
+        )
 
     def test_only_deletes_specified_pk(self):
         """View only deletes the specified pk."""
@@ -14324,7 +14329,7 @@ class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertEqual(
-            views.GroupAccountMembershipCreate.success_msg, str(messages[0])
+            views.GroupAccountMembershipCreate.success_message, str(messages[0])
         )
 
     def test_can_create_an_object_admin(self):
@@ -14939,7 +14944,7 @@ class GroupAccountMembershipCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertEqual(
-            views.GroupAccountMembershipCreate.success_msg, str(messages[0])
+            views.GroupAccountMembershipCreate.success_message, str(messages[0])
         )
 
     def test_can_create_an_object_admin(self):
@@ -15463,7 +15468,7 @@ class GroupAccountMembershipCreateByAccountTest(AnVILAPIMockTestMixin, TestCase)
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertEqual(
-            views.GroupAccountMembershipCreate.success_msg, str(messages[0])
+            views.GroupAccountMembershipCreate.success_message, str(messages[0])
         )
 
     def test_can_create_an_object_admin(self):
@@ -15984,7 +15989,7 @@ class GroupAccountMembershipCreateByGroupAccountTest(AnVILAPIMockTestMixin, Test
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertEqual(
-            views.GroupAccountMembershipCreate.success_msg, str(messages[0])
+            views.GroupAccountMembershipCreate.success_message, str(messages[0])
         )
 
     def test_can_create_an_object_admin(self):
@@ -16770,7 +16775,7 @@ class GroupAccountMembershipDeleteTest(AnVILAPIMockTestMixin, TestCase):
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertEqual(
-            views.GroupAccountMembershipDelete.success_msg, str(messages[0])
+            views.GroupAccountMembershipDelete.success_message, str(messages[0])
         )
 
     def test_only_deletes_specified_pk(self):
@@ -17322,7 +17327,7 @@ class WorkspaceGroupSharingCreateTest(AnVILAPIMockTestMixin, TestCase):
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertEqual(
-            views.WorkspaceGroupSharingCreate.success_msg, str(messages[0])
+            views.WorkspaceGroupSharingCreate.success_message, str(messages[0])
         )
 
     def test_can_create_an_object_writer(self):
@@ -18142,7 +18147,7 @@ class WorkspaceGroupSharingCreateByWorkspaceTest(AnVILAPIMockTestMixin, TestCase
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertEqual(
-            views.WorkspaceGroupSharingCreateByWorkspaceGroup.success_msg,
+            views.WorkspaceGroupSharingCreateByWorkspaceGroup.success_message,
             str(messages[0]),
         )
 
@@ -18882,7 +18887,7 @@ class WorkspaceGroupSharingCreateByGroupTest(AnVILAPIMockTestMixin, TestCase):
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertEqual(
-            views.WorkspaceGroupSharingCreateByWorkspaceGroup.success_msg,
+            views.WorkspaceGroupSharingCreateByWorkspaceGroup.success_message,
             str(messages[0]),
         )
 
@@ -19621,7 +19626,7 @@ class WorkspaceGroupSharingCreateByWorkspaceGroupTest(AnVILAPIMockTestMixin, Tes
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertEqual(
-            views.WorkspaceGroupSharingCreateByWorkspaceGroup.success_msg,
+            views.WorkspaceGroupSharingCreateByWorkspaceGroup.success_message,
             str(messages[0]),
         )
 
@@ -20417,7 +20422,7 @@ class WorkspaceGroupSharingUpdateTest(AnVILAPIMockTestMixin, TestCase):
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertEqual(
-            views.WorkspaceGroupSharingUpdate.success_msg, str(messages[0])
+            views.WorkspaceGroupSharingUpdate.success_message, str(messages[0])
         )
 
     def test_redirects_to_detail(self):
@@ -20940,7 +20945,7 @@ class WorkspaceGroupSharingDeleteTest(AnVILAPIMockTestMixin, TestCase):
         messages = list(response.context["messages"])
         self.assertEqual(len(messages), 1)
         self.assertEqual(
-            views.WorkspaceGroupSharingDelete.success_msg, str(messages[0])
+            views.WorkspaceGroupSharingDelete.success_message, str(messages[0])
         )
 
     def test_only_deletes_specified_pk(self):

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -8857,7 +8857,6 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_get_workspace_not_found(self):
         """Raises a 404 error when workspace does not exist."""
-        print(self.get_url("foo", "bar", self.workspace_type))
         request = self.factory.get(self.get_url("foo", "bar", self.workspace_type))
         request.user = self.user
         with self.assertRaises(Http404):

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -3,6 +3,7 @@ from django import VERSION as DJANGO_VERSION
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.mixins import LoginRequiredMixin
+from django.contrib.messages.views import SuccessMessageMixin
 from django.contrib.sites.shortcuts import get_current_site
 from django.core.exceptions import ImproperlyConfigured
 from django.db import transaction
@@ -78,23 +79,6 @@ else:
         """
 
         template_name_suffix = "_confirm_delete"
-
-
-class SuccessMessageMixin:
-    """Mixin to add a success message to views."""
-
-    @property
-    def success_msg(self):
-        return NotImplemented
-
-    def add_success_message(self):
-        """Add a success message to the request."""
-        messages.success(self.request, self.success_msg)
-
-    def form_valid(self, form):
-        """Automatically add a success message when the form is valid."""
-        self.add_success_message()
-        return super().form_valid(form)
 
 
 class AnVILAuditMixin:
@@ -177,7 +161,7 @@ class BillingProjectImport(
     message_not_users_of_billing_project = (
         "Not a user of requested billing project or it doesn't exist on AnVIL."
     )
-    success_msg = "Successfully imported Billing Project from AnVIL."
+    success_message = "Successfully imported Billing Project from AnVIL."
 
     def form_valid(self, form):
         """If the form is valid, check that we can access the BillingProject on AnVIL and save the associated model."""
@@ -199,7 +183,7 @@ class BillingProjectImport(
             )
             return self.render_to_response(self.get_context_data(form=form))
 
-        messages.add_message(self.request, messages.SUCCESS, self.success_msg)
+        messages.add_message(self.request, messages.SUCCESS, self.success_message)
         return HttpResponseRedirect(self.get_success_url())
 
 
@@ -212,7 +196,7 @@ class BillingProjectUpdate(
     slug_field = "name"
     form_class = forms.BillingProjectUpdateForm
     template_name = "anvil_consortium_manager/billingproject_update.html"
-    success_msg = "Successfully updated Billing Project."
+    success_message = "Successfully updated Billing Project."
 
 
 class BillingProjectDetail(
@@ -353,7 +337,7 @@ class AccountImport(
     form_class = forms.AccountImportForm
     """A string that can be displayed if the account does not exist on AnVIL."""
 
-    success_msg = "Successfully imported Account from AnVIL."
+    success_message = "Successfully imported Account from AnVIL."
     """A string that can be displayed if the account was imported successfully."""
 
     def form_valid(self, form):
@@ -387,7 +371,7 @@ class AccountUpdate(
     model = models.Account
     form_class = forms.AccountUpdateForm
     template_name = "anvil_consortium_manager/account_update.html"
-    success_msg = "Successfully updated Account."
+    success_message = "Successfully updated Account."
 
 
 class AccountLink(LoginRequiredMixin, SuccessMessageMixin, FormView):
@@ -402,7 +386,7 @@ class AccountLink(LoginRequiredMixin, SuccessMessageMixin, FormView):
         "An AnVIL Account with this email already exists in this app."
     )
     form_class = forms.UserEmailEntryForm
-    success_msg = (
+    success_message = (
         "To complete linking the account, check your email for a verification link."
     )
 
@@ -614,7 +598,7 @@ class AccountDeactivate(
     context_table_name = "group_table"
     message_error_removing_from_groups = "Error removing account from groups; manually verify group memberships on AnVIL. (AnVIL API Error: {})"  # noqa
     message_already_inactive = "This Account is already inactive."
-    success_msg = "Successfully deactivated Account in app."
+    success_message = "Successfully deactivated Account in app."
 
     def get_table(self):
         return tables.GroupAccountMembershipTable(
@@ -659,7 +643,7 @@ class AccountDeactivate(
             return HttpResponseRedirect(self.object.get_absolute_url())
         else:
             # Need to add the message because we're not calling the super method.
-            messages.success(self.request, self.success_msg)
+            messages.success(self.request, self.success_message)
             return HttpResponseRedirect(self.get_success_url())
 
 
@@ -678,7 +662,7 @@ class AccountReactivate(
     template_name = "anvil_consortium_manager/account_confirm_reactivate.html"
     message_error_adding_to_groups = "Error adding account to groups; manually verify group memberships on AnVIL. (AnVIL API Error: {})"  # noqa
     message_already_active = "This Account is already active."
-    success_msg = "Successfully reactivated Account in app."
+    success_message = "Successfully reactivated Account in app."
 
     def get_success_url(self):
         return self.object.get_absolute_url()
@@ -735,7 +719,7 @@ class AccountDelete(
 ):
     model = models.Account
     message_error_removing_from_groups = "Error removing account from groups; manually verify group memberships on AnVIL. (AnVIL API Error: {})"  # noqa
-    success_msg = "Successfully deleted Account from app."
+    success_message = "Successfully deleted Account from app."
 
     def get_success_url(self):
         return reverse("anvil_consortium_manager:accounts:list")
@@ -844,7 +828,7 @@ class ManagedGroupCreate(
     model = models.ManagedGroup
     form_class = forms.ManagedGroupCreateForm
     template_name = "anvil_consortium_manager/managedgroup_create.html"
-    success_msg = "Successfully created Managed Group on AnVIL."
+    success_message = "Successfully created Managed Group on AnVIL."
 
     def form_valid(self, form):
         """If the form is valid, save the associated model and create it on AnVIL."""
@@ -874,7 +858,7 @@ class ManagedGroupUpdate(
     form_class = forms.ManagedGroupUpdateForm
     slug_field = "name"
     template_name = "anvil_consortium_manager/managedgroup_update.html"
-    success_msg = "Successfully updated ManagedGroup."
+    success_message = "Successfully updated ManagedGroup."
 
 
 class ManagedGroupList(auth.AnVILConsortiumManagerViewRequired, SingleTableView):
@@ -907,7 +891,7 @@ class ManagedGroupDelete(
     message_could_not_delete_group_from_anvil = (
         "Cannot not delete group from AnVIL - unknown reason."
     )
-    success_msg = "Successfully deleted Group on AnVIL."
+    success_message = "Successfully deleted Group on AnVIL."
 
     def get_success_url(self):
         return reverse("anvil_consortium_manager:managed_groups:list")
@@ -981,7 +965,9 @@ class ManagedGroupDelete(
             with transaction.atomic():
                 self.object.delete()
                 self.object.anvil_delete()
-                self.add_success_message()
+                success_message = self.get_success_message(form.cleaned_data)
+                if success_message:
+                    messages.success(self.request, success_message)
                 response = HttpResponseRedirect(self.get_success_url())
         except (ProtectedError, RestrictedError):
             messages.add_message(
@@ -1158,7 +1144,7 @@ class WorkspaceCreate(
     FormView,
 ):
     form_class = forms.WorkspaceCreateForm
-    success_msg = "Successfully created Workspace on AnVIL."
+    success_message = "Successfully created Workspace on AnVIL."
     template_name = "anvil_consortium_manager/workspace_create.html"
 
     def get_workspace_data_formset(self):
@@ -1272,7 +1258,7 @@ class WorkspaceImport(
     message_workspace_exists = "This workspace already exists in the web app."
     message_error_fetching_workspaces = "Unable to fetch workspaces from AnVIL."
     message_no_available_workspaces = "No workspaces available for import from AnVIL."
-    success_msg = "Successfully imported Workspace from AnVIL."
+    success_message = "Successfully imported Workspace from AnVIL."
     # Set in a method.
     workspace_choices = None
 
@@ -1413,7 +1399,7 @@ class WorkspaceClone(
 ):
     model = models.Workspace
     form_class = forms.WorkspaceCloneForm
-    success_msg = "Successfully created Workspace on AnVIL."
+    success_message = "Successfully created Workspace on AnVIL."
     template_name = "anvil_consortium_manager/workspace_clone.html"
 
     def get_object(self, queryset=None):
@@ -1567,7 +1553,7 @@ class WorkspaceUpdate(
     form_class = forms.WorkspaceUpdateForm
     slug_field = "name"
     template_name = "anvil_consortium_manager/workspace_update.html"
-    success_msg = "Successfully updated Workspace."
+    success_message = "Successfully updated Workspace."
 
     def get_object(self, queryset=None):
         """Return the object the view is displaying."""
@@ -1699,7 +1685,7 @@ class WorkspaceDelete(
     auth.AnVILConsortiumManagerEditRequired, SuccessMessageMixin, DeleteView
 ):
     model = models.Workspace
-    success_msg = "Successfully deleted Workspace on AnVIL."
+    success_message = "Successfully deleted Workspace on AnVIL."
     message_could_not_delete_workspace_from_app = (
         "Cannot delete workspace from app due to foreign key restrictions."
     )
@@ -1742,7 +1728,9 @@ class WorkspaceDelete(
             with transaction.atomic():
                 self.object.delete()
                 self.object.anvil_delete()
-                self.add_success_message()
+                success_message = self.get_success_message(form.cleaned_data)
+                if success_message:
+                    messages.success(self.request, success_message)
                 response = HttpResponseRedirect(self.get_success_url())
         except (ProtectedError, RestrictedError):
             messages.add_message(
@@ -1874,7 +1862,7 @@ class GroupGroupMembershipCreate(
 ):
     model = models.GroupGroupMembership
     form_class = forms.GroupGroupMembershipForm
-    success_msg = "Successfully created group membership."
+    success_message = "Successfully created group membership."
 
     def get_success_url(self):
         return reverse("anvil_consortium_manager:group_group_membership:list")
@@ -2101,7 +2089,7 @@ class GroupGroupMembershipDelete(
     auth.AnVILConsortiumManagerEditRequired, SuccessMessageMixin, DeleteView
 ):
     model = models.GroupGroupMembership
-    success_msg = "Successfully deleted group membership on AnVIL."
+    success_message = "Successfully deleted group membership on AnVIL."
 
     message_parent_group_not_managed_by_app = (
         "Cannot remove members from parent group because it is not managed by this app."
@@ -2215,7 +2203,7 @@ class GroupAccountMembershipCreate(
 ):
     model = models.GroupAccountMembership
     form_class = forms.GroupAccountMembershipForm
-    success_msg = "Successfully added account membership."
+    success_message = "Successfully added account membership."
 
     def get_success_url(self):
         return reverse("anvil_consortium_manager:group_account_membership:list")
@@ -2467,7 +2455,7 @@ class GroupAccountMembershipDelete(
     auth.AnVILConsortiumManagerEditRequired, SuccessMessageMixin, DeleteView
 ):
     model = models.GroupAccountMembership
-    success_msg = "Successfully deleted account membership on AnVIL."
+    success_message = "Successfully deleted account membership on AnVIL."
 
     message_group_not_managed_by_app = (
         "Cannot remove members from group because it is not managed by this app."
@@ -2582,7 +2570,7 @@ class WorkspaceGroupSharingCreate(
 
     model = models.WorkspaceGroupSharing
     form_class = forms.WorkspaceGroupSharingForm
-    success_msg = "Successfully shared Workspace with Group."
+    success_message = "Successfully shared Workspace with Group."
     """Message to display when the WorkspaceGroupSharing object was successfully created in the app and on AnVIL."""
 
     message_group_not_found = "Managed Group not found on AnVIL."
@@ -2622,7 +2610,7 @@ class WorkspaceGroupSharingCreateByWorkspace(WorkspaceGroupSharingCreate):
     template_name = (
         "anvil_consortium_manager/workspacegroupsharing_form_byworkspace.html"
     )
-    success_msg = "Successfully shared Workspace with Group."
+    success_message = "Successfully shared Workspace with Group."
     """Message to display when the WorkspaceGroupSharing object was successfully created in the app and on AnVIL."""
 
     message_group_not_found = "Managed Group not found on AnVIL."
@@ -2677,7 +2665,7 @@ class WorkspaceGroupSharingCreateByGroup(WorkspaceGroupSharingCreate):
     model = models.WorkspaceGroupSharing
     form_class = forms.WorkspaceGroupSharingForm
     template_name = "anvil_consortium_manager/workspacegroupsharing_form_bygroup.html"
-    success_msg = "Successfully shared Workspace with Group."
+    success_message = "Successfully shared Workspace with Group."
     """Message to display when the WorkspaceGroupSharing object was successfully created in the app and on AnVIL."""
 
     message_group_not_found = "Managed Group not found on AnVIL."
@@ -2731,7 +2719,7 @@ class WorkspaceGroupSharingCreateByWorkspaceGroup(WorkspaceGroupSharingCreate):
     template_name = (
         "anvil_consortium_manager/workspacegroupsharing_form_byworkspacegroup.html"
     )
-    success_msg = "Successfully shared Workspace with Group."
+    success_message = "Successfully shared Workspace with Group."
     """Message to display when the WorkspaceGroupSharing object was successfully created in the app and on AnVIL."""
 
     message_group_not_found = "Managed Group not found on AnVIL."
@@ -2818,7 +2806,7 @@ class WorkspaceGroupSharingUpdate(
         "can_compute",
     )
     template_name = "anvil_consortium_manager/workspacegroupsharing_update.html"
-    success_msg = "Successfully updated Workspace sharing."
+    success_message = "Successfully updated Workspace sharing."
     """Message to display when the WorkspaceGroupSharing object was successfully updated."""
 
     def get_object(self, queryset=None):
@@ -2880,7 +2868,7 @@ class WorkspaceGroupSharingDelete(
     auth.AnVILConsortiumManagerEditRequired, SuccessMessageMixin, DeleteView
 ):
     model = models.WorkspaceGroupSharing
-    success_msg = "Successfully removed workspace sharing on AnVIL."
+    success_message = "Successfully removed workspace sharing on AnVIL."
 
     def get_object(self, queryset=None):
         """Return the object the view is displaying."""

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -1481,7 +1481,6 @@ class WorkspaceClone(
                 workspace_data_formset.forms[0].save()
                 # Then create the workspace on AnVIL.
                 authorization_domains = self.new_workspace.authorization_domains.all()
-                print(authorization_domains)
                 self.object.anvil_clone(
                     self.new_workspace.billing_project,
                     self.new_workspace.name,

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -10,6 +10,7 @@ django-stubs==1.9.0  # https://github.com/typeddjango/django-stubs
 pytest==7.2.1  # https://github.com/pytest-dev/pytest
 pytest-sugar==0.9.4  # https://github.com/Frozenball/pytest-sugar
 freezegun==1.2.2  # https://github.com/spulec/freezegun - Fixing the time in tests.
+tox==4.4.2
 
 # Documentation
 # ------------------------------------------------------------------------------

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py{38,39,310}-django{32,41}-{sqlite,mariadb}
+envlist = py{38,39,310}-django{32,41}-{sqlite,mysql}
 isolated_build = true
 
 [testenv]
@@ -13,7 +13,7 @@ deps =
     coverage
     django-coverage-plugin
     freezegun
-    mariadb: mysqlclient
+    mysql: mysqlclient
 passenv =
     DBNAME
     DBUSER
@@ -24,7 +24,7 @@ passenv =
 commands =
     coverage run -p ./manage.py test anvil_consortium_manager --settings=anvil_consortium_manager.tests.settings.test
 
-[testenv:py{38,39,310}-django{32,41}-mariadb]
+[testenv:py{38,39,310}-django{32,41}-mysql]
 setenv =
     DBBACKEND = mysql
 
@@ -37,4 +37,4 @@ python =
 [gh-actions:env]
 DBBACKEND =
     sqlite3: sqlite
-    mariadb: mariadb
+    mysql: mysql

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py{38,39,310}-django{32,41}-{sqlite,mariadb},cov
+envlist = py{38,39,310}-django{32,41}-{sqlite,mariadb}
 isolated_build = true
 
 [testenv]
@@ -23,8 +23,6 @@ passenv =
     DBPORT
 commands =
     coverage run -p ./manage.py test anvil_consortium_manager --settings=anvil_consortium_manager.tests.settings.test
-    cov: coverage combine
-    cov: coverage xml
 
 [testenv:py{38,39,310}-django{32,41}-mariadb]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,12 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py{38,39,310}-{sqlite,mariadb}
+envlist = py{38,39,310}-django{32,40}-{sqlite,mariadb}
 isolated_build = true
 
 [testenv]
 deps =
-    Django==3.2.*
+    django32: Django==3.2.*
+    django40: Django==4.0.*
     responses
     factory-boy
     coverage

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,13 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py{38,39,310}-django{32,40}-{sqlite,mariadb}
+envlist = py{38,39,310}-django{32,41}-{sqlite,mariadb}
 isolated_build = true
 
 [testenv]
 deps =
     django32: Django==3.2.*
     django40: Django==4.0.*
+    django41: Django==4.1.*
     responses
     factory-boy
     coverage

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
-envlist = py{38,39,310}-django{32,41}-{sqlite,mariadb}
+envlist = py{38,39,310}-django{32,41}-{sqlite,mariadb},cov
 isolated_build = true
 
 [testenv]
@@ -16,9 +16,10 @@ deps =
     mariadb: mysqlclient
 passenv = *
 commands =
-    sqlite: coverage run ./manage.py test anvil_consortium_manager --settings=anvil_consortium_manager.tests.settings.test
-    mariadb: coverage run ./manage.py test anvil_consortium_manager --settings=anvil_consortium_manager.tests.settings.test_mariadb
-    coverage xml
+    sqlite: coverage run -p ./manage.py test anvil_consortium_manager --settings=anvil_consortium_manager.tests.settings.test
+    mariadb: coverage run -p ./manage.py test anvil_consortium_manager --settings=anvil_consortium_manager.tests.settings.test_mariadb
+    cov: coverage combine
+    cov: coverage xml
 
 [gh-actions]
 python =

--- a/tox.ini
+++ b/tox.ini
@@ -14,12 +14,21 @@ deps =
     django-coverage-plugin
     freezegun
     mariadb: mysqlclient
-passenv = *
+passenv =
+    DBNAME
+    DBUSER
+    DBPASSWORD
+    DBHOST
+    DBBACKEND
+    DBPORT
 commands =
-    sqlite: coverage run -p ./manage.py test anvil_consortium_manager --settings=anvil_consortium_manager.tests.settings.test
-    mariadb: coverage run -p ./manage.py test anvil_consortium_manager --settings=anvil_consortium_manager.tests.settings.test_mariadb
+    coverage run -p ./manage.py test anvil_consortium_manager --settings=anvil_consortium_manager.tests.settings.test
     cov: coverage combine
     cov: coverage xml
+
+[testenv:py{38,39,310}-django{32,41}-mariadb]
+setenv =
+    DBBACKEND = mysql
 
 [gh-actions]
 python =
@@ -28,6 +37,6 @@ python =
     3.10: py310
 
 [gh-actions:env]
-BACKEND =
-    sqlite: sqlite
+DBBACKEND =
+    sqlite3: sqlite
     mariadb: mariadb

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,12 @@ commands =
 setenv =
     DBBACKEND = mysql
 
+[testenv:py{38,39,310}-dj{32,41}-sqlite]
+setenv =
+    {[testenv]setenv}
+    DBBACKEND = sqlite3
+    DBNAME = ":memory:"
+
 [gh-actions]
 python =
     3.8: py38


### PR DESCRIPTION
Add test support for Django 4.1.

- Redefine DeleteView to match the Django 4.1 behavior (with a FormView).
- Because delete views now use a FormView, use the built-in Django `SuccessMessageMixin`.
- Skip the case-insensitive uniqueness check in the `WorkspaceCreateForm` on mariadb with Django 4.1+.

Closes #194  