### PR TITLE
Bugfix/account accessible workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Fix broken links in group membership detail pages.
 - Add last update date to GroupGroupMembership, GroupAccountMembership, and WorkspaceGroupSharing tables.
 - Load workspace data form media in workspace editing templates.
+- Bugfix: Accessible workspaces for an account only includes workspaces that are shared with groups they are in.
 
 ## 0.11 (2023-02-24)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.12dev4"
+__version__ = "0.12dev5"

--- a/anvil_consortium_manager/models.py
+++ b/anvil_consortium_manager/models.py
@@ -383,15 +383,7 @@ class Account(TimeStampedModel, ActivatorModel):
         Returns:
             A list of workspaces that are accessible to the account.
         """
-        # get a list of all groups that an Account is in, directly and indirectly;
-        group_memberships = self.groupaccountmembership_set.all()
-        groups = []
-        for membership in group_memberships:
-            groups.append(membership.group)
-            parents = membership.group.get_all_parents()
-
-            for group in parents:
-                groups.append(group)
+        groups = self.get_all_groups()
         # check what workspaces have been shared with any of those groups;
         workspaces = WorkspaceGroupSharing.objects.filter(group__in=groups)
         # check if all the auth domains for each workspace are in the Account's set of groups.
@@ -402,6 +394,18 @@ class Account(TimeStampedModel, ActivatorModel):
             if len(set(authorized_domains).difference(set(groups))) == 0:
                 accessible_workspaces.add(ws.workspace)
         return accessible_workspaces
+
+    def get_all_groups(self):
+        """get a list of all groups that an Account is in, directly and indirectly"""
+        groups = set()
+        group_memberships = self.groupaccountmembership_set.all()
+        for membership in group_memberships:
+            groups.add(membership.group)
+            parents = membership.group.get_all_parents()
+
+            for group in parents:
+                groups.add(group)
+        return groups
 
 
 class ManagedGroup(TimeStampedModel):

--- a/anvil_consortium_manager/tests/test_models.py
+++ b/anvil_consortium_manager/tests/test_models.py
@@ -786,6 +786,7 @@ class AccountTest(TestCase):
         factories.GroupAccountMembershipFactory.create(group=group, account=account)
         groups = account.get_all_groups()
         self.assertEqual(len(groups), 1)
+        self.assertIn(group, groups)
 
     def test_get_all_groups_one_parent(self):
         """Two groups returned in the set"""
@@ -798,6 +799,8 @@ class AccountTest(TestCase):
         )
         groups = account.get_all_groups()
         self.assertEqual(len(groups), 2)
+        self.assertIn(parent, groups)
+        self.assertIn(child, groups)
 
     def test_get_all_groups_one_parent_account_in_both(self):
         """Two groups returned in the set when the account is in both child and parent groups"""
@@ -811,6 +814,8 @@ class AccountTest(TestCase):
         factories.GroupAccountMembershipFactory.create(group=parent, account=account)
         groups = account.get_all_groups()
         self.assertEqual(len(groups), 2)
+        self.assertIn(parent, groups)
+        self.assertIn(child, groups)
 
     def test_get_all_groups_one_grandparent(self):
         """Three groups returned in the set"""
@@ -827,6 +832,9 @@ class AccountTest(TestCase):
         )
         groups = account.get_all_groups()
         self.assertEqual(len(groups), 3)
+        self.assertIn(parent, groups)
+        self.assertIn(child, groups)
+        self.assertIn(grandparent, groups)
 
     def test_get_all_groups_one_parent_two_grandparents(self):
         """Four groups returned in the set"""
@@ -847,6 +855,10 @@ class AccountTest(TestCase):
         )
         groups = account.get_all_groups()
         self.assertEqual(len(groups), 4)
+        self.assertIn(parent, groups)
+        self.assertIn(child, groups)
+        self.assertIn(grandparent_1, groups)
+        self.assertIn(grandparent_2, groups)
 
     def test_get_all_groups_grandparent_is_also_parent(self):
         """Three groups returned when a child group has one parent and a grandparent.  The grandparent group is also a parent to the child's group"""  # noqa: E501
@@ -866,6 +878,9 @@ class AccountTest(TestCase):
         )
         groups = account.get_all_groups()
         self.assertEqual(len(groups), 3)
+        self.assertIn(parent, groups)
+        self.assertIn(child, groups)
+        self.assertIn(grandparent, groups)
 
     def test_get_all_groups_one_child(self):
         """Child groups are not returned."""

--- a/anvil_consortium_manager/tests/test_models.py
+++ b/anvil_consortium_manager/tests/test_models.py
@@ -779,6 +779,94 @@ class AccountTest(TestCase):
         self.assertEqual(len(accessible_workspaces), 1)
         self.assertIn(workspace, accessible_workspaces)
 
