### PR TITLE
Load media for workspace_data_formset in workspace edit templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Support Django 4.1.*.
 - Fix broken links in group membership detail pages.
 - Add last update date to GroupGroupMembership, GroupAccountMembership, and WorkspaceGroupSharing tables.
+- Load workspace data form media in workspace editing templates.
 
 ## 0.11 (2023-02-24)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.12dev3"
+__version__ = "0.12dev4"

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_clone.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_clone.html
@@ -20,4 +20,5 @@
 
 {% block inline_javascript %}
   {{ form.media }}
+  {{ workspace_data_formset.media }}
 {% endblock inline_javascript %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_create.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_create.html
@@ -20,4 +20,5 @@
 
 {% block inline_javascript %}
   {{ form.media }}
+  {{ workspace_data_formset.media }}
 {% endblock inline_javascript %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_import.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_import.html
@@ -14,3 +14,8 @@
     <button type="submit" class="btn btn-success">Import</button>
   </form>
 {% endblock %}
+
+{% block inline_javascript %}
+  {{ form.media }}
+  {{ workspace_data_formset.media }}
+{% endblock inline_javascript %}


### PR DESCRIPTION
If a workspace data form requires media, it needs to be loaded in the template.