### PR TITLE
Add last update date to membership and sharing tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Devel
 
 - Support Django 4.1.*.
-- Fix broken links in group membership deatil pages.
+- Fix broken links in group membership detail pages.
+- Add last update date to GroupGroupMembership, GroupAccountMembership, and WorkspaceGroupSharing tables.
 
 ## 0.11 (2023-02-24)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.12dev2"
+__version__ = "0.12dev3"

--- a/anvil_consortium_manager/tables.py
+++ b/anvil_consortium_manager/tables.py
@@ -113,6 +113,7 @@ class GroupGroupMembershipTable(tables.Table):
     parent_group = tables.Column(linkify=True)
     child_group = tables.Column(linkify=True)
     role = tables.Column()
+    last_update = tables.DateTimeColumn(verbose_name="Last update", accessor="modified")
 
     class Meta:
         models = models.GroupAccountMembership
@@ -131,6 +132,7 @@ class GroupAccountMembershipTable(tables.Table):
     status = tables.Column(accessor="account__status")
     group = tables.Column(linkify=True)
     role = tables.Column()
+    last_update = tables.DateTimeColumn(verbose_name="Last update", accessor="modified")
 
     class Meta:
         models = models.GroupAccountMembership
@@ -147,6 +149,8 @@ class WorkspaceGroupSharingTable(tables.Table):
     workspace = tables.Column(linkify=True)
     group = tables.Column(linkify=True)
     access = tables.Column()
+    can_compute = tables.BooleanColumn(verbose_name="Compute allowed?")
+    last_update = tables.DateTimeColumn(verbose_name="Last update", accessor="modified")
 
     class Meta:
         model = models.WorkspaceGroupSharing

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -2079,10 +2079,6 @@ class GroupGroupMembershipList(
 ):
     model = models.GroupGroupMembership
     table_class = tables.GroupGroupMembershipTable
-    ordering = (
-        "parent_group__name",
-        "child_group__name",
-    )
 
 
 class GroupGroupMembershipDelete(
@@ -2413,10 +2409,6 @@ class GroupAccountMembershipList(
 
     model = models.GroupAccountMembership
     table_class = tables.GroupAccountMembershipTable
-    ordering = (
-        "group__name",
-        "account__email",
-    )
 
 
 class GroupAccountMembershipActiveList(
@@ -2857,11 +2849,6 @@ class WorkspaceGroupSharingList(
 ):
     model = models.WorkspaceGroupSharing
     table_class = tables.WorkspaceGroupSharingTable
-    ordering = (
-        "workspace__billing_project__name",
-        "workspace__name",
-        "group__name",
-    )
 
 
 class WorkspaceGroupSharingDelete(


### PR DESCRIPTION
Add the last update date to the WorkspaceGroupSharing table and to the GroupGroupMembership and GroupAccountMembership tables.

Closes #281