### PR TITLE
Feature/workspace autocomplete by type

### DIFF
--- a/anvil_consortium_manager/adapters/workspace.py
+++ b/anvil_consortium_manager/adapters/workspace.py
@@ -107,6 +107,14 @@ class BaseWorkspaceAdapter(ABC):
             raise ImproperlyConfigured("Set `workspace_detail_template_name`.")
         return self.workspace_detail_template_name
 
+    def get_autocomplete_queryset(self, queryset, q):
+        """Return the queryset after filtering for WorkspaceAutocompleteByType view.
+
+        The default filtering is that the workspace name contains the queryset, case-
+        insensitive. If desired, custom autocomplete filtering for a workspace type can
+        be implemented by overriding this method."""
+        return queryset.filter(name__icontains=q)
+
 
 class AdapterAlreadyRegisteredError(Exception):
     """Exception raised when an adapter or its type is already registered."""

--- a/anvil_consortium_manager/tests/test_app/adapters.py
+++ b/anvil_consortium_manager/tests/test_app/adapters.py
@@ -15,6 +15,9 @@ class TestWorkspaceAdapter(BaseWorkspaceAdapter):
     workspace_data_form_class = forms.TestWorkspaceDataForm
     workspace_detail_template_name = "test_workspace_detail.html"
 
+    def get_autocomplete_queryset(self, queryset, q):
+        return queryset.filter(name=q)
+
 
 class TestAccountAdapter(BaseAccountAdapter):
     """Test adapter for accounts."""

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -10855,6 +10855,14 @@ class WorkspaceDeleteTest(AnVILAPIMockTestMixin, TestCase):
             )
         )
 
+    def tearDown(self):
+        """Clean up after tests."""
+        # Unregister all adapters.
+        workspace_adapter_registry._registry = {}
+        # Register the default adapter.
+        workspace_adapter_registry.register(DefaultWorkspaceAdapter)
+        super().tearDown()
+
     def get_url(self, *args):
         """Get the url for the view being tested."""
         return reverse("anvil_consortium_manager:workspaces:delete", args=args)

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -11321,6 +11321,178 @@ class WorkspaceAutocompleteTest(TestCase):
         self.assertEqual(returned_ids[0], workspace.pk)
 
 