+    def test_get_all_groups_no_parents(self):
+        """One group returns in the set"""
+        account = factories.AccountFactory.create()
+        group = factories.ManagedGroupFactory.create()
+        factories.GroupAccountMembershipFactory.create(group=group, account=account)
+        groups = account.get_all_groups()
+        self.assertEqual(len(groups), 1)
+
+    def test_get_all_groups_one_parent(self):
+        """Two groups returned in the set"""
+        account = factories.AccountFactory.create()
+        child = factories.ManagedGroupFactory.create()
+        factories.GroupAccountMembershipFactory.create(group=child, account=account)
+        parent = factories.ManagedGroupFactory.create()
+        factories.GroupGroupMembershipFactory.create(
+            parent_group=parent, child_group=child
+        )
+        groups = account.get_all_groups()
+        self.assertEqual(len(groups), 2)
+
+    def test_get_all_groups_one_parent_account_in_both(self):
+        """Two groups returned in the set when the account is in both child and parent groups"""
+        account = factories.AccountFactory.create()
+        child = factories.ManagedGroupFactory.create()
+        factories.GroupAccountMembershipFactory.create(group=child, account=account)
+        parent = factories.ManagedGroupFactory.create()
+        factories.GroupGroupMembershipFactory.create(
+            parent_group=parent, child_group=child
+        )
+        factories.GroupAccountMembershipFactory.create(group=parent, account=account)
+        groups = account.get_all_groups()
+        self.assertEqual(len(groups), 2)
+
+    def test_get_all_groups_one_grandparent(self):
+        """Three groups returned in the set"""
+        account = factories.AccountFactory.create()
+        child = factories.ManagedGroupFactory.create()
+        factories.GroupAccountMembershipFactory.create(group=child, account=account)
+        parent = factories.ManagedGroupFactory.create()
+        factories.GroupGroupMembershipFactory.create(
+            parent_group=parent, child_group=child
+        )
+        grandparent = factories.ManagedGroupFactory.create()
+        factories.GroupGroupMembershipFactory.create(
+            parent_group=grandparent, child_group=parent
+        )
+        groups = account.get_all_groups()
+        self.assertEqual(len(groups), 3)
+
+    def test_get_all_groups_one_parent_two_grandparents(self):
+        """Four groups returned in the set"""
+        account = factories.AccountFactory.create()
+        child = factories.ManagedGroupFactory.create()
+        factories.GroupAccountMembershipFactory.create(group=child, account=account)
+        parent = factories.ManagedGroupFactory.create()
+        factories.GroupGroupMembershipFactory.create(
+            parent_group=parent, child_group=child
+        )
+        grandparent_1 = factories.ManagedGroupFactory.create()
+        factories.GroupGroupMembershipFactory.create(
+            parent_group=grandparent_1, child_group=parent
+        )
+        grandparent_2 = factories.ManagedGroupFactory.create()
+        factories.GroupGroupMembershipFactory.create(
+            parent_group=grandparent_2, child_group=parent
+        )
+        groups = account.get_all_groups()
+        self.assertEqual(len(groups), 4)
+
+    def test_get_all_groups_grandparent_is_also_parent(self):
+        """Three groups returned when a child group has one parent and a grandparent.  The grandparent group is also a parent to the child's group"""  # noqa: E501
+        account = factories.AccountFactory.create()
+        child = factories.ManagedGroupFactory.create()
+        factories.GroupAccountMembershipFactory.create(group=child, account=account)
+        parent = factories.ManagedGroupFactory.create()
+        factories.GroupGroupMembershipFactory.create(
+            parent_group=parent, child_group=child
+        )
+        grandparent = factories.ManagedGroupFactory.create()
+        factories.GroupGroupMembershipFactory.create(
+            parent_group=grandparent, child_group=parent
+        )
+        factories.GroupGroupMembershipFactory.create(
+            parent_group=grandparent, child_group=child
+        )
+        groups = account.get_all_groups()
+        self.assertEqual(len(groups), 3)
+
 
 class ManagedGroupTest(TestCase):
     def test_model_saving(self):

--- a/anvil_consortium_manager/tests/test_models.py
+++ b/anvil_consortium_manager/tests/test_models.py
@@ -867,6 +867,19 @@ class AccountTest(TestCase):
         groups = account.get_all_groups()
         self.assertEqual(len(groups), 3)
 
+    def test_get_all_groups_one_child(self):
+        """Child groups are not returned."""
+        account = factories.AccountFactory.create()
+        child = factories.ManagedGroupFactory.create()
+        parent = factories.ManagedGroupFactory.create()
+        factories.GroupGroupMembershipFactory.create(
+            parent_group=parent, child_group=child
+        )
+        factories.GroupAccountMembershipFactory.create(group=parent, account=account)
+        groups = account.get_all_groups()
+        self.assertEqual(len(groups), 1)
+        self.assertIn(parent, groups)
+
 
 class ManagedGroupTest(TestCase):
     def test_model_saving(self):

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -306,7 +306,8 @@ class AccountDetail(
         )
 
         workspace_sharing = models.WorkspaceGroupSharing.objects.filter(
-            workspace__in=self.object.get_accessible_workspaces()
+            workspace__in=self.object.get_accessible_workspaces(),
+            group__in=self.object.get_all_groups(),
         ).order_by("workspace", "group")
 
         context["accessible_workspace_table"] = tables.WorkspaceGroupSharingTable(


### PR DESCRIPTION
- Separate out the code that gets the account's list of groups from get_accessible_workspaces()
- Add Account.get_all_groups() 
- Filter WorkspaceGroupSharing in Account detail view to show the list of workspaces returned by Account.get_accessible_workspaces() and Account.get_all_parent_groups().