### PR TITLE
Fix test failures for urllib3 update

### DIFF
--- a/anvil_consortium_manager/tests/test_models_anvil_api_unit.py
+++ b/anvil_consortium_manager/tests/test_models_anvil_api_unit.py
@@ -755,7 +755,6 @@ class ManagedGroupAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             responses.DELETE,
             self.api_url_delete,
             status=204,
-            json={"message": "mock message"},
         )
         self.object.anvil_delete()
 
@@ -6353,7 +6352,6 @@ class GroupAccountMembershipAnVILAPIMockTest(AnVILAPIMockTestMixin, TestCase):
             responses.DELETE,
             self.api_url_delete,
             status=204,
-            json={"message": "mock message"},
         )
         self.object.anvil_delete()
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,4 +20,4 @@ networkx==2.8.2
 numpy==1.24
 
 # Requests
-requests==2.28.2
+requests==2.30.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -44,10 +44,12 @@ setuptools==65.5.1
 # ------------------------------------------------------------------------------
 
 # Mocked responses in tests:
-responses==0.18.0  # https://github.com/getsentry/responses
+responses==0.23.1  # https://github.com/getsentry/responses
 
 # For mariadb/mysql backend:
 mysqlclient==2.1.0
 
 # Testing migrations:
 django-test-migrations==1.2.0  # https://github.com/wemake-services/django-test-migrations - for testing migrations
+
+urllib3==2.0.2  # This broke some of the code in CI.


### PR DESCRIPTION
The new version of urllib3 enforces content length in the header matching the actual response length. A couple tests added a json message to the DELETE response for groups, which then broke the tests with the updated urllib3. See urllib3 pull request:
https://github.com/urllib3/urllib3/pull/2514