+class WorkspaceAutocompleteByTypeTest(TestCase):
+    """Tests for the WorkspaceAutocompleteByType view."""
+
+    def setUp(self):
+        """Set up test class."""
+        self.factory = RequestFactory()
+        # Create a user with the correct permissions.
+        self.user = User.objects.create_user(username="test", password="test")
+        self.user.user_permissions.add(
+            Permission.objects.get(
+                codename=models.AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME
+            )
+        )
+        self.workspace_type = DefaultWorkspaceAdapter().get_type()
+        workspace_adapter_registry.register(TestWorkspaceAdapter)
+
+    def tearDown(self):
+        workspace_adapter_registry.unregister(TestWorkspaceAdapter)
+
+    def get_url(self, *args):
+        """Get the url for the view being tested."""
+        return reverse(
+            "anvil_consortium_manager:workspaces:autocomplete_by_type", args=args
+        )
+
+    def get_view(self):
+        """Return the view being tested."""
+        return views.WorkspaceAutocompleteByType.as_view()
+
+    def test_view_redirect_not_logged_in(self):
+        "View redirects to login view when user is not logged in."
+        # Need a client for redirects.
+        response = self.client.get(self.get_url(self.workspace_type))
+        self.assertRedirects(
+            response,
+            resolve_url(settings.LOGIN_URL)
+            + "?next="
+            + self.get_url(self.workspace_type),
+        )
+
+    def test_status_code_with_user_permission(self):
+        """Returns successful response code."""
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url(self.workspace_type))
+        self.assertEqual(response.status_code, 200)
+
+    def test_access_without_user_permission(self):
+        """Raises permission denied if user has no permissions."""
+        user_no_perms = User.objects.create_user(
+            username="test-none", password="test-none"
+        )
+        request = self.factory.get(self.get_url(self.workspace_type))
+        request.user = user_no_perms
+        with self.assertRaises(PermissionDenied):
+            self.get_view()(request, workspace_type=self.workspace_type)
+
+    def test_404_with_unregistered_workspace_type(self):
+        """Raises 404 with get request if workspace type is not registered with adapter."""
+        request = self.factory.get(self.get_url("foo"))
+        request.user = self.user
+        with self.assertRaises(Http404):
+            self.get_view()(request, workspace_type="foo")
+
+    def test_returns_all_objects(self):
+        """Queryset returns all objects when there is no query."""
+        workspaces = factories.WorkspaceFactory.create_batch(10)
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url(self.workspace_type))
+        returned_ids = [
+            int(x["id"])
+            for x in json.loads(response.content.decode("utf-8"))["results"]
+        ]
+        self.assertEqual(len(returned_ids), 10)
+        self.assertEqual(
+            sorted(returned_ids), sorted([workspace.pk for workspace in workspaces])
+        )
+
+    def test_returns_correct_object_match(self):
+        """Queryset returns the correct objects when query matches the name."""
+        workspace = factories.WorkspaceFactory.create(name="test-workspace")
+        self.client.force_login(self.user)
+        response = self.client.get(
+            self.get_url(self.workspace_type), {"q": "test-workspace"}
+        )
+        returned_ids = [
+            int(x["id"])
+            for x in json.loads(response.content.decode("utf-8"))["results"]
+        ]
+        self.assertEqual(len(returned_ids), 1)
+        self.assertEqual(returned_ids[0], workspace.pk)
+
+    def test_returns_correct_object_starting_with_query(self):
+        """Queryset returns the correct objects when query matches the beginning of the name."""
+        workspace = factories.WorkspaceFactory.create(name="test-workspace")
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url(self.workspace_type), {"q": "test"})
+        returned_ids = [
+            int(x["id"])
+            for x in json.loads(response.content.decode("utf-8"))["results"]
+        ]
+        self.assertEqual(len(returned_ids), 1)
+        self.assertEqual(returned_ids[0], workspace.pk)
+
+    def test_returns_correct_object_containing_query(self):
+        """Queryset returns the correct objects when the name contains the query."""
+        workspace = factories.WorkspaceFactory.create(name="test-workspace")
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url(self.workspace_type), {"q": "work"})
+        returned_ids = [
+            int(x["id"])
+            for x in json.loads(response.content.decode("utf-8"))["results"]
+        ]
+        self.assertEqual(len(returned_ids), 1)
+        self.assertEqual(returned_ids[0], workspace.pk)
+
+    def test_returns_correct_object_case_insensitive(self):
+        """Queryset returns the correct objects when query matches the beginning of the name."""
+        workspace = factories.WorkspaceFactory.create(name="test-workspace")
+        self.client.force_login(self.user)
+        response = self.client.get(
+            self.get_url(self.workspace_type), {"q": "TEST-WORKSPACE"}
+        )
+        returned_ids = [
+            int(x["id"])
+            for x in json.loads(response.content.decode("utf-8"))["results"]
+        ]
+        self.assertEqual(len(returned_ids), 1)
+        self.assertEqual(returned_ids[0], workspace.pk)
+
+    def test_only_specified_workspace_type(self):
+        """Queryset returns only objects with the specified workspace type."""
+        workspace = factories.WorkspaceFactory.create()
+        other_workspace = factories.WorkspaceFactory.create(
+            workspace_type=TestWorkspaceAdapter().get_type()
+        )
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url(workspace.workspace_type))
+        returned_ids = [
+            int(x["id"])
+            for x in json.loads(response.content.decode("utf-8"))["results"]
+        ]
+        self.assertEqual(len(returned_ids), 1)
+        self.assertEqual(returned_ids[0], workspace.pk)
+        response = self.client.get(self.get_url(other_workspace.workspace_type))
+        returned_ids = [
+            int(x["id"])
+            for x in json.loads(response.content.decode("utf-8"))["results"]
+        ]
+        self.assertEqual(len(returned_ids), 1)
+        self.assertEqual(returned_ids[0], other_workspace.pk)
+
+    def test_custom_autocomplete_method(self):
+        # Workspace that will match the custom autocomplete filtering.
+        workspace_1 = factories.WorkspaceFactory.create(
+            name="TEST", workspace_type=TestWorkspaceAdapter().get_type()
+        )
+        # Workspace that should not match the custom autocomplete filtering.
+        factories.WorkspaceFactory.create(
+            name="TEST-WORKSPACE", workspace_type=TestWorkspaceAdapter().get_type()
+        )
+        self.client.force_login(self.user)
+        response = self.client.get(
+            self.get_url(workspace_1.workspace_type), {"q": "TEST"}
+        )
+        returned_ids = [
+            int(x["id"])
+            for x in json.loads(response.content.decode("utf-8"))["results"]
+        ]
+        self.assertEqual(len(returned_ids), 1)
+        self.assertEqual(returned_ids[0], workspace_1.pk)
+
+
 class WorkspaceAuditTest(AnVILAPIMockTestMixin, TestCase):
     """Tests for the WorkspaceAudit view."""
 

--- a/anvil_consortium_manager/urls.py
+++ b/anvil_consortium_manager/urls.py
@@ -214,6 +214,11 @@ workspace_patterns = (
             views.WorkspaceImport.as_view(),
             name="import",
         ),
+        path(
+            "types/<str:workspace_type>/autocomplete/",
+            views.WorkspaceAutocompleteByType.as_view(),
+            name="autocomplete_by_type",
+        ),
         # path(
         #     "types/<str:workspace_type>/clone/",
         #     views.WorkspaceClone.as_view(),

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -2092,6 +2092,28 @@ class WorkspaceAutocomplete(
         return qs
 
 
+class WorkspaceAutocompleteByType(
+    auth.AnVILConsortiumManagerViewRequired,
+    WorkspaceAdapterMixin,
+    autocomplete.Select2QuerySetView,
+):
+    """View to provide autocompletion for Workspaces by type."""
+
+    def get_queryset(self):
+        # Eventually, add a new method to the workspace adapter that can be overridden for custom autocomplete.
+        # Filter out unathorized users, or does the auth mixin do that?
+        qs = models.Workspace.objects.filter(
+            workspace_type=self.adapter.get_type()
+        ).order_by("billing_project", "name")
+
+        if self.q:
+            # Use the workspace adapter to process the query.
+            #            import ipdb; ipdb.set_trace()
+            qs = self.adapter.get_autocomplete_queryset(qs, self.q)
+
+        return qs
+
+
 class GroupGroupMembershipDetail(auth.AnVILConsortiumManagerViewRequired, DetailView):
     model = models.GroupGroupMembership
 


### PR DESCRIPTION
- Add new autocomplete views that autocomplete specific workspace types.
- Add a new method `BaseWorkspaceAdapter.get_autocomplete_queryset()` that can be overridden by projects defining custom database types.