### PR TITLE
Fix incorrect urls in group membership detail pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Devel
 
-- Support Django 4.1.*
+- Support Django 4.1.*.
+- Fix broken links in group membership deatil pages.
 
 ## 0.11 (2023-02-24)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.12dev1"
+__version__ = "0.12dev2"

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/groupaccountmembership_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/groupaccountmembership_detail.html
@@ -5,7 +5,7 @@
 
 {% block panel %}
 <dl class="row">
-  <dt class="col-sm-2">Group</dt> <dd class="col-sm-10"><a href="{{ object.billing_project.get_absolute_url }}">{{ object.group }}</a></dd>
+  <dt class="col-sm-2">Group</dt> <dd class="col-sm-10"><a href="{{ object.group.get_absolute_url }}">{{ object.group }}</a></dd>
   <dt class="col-sm-2">Account</dt> <dd class="col-sm-10"><a href="{{ object.account.get_absolute_url }}">{{ object.account }}</a></dd>
   <dt class="col-sm-2">Role</dt> <dd class="col-sm-10">{{ object.role }}</dd>
   <dt class="col-sm-2">Date created</dt> <dd class="col-sm-10">{{ object.created }}</dd>

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/groupgroupmembership_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/groupgroupmembership_detail.html
@@ -9,8 +9,8 @@
 <h2>Group Group Membership Details</h2>
 <div class="my-3 p-3 bg-light border rounded shadow-sm">
   <dl class="row">
-    <dt class="col-sm-2">Parent group</dt> <dd class="col-sm-10"><a href="{{ object.billing_project.get_absolute_url }}">{{ object.parent_group }}</a></dd>
-    <dt class="col-sm-2">Child group</dt> <dd class="col-sm-10"><a href="{{ object.account.get_absolute_url }}">{{ object.child_group }}</a></dd>
+    <dt class="col-sm-2">Parent group</dt> <dd class="col-sm-10"><a href="{{ object.parent_group.get_absolute_url }}">{{ object.parent_group }}</a></dd>
+    <dt class="col-sm-2">Child group</dt> <dd class="col-sm-10"><a href="{{ object.child_group.get_absolute_url }}">{{ object.child_group }}</a></dd>
     <dt class="col-sm-2">Role</dt> <dd class="col-sm-10">{{ object.role }}</dd>
     <dt class="col-sm-2">Date created</dt> <dd class="col-sm-10">{{ object.created }}</dd>
     <dt class="col-sm-2">Date modified</dt> <dd class="col-sm-10">{{ object.modified }}</dd>

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -11331,6 +11331,20 @@ class GroupGroupMembershipDetailTest(TestCase):
             ),
         )
 
+    def test_detail_page_links(self):
+        """Links to other urls appear correctly."""
+        self.client.force_login(self.user)
+        obj = factories.GroupGroupMembershipFactory.create()
+        response = self.client.get(obj.get_absolute_url())
+        html = """<a href="{url}">{text}</a>""".format(
+            url=obj.parent_group.get_absolute_url(), text=str(obj.parent_group)
+        )
+        self.assertContains(response, html)
+        html = """<a href="{url}">{text}</a>""".format(
+            url=obj.child_group.get_absolute_url(), text=str(obj.child_group)
+        )
+        self.assertContains(response, html)
+
 
 class GroupGroupMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):
 
@@ -14188,6 +14202,20 @@ class GroupAccountMembershipDetailTest(TestCase):
                 },
             ),
         )
+
+    def test_detail_page_links(self):
+        """Links to other object detail pages appear correctly."""
+        self.client.force_login(self.user)
+        obj = factories.GroupAccountMembershipFactory.create()
+        response = self.client.get(obj.get_absolute_url())
+        html = """<a href="{url}">{text}</a>""".format(
+            url=obj.group.get_absolute_url(), text=str(obj.group)
+        )
+        self.assertContains(response, html)
+        html = """<a href="{url}">{text}</a>""".format(
+            url=obj.account.get_absolute_url(), text=str(obj.account)
+        )
+        self.assertContains(response, html)
 
 
 class GroupAccountMembershipCreateTest(AnVILAPIMockTestMixin, TestCase):


### PR DESCRIPTION
The GroupAccountMembershipDetail and GroupGroupMembershipDetail templates had incorrect links for the groups. Fix the links in the templates and add tests to make sure the correct links appear.

Closes #279