### PR TITLE
Better audit report email formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Devel
 
+* The `run_anvil_audit` management command now sends html emails instead of only text emails.
 
 ## 0.15 (2023-4-18)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.15.1dev1"
+__version__ = "0.15.1dev2"

--- a/anvil_consortium_manager/anvil_audit.py
+++ b/anvil_consortium_manager/anvil_audit.py
@@ -97,7 +97,7 @@ class AnVILAuditResults(ABC):
         """
         return not self.errors and not self.not_in_app
 
-    def to_json(
+    def export(
         self, include_verified=True, include_errors=True, include_not_in_app=True
     ):
         """Return a dictionary representation of the audit results."""

--- a/anvil_consortium_manager/anvil_audit.py
+++ b/anvil_consortium_manager/anvil_audit.py
@@ -104,12 +104,12 @@ class AnVILAuditResults(ABC):
         x = {}
         if include_verified:
             x["verified"] = [
-                {"id": instance.pk, "instance": str(instance)}
+                {"id": instance.pk, "instance": instance}
                 for instance in self.get_verified()
             ]
         if include_errors:
             x["errors"] = [
-                {"id": k.pk, "instance": str(k), "errors": v}
+                {"id": k.pk, "instance": k, "errors": v}
                 for k, v in self.get_errors().items()
             ]
         if include_not_in_app:

--- a/anvil_consortium_manager/management/commands/run_anvil_audit.py
+++ b/anvil_consortium_manager/management/commands/run_anvil_audit.py
@@ -1,5 +1,3 @@
-import json
-
 import django_tables2 as tables
 from django.core.mail import send_mail
 from django.core.management.base import BaseCommand
@@ -11,7 +9,7 @@ from ...anvil_api import AnVILAPIError
 
 class ErrorsTable(tables.Table):
     id = tables.Column(orderable=False)
-    instance = tables.Column(orderable=False)
+    instance = tables.Column(orderable=False, linkify=True)
     errors = tables.Column(orderable=False)
 
     def render_errors(self, value):
@@ -63,7 +61,7 @@ class Command(BaseCommand):
             if not results.ok():
                 self.stdout.write(self.style.ERROR("problems found."))
                 json_results = results.to_json(include_verified=False)
-                report = json.dumps(json_results, indent=2)
+                # report = json.dumps(json_results, indent=2)
                 if email:
                     # trying json2html
                     # table_attributes = table_attributes="class=\"table\""
@@ -89,14 +87,15 @@ class Command(BaseCommand):
                     # import ipdb; ipdb.set_trace()
                     send_mail(
                         "AnVIL Audit for {} -- errors".format(model_name),
-                        report,
+                        "",  # report,
                         None,
                         [email],
                         fail_silently=False,
                         html_message=html_body,
                     )
                 else:
-                    self.stdout.write(report)
+                    # self.stdout.write(report)
+                    pass
             else:
                 self.stdout.write(self.style.SUCCESS("ok!"))
                 if email and not errors_only:

--- a/anvil_consortium_manager/management/commands/run_anvil_audit.py
+++ b/anvil_consortium_manager/management/commands/run_anvil_audit.py
@@ -62,7 +62,7 @@ class Command(BaseCommand):
         email = options["email"]
         errors_only = options["errors_only"]
 
-        model_name = model._meta.verbose_name_plural
+        model_name = model._meta.object_name
 
         self.stdout.write("Running on {}... ".format(model_name), ending="")
         try:
@@ -78,6 +78,7 @@ class Command(BaseCommand):
                     html_body = render_to_string(
                         "anvil_consortium_manager/email_audit_report.html",
                         context={
+                            "model_name": model_name,
                             "errors_table": ErrorsTable(exported_results["errors"]),
                             "not_in_app_table": NotInAppTable(
                                 exported_results["not_in_app"]
@@ -98,7 +99,9 @@ class Command(BaseCommand):
                 self.stdout.write(self.style.SUCCESS("ok!"))
                 if email and not errors_only:
                     send_mail(
-                        "AnVIL Audit for {} -- ok".format(model_name),
+                        "AnVIL Audit for {} -- ok".format(
+                            models.BillingProject._meta.object_name
+                        ),
                         "Audit ok ({} instances)".format(len(results.get_verified())),
                         None,
                         [email],

--- a/anvil_consortium_manager/management/commands/run_anvil_audit.py
+++ b/anvil_consortium_manager/management/commands/run_anvil_audit.py
@@ -12,7 +12,10 @@ from ...anvil_api import AnVILAPIError
 class ErrorsTable(tables.Table):
     id = tables.Column(orderable=False)
     instance = tables.Column(orderable=False)
-    errors = tables.ManyToManyColumn(orderable=False)
+    errors = tables.Column(orderable=False)
+
+    def render_errors(self, value):
+        return ", ".join(value)
 
 
 class NotInAppTable(tables.Table):

--- a/anvil_consortium_manager/management/commands/run_anvil_audit.py
+++ b/anvil_consortium_manager/management/commands/run_anvil_audit.py
@@ -10,21 +10,6 @@ from ... import models
 from ...anvil_api import AnVILAPIError
 
 
-class VerifiedTable(tables.Table):
-    id = tables.Column(orderable=False)
-    instance = tables.Column(
-        orderable=False,
-        linkify=lambda value, table: "https://{domain}{url}".format(
-            domain=table.site.domain, url=value.get_absolute_url()
-        ),
-    )
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        # Set the site here so it only hits the db once.
-        self.site = Site.objects.get_current()
-
-
 class ErrorsTable(tables.Table):
     id = tables.Column(orderable=False)
     instance = tables.Column(

--- a/anvil_consortium_manager/management/commands/run_anvil_audit.py
+++ b/anvil_consortium_manager/management/commands/run_anvil_audit.py
@@ -10,20 +10,20 @@ from ... import models
 from ...anvil_api import AnVILAPIError
 
 
-def build_absolute_url(record):
-    site = Site.objects.get_current()
-    uri = "https://{domain}{url}".format(
-        domain=site.domain, url=record["instance"].get_absolute_url()
-    )
-    return uri
-
-
 class ErrorsTable(tables.Table):
     id = tables.Column(orderable=False)
     instance = tables.Column(
-        orderable=False, linkify=lambda record: build_absolute_url(record)
+        orderable=False,
+        linkify=lambda value, table: "https://{domain}{url}".format(
+            domain=table.site.domain, url=value.get_absolute_url()
+        ),
     )
     errors = tables.Column(orderable=False)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Set the site here so it only hits the db once.
+        self.site = Site.objects.get_current()
 
     def render_errors(self, value):
         return ", ".join(value)

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/email_audit_report.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/email_audit_report.html
@@ -1,18 +1,37 @@
-{% extends "anvil_consortium_manager/base.html" %}
-{% block title %}Audit Errors{% endblock %}
 
+{% load static i18n %}<!DOCTYPE html>
 {% load render_table from django_tables2 %}
+{% get_current_language as LANGUAGE_CODE %}
+<html lang="{{ LANGUAGE_CODE }}">
+  <head>
+    <title>Audit report</title>
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap/5.1.3/css/bootstrap.min.css" integrity="sha512-GQGU0fMMi238uA+a/bdWJfpUGKUkBdgfFdgBm72SUQ6BeyWjoY/ton0tEjH+OSH9iP4Dfh+7HM0I9f5eR0L/4w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+  </head>
+
+  <body>
+    <div class="container">
 
 {% block content %}
 
-<h1>Audit report - {{ model_name }}</h1>
+      <h1>Audit report - {{ model_name }}</h1>
 
-<h2>Verified</h2>
+      <h2>Verified</h2>
+      <div class="container">
+        <p>{{ verified_results|length }} instance(s) verified.</p>
+      </div>
 
-<h2>Errors</h2>
-{% render_table errors_table %}
+      <h2>Errors</h2>
+      <div class="container">
+        {% render_table errors_table %}
+      </div>
 
-<h2>Not in app</h2>
-{% render_table not_in_app_table %}
+      <h2>Not in app</h2>
+      <div class="container">
+        {% render_table not_in_app_table %}
+      </div>
 
 {% endblock content %}
+
+    </div>
+  </body>
+</html>

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/email_audit_report.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/email_audit_report.html
@@ -1,13 +1,18 @@
-{% autoescape off %}
+{% extends "anvil_consortium_manager/base.html" %}
+{% block title %}Audit Errors{% endblock %}
 
 {% load render_table from django_tables2 %}
 
 {% block content %}
 
+<h1>Audit report - {{ model_name }}</h1>
+
+<h2>Verified</h2>
+
+<h2>Errors</h2>
 {% render_table errors_table %}
 
+<h2>Not in app</h2>
 {% render_table not_in_app_table %}
 
 {% endblock content %}
-
-{% endautoescape %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/email_audit_report.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/email_audit_report.html
@@ -1,0 +1,13 @@
+{% autoescape off %}
+
+{% load render_table from django_tables2 %}
+
+{% block content %}
+
+{% render_table errors_table %}
+
+{% render_table not_in_app_table %}
+
+{% endblock content %}
+
+{% endautoescape %}

--- a/anvil_consortium_manager/tests/settings/test.py
+++ b/anvil_consortium_manager/tests/settings/test.py
@@ -12,8 +12,6 @@ import os
 # though not all of them may be available with every OS.
 # In Windows, this must be set to your system time zone.
 TIME_ZONE = "America/Los_Angeles"
-# https://docs.djangoproject.com/en/dev/ref/settings/#site-id
-SITE_ID = 1
 # https://docs.djangoproject.com/en/dev/ref/settings/#use-tz
 USE_TZ = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#secret-key

--- a/anvil_consortium_manager/tests/settings/test.py
+++ b/anvil_consortium_manager/tests/settings/test.py
@@ -16,6 +16,8 @@ TIME_ZONE = "America/Los_Angeles"
 USE_TZ = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#secret-key
 SECRET_KEY = "w5S8S9eqW5ZqWXPnsCpgbOkcOtajCMmRDjakwXR39lbmVDSunZPwiSV80jSaVBdL"
+# https://docs.djangoproject.com/en/dev/ref/settings/#site-id
+SITE_ID = 1
 # https://docs.djangoproject.com/en/dev/ref/settings/#test-runner
 TEST_RUNNER = "django.test.runner.DiscoverRunner"
 
@@ -52,6 +54,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.admin",
+    "django.contrib.sites",
     "django.forms",
     # Third party apps.
     "crispy_forms",

--- a/anvil_consortium_manager/tests/test_anvil_audit.py
+++ b/anvil_consortium_manager/tests/test_anvil_audit.py
@@ -121,28 +121,28 @@ class AnVILAuditTest(TestCase):
         self.audit_results.add_not_in_app("foo")
         self.assertEqual(self.audit_results.ok(), False)
 
-    def test_to_json(self):
-        """to_json method works as expected."""
+    def test_export(self):
+        """export method works as expected."""
         obj_verified = self.model_factory.create()
         self.audit_results.add_verified(obj_verified)
         obj_error = self.model_factory.create()
         self.audit_results.add_error(obj_error, self.audit_results.TEST_ERROR_1)
         self.audit_results.add_not_in_app("foo")
         expected_json = {
-            "verified": [{"instance": str(obj_verified), "id": obj_verified.pk}],
+            "verified": [{"instance": obj_verified, "id": obj_verified.pk}],
             "errors": [
                 {
                     "id": obj_error.pk,
-                    "instance": str(obj_error),
+                    "instance": obj_error,
                     "errors": [self.audit_results.TEST_ERROR_1],
                 }
             ],
             "not_in_app": ["foo"],
         }
-        self.assertEqual(self.audit_results.to_json(), expected_json)
+        self.assertEqual(self.audit_results.export(), expected_json)
 
-    def test_to_json_include_verified_false(self):
-        """to_json method works as expected."""
+    def test_export_include_verified_false(self):
+        """export method works as expected."""
         obj_verified = self.model_factory.create()
         self.audit_results.add_verified(obj_verified)
         obj_error = self.model_factory.create()
@@ -152,48 +152,46 @@ class AnVILAuditTest(TestCase):
             "errors": [
                 {
                     "id": obj_error.pk,
-                    "instance": str(obj_error),
+                    "instance": obj_error,
                     "errors": [self.audit_results.TEST_ERROR_1],
                 }
             ],
             "not_in_app": ["foo"],
         }
         self.assertEqual(
-            self.audit_results.to_json(include_verified=False), expected_json
+            self.audit_results.export(include_verified=False), expected_json
         )
 
-    def test_to_json_include_errors_false(self):
-        """to_json method works as expected."""
+    def test_export_include_errors_false(self):
+        """export method works as expected."""
         obj_verified = self.model_factory.create()
         self.audit_results.add_verified(obj_verified)
         obj_error = self.model_factory.create()
         self.audit_results.add_error(obj_error, self.audit_results.TEST_ERROR_1)
         self.audit_results.add_not_in_app("foo")
         expected_json = {
-            "verified": [{"instance": str(obj_verified), "id": obj_verified.pk}],
+            "verified": [{"instance": obj_verified, "id": obj_verified.pk}],
             "not_in_app": ["foo"],
         }
-        self.assertEqual(
-            self.audit_results.to_json(include_errors=False), expected_json
-        )
+        self.assertEqual(self.audit_results.export(include_errors=False), expected_json)
 
-    def test_to_json_include_not_in_app_false(self):
-        """to_json method works as expected."""
+    def test_export_include_not_in_app_false(self):
+        """export method works as expected."""
         obj_verified = self.model_factory.create()
         self.audit_results.add_verified(obj_verified)
         obj_error = self.model_factory.create()
         self.audit_results.add_error(obj_error, self.audit_results.TEST_ERROR_1)
         self.audit_results.add_not_in_app("foo")
         expected_json = {
-            "verified": [{"instance": str(obj_verified), "id": obj_verified.pk}],
+            "verified": [{"instance": obj_verified, "id": obj_verified.pk}],
             "errors": [
                 {
                     "id": obj_error.pk,
-                    "instance": str(obj_error),
+                    "instance": obj_error,
                     "errors": [self.audit_results.TEST_ERROR_1],
                 }
             ],
         }
         self.assertEqual(
-            self.audit_results.to_json(include_not_in_app=False), expected_json
+            self.audit_results.export(include_not_in_app=False), expected_json
         )

--- a/anvil_consortium_manager/tests/test_commands.py
+++ b/anvil_consortium_manager/tests/test_commands.py
@@ -50,10 +50,10 @@ class RunAnvilAuditTest(AnVILAPIMockTestMixin, TestCase):
         )
         out = StringIO()
         call_command("run_anvil_audit", "--no-color", stdout=out)
-        self.assertIn("billing projects... ok!", out.getvalue())
-        self.assertIn("accounts... ok!", out.getvalue())
-        self.assertIn("managed groups... ok!", out.getvalue())
-        self.assertIn("workspaces... ok!", out.getvalue())
+        self.assertIn("BillingProject... ok!", out.getvalue())
+        self.assertIn("Account... ok!", out.getvalue())
+        self.assertIn("ManagedGroup... ok!", out.getvalue())
+        self.assertIn("Workspace... ok!", out.getvalue())
 
     def test_command_output_multiple_models(self):
         """Can audit multiple models at the same time."""
@@ -64,8 +64,8 @@ class RunAnvilAuditTest(AnVILAPIMockTestMixin, TestCase):
             models=["BillingProject", "Account"],
             stdout=out,
         )
-        self.assertIn("billing projects... ok!", out.getvalue())
-        self.assertIn("accounts... ok!", out.getvalue())
+        self.assertIn("BillingProject... ok!", out.getvalue())
+        self.assertIn("Account... ok!", out.getvalue())
 
     def test_command_output_billing_project_no_instances(self):
         """Test command output."""
@@ -73,13 +73,13 @@ class RunAnvilAuditTest(AnVILAPIMockTestMixin, TestCase):
         call_command(
             "run_anvil_audit", "--no-color", models=["BillingProject"], stdout=out
         )
-        self.assertIn("billing projects... ok!", out.getvalue())
+        self.assertIn("BillingProject... ok!", out.getvalue())
 
     def test_command_output_account_no_instances(self):
         """Test command output."""
         out = StringIO()
         call_command("run_anvil_audit", "--no-color", models=["Account"], stdout=out)
-        self.assertIn("accounts... ok!", out.getvalue())
+        self.assertIn("Account... ok!", out.getvalue())
 
     def test_command_output_managed_group_no_instances(self):
         """Test command output."""
@@ -93,7 +93,7 @@ class RunAnvilAuditTest(AnVILAPIMockTestMixin, TestCase):
         call_command(
             "run_anvil_audit", "--no-color", models=["ManagedGroup"], stdout=out
         )
-        self.assertIn("managed groups... ok!", out.getvalue())
+        self.assertIn("ManagedGroup... ok!", out.getvalue())
 
     def test_command_output_workspace_no_instances(self):
         """Test command output."""
@@ -105,7 +105,7 @@ class RunAnvilAuditTest(AnVILAPIMockTestMixin, TestCase):
         )
         out = StringIO()
         call_command("run_anvil_audit", "--no-color", models=["Workspace"], stdout=out)
-        self.assertIn("workspaces... ok!", out.getvalue())
+        self.assertIn("Workspace... ok!", out.getvalue())
 
     def test_command_run_audit_one_instance_ok(self):
         """Test command output."""
@@ -117,7 +117,7 @@ class RunAnvilAuditTest(AnVILAPIMockTestMixin, TestCase):
         call_command(
             "run_anvil_audit", "--no-color", models=["BillingProject"], stdout=out
         )
-        self.assertIn("billing projects... ok!", out.getvalue())
+        self.assertIn("BillingProject... ok!", out.getvalue())
         self.assertNotIn("errors", out.getvalue())
         self.assertNotIn("not_in_app", out.getvalue())
 
@@ -135,7 +135,7 @@ class RunAnvilAuditTest(AnVILAPIMockTestMixin, TestCase):
             email="test@example.com",
             stdout=out,
         )
-        self.assertIn("billing projects... ok!", out.getvalue())
+        self.assertIn("BillingProject... ok!", out.getvalue())
         # One message has been sent by default.
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn("ok", mail.outbox[0].subject)
@@ -156,7 +156,7 @@ class RunAnvilAuditTest(AnVILAPIMockTestMixin, TestCase):
             errors_only=True,
             stdout=out,
         )
-        self.assertIn("billing projects... ok!", out.getvalue())
+        self.assertIn("BillingProject... ok!", out.getvalue())
         # No message has been sent by default.
         self.assertEqual(len(mail.outbox), 0)
 
@@ -172,7 +172,7 @@ class RunAnvilAuditTest(AnVILAPIMockTestMixin, TestCase):
         call_command(
             "run_anvil_audit", "--no-color", models=["BillingProject"], stdout=out
         )
-        self.assertIn("billing projects... problems found.", out.getvalue())
+        self.assertIn("BillingProject... problems found.", out.getvalue())
         self.assertIn("""'errors':""", out.getvalue())
         self.assertIn(
             anvil_audit.BillingProjectAuditResults.ERROR_NOT_IN_ANVIL, out.getvalue()
@@ -194,7 +194,7 @@ class RunAnvilAuditTest(AnVILAPIMockTestMixin, TestCase):
             email="test@example.com",
             stdout=out,
         )
-        self.assertIn("billing projects... problems found.", out.getvalue())
+        self.assertIn("BillingProject... problems found.", out.getvalue())
         # Not printed to stdout.
         self.assertNotIn("""'errors':""", out.getvalue())
         # One message has been sent.
@@ -272,7 +272,7 @@ class RunAnvilAuditTest(AnVILAPIMockTestMixin, TestCase):
         call_command(
             "run_anvil_audit", "--no-color", models=["BillingProject"], stdout=out
         )
-        self.assertIn("billing projects... API error.", out.getvalue())
+        self.assertIn("BillingProject... API error.", out.getvalue())
 
     # This test is complicated so skipping for now.
     # When trying to change the settings, the test attempts to repopulate the

--- a/anvil_consortium_manager/tests/test_commands.py
+++ b/anvil_consortium_manager/tests/test_commands.py
@@ -7,7 +7,7 @@ import responses
 from django.contrib.sites.models import Site
 from django.core import mail
 from django.core.management import CommandError, call_command
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from .. import anvil_audit
 from . import factories
@@ -234,10 +234,10 @@ class RunAnvilAuditTest(AnVILAPIMockTestMixin, TestCase):
         )
         self.assertInHTML(html_fragment, email.alternatives[0][0])
 
+    @override_settings(SITE_ID=2)
     def test_command_run_audit_not_ok_email_has_html_link_different_domain(self):
         """Test command output when BillingProject audit is not ok with email specified."""
-        site = Site.objects.get_current()
-        site.domain = "foobar.com"
+        site = Site.objects.create(domain="foobar.com", name="test")
         site.save()
         billing_project = factories.BillingProjectFactory.create()
         # Add a response.

--- a/anvil_consortium_manager/tests/test_commands.py
+++ b/anvil_consortium_manager/tests/test_commands.py
@@ -1,8 +1,10 @@
 """Tests for management commands in `anvil_consortium_manager`."""
 
 from io import StringIO
+from unittest import skip
 
 import responses
+from django.contrib.sites.models import Site
 from django.core import mail
 from django.core.management import CommandError, call_command
 from django.test import TestCase
@@ -171,7 +173,7 @@ class RunAnvilAuditTest(AnVILAPIMockTestMixin, TestCase):
             "run_anvil_audit", "--no-color", models=["BillingProject"], stdout=out
         )
         self.assertIn("billing projects... problems found.", out.getvalue())
-        self.assertIn(""""errors":""", out.getvalue())
+        self.assertIn("""'errors':""", out.getvalue())
         self.assertIn(
             anvil_audit.BillingProjectAuditResults.ERROR_NOT_IN_ANVIL, out.getvalue()
         )
@@ -194,17 +196,69 @@ class RunAnvilAuditTest(AnVILAPIMockTestMixin, TestCase):
         )
         self.assertIn("billing projects... problems found.", out.getvalue())
         # Not printed to stdout.
-        self.assertNotIn(""""errors":""", out.getvalue())
+        self.assertNotIn("""'errors':""", out.getvalue())
         # One message has been sent.
         self.assertEqual(len(mail.outbox), 1)
-        self.assertEqual(mail.outbox[0].to, ["test@example.com"])
-        self.assertIn("errors", mail.outbox[0].subject)
-        # Instead in the email body:
-        self.assertIn(""""errors":""", mail.outbox[0].body)
+        email = mail.outbox[0]
+        self.assertEqual(email.to, ["test@example.com"])
+        self.assertIn("errors", email.subject)
+        # Text body.
+        self.assertIn("""'errors':""", email.body)
         self.assertIn(
             anvil_audit.BillingProjectAuditResults.ERROR_NOT_IN_ANVIL,
-            mail.outbox[0].body,
+            email.body,
         )
+        # HTML body.
+        self.assertEqual(len(email.alternatives), 1)
+
+    def test_command_run_audit_not_ok_email_has_html_link(self):
+        """Test command output when BillingProject audit is not ok with email specified."""
+        billing_project = factories.BillingProjectFactory.create()
+        # Add a response.
+        api_url = self.get_api_url_billing_project(billing_project.name)
+        self.anvil_response_mock.add(
+            responses.GET, api_url, status=404, json={"message": "error"}
+        )
+        out = StringIO()
+        call_command(
+            "run_anvil_audit",
+            "--no-color",
+            models=["BillingProject"],
+            email="test@example.com",
+            stdout=out,
+        )
+        email = mail.outbox[0]
+        self.assertEqual(len(email.alternatives), 1)
+        html_fragment = """<a href="https://example.com{url}">{obj}</a>""".format(
+            obj=str(billing_project), url=billing_project.get_absolute_url()
+        )
+        self.assertInHTML(html_fragment, email.alternatives[0][0])
+
+    def test_command_run_audit_not_ok_email_has_html_link_different_domain(self):
+        """Test command output when BillingProject audit is not ok with email specified."""
+        site = Site.objects.get_current()
+        site.domain = "foobar.com"
+        site.save()
+        billing_project = factories.BillingProjectFactory.create()
+        # Add a response.
+        api_url = self.get_api_url_billing_project(billing_project.name)
+        self.anvil_response_mock.add(
+            responses.GET, api_url, status=404, json={"message": "error"}
+        )
+        out = StringIO()
+        call_command(
+            "run_anvil_audit",
+            "--no-color",
+            models=["BillingProject"],
+            email="test@example.com",
+            stdout=out,
+        )
+        email = mail.outbox[0]
+        self.assertEqual(len(email.alternatives), 1)
+        html_fragment = """<a href="https://foobar.com{url}">{obj}</a>""".format(
+            obj=str(billing_project), url=billing_project.get_absolute_url()
+        )
+        self.assertInHTML(html_fragment, email.alternatives[0][0])
 
     def test_command_run_audit_api_error(self):
         """Test command output when BillingProject audit is not ok."""
@@ -219,3 +273,21 @@ class RunAnvilAuditTest(AnVILAPIMockTestMixin, TestCase):
             "run_anvil_audit", "--no-color", models=["BillingProject"], stdout=out
         )
         self.assertIn("billing projects... API error.", out.getvalue())
+
+    # This test is complicated so skipping for now.
+    # When trying to change the settings, the test attempts to repopulate the
+    # workspace registry. This then causes an error. Skip it until we figure out
+    # how best to handle this situation.
+    @skip
+    def test_command_without_sites(self):
+        """Test command behavior without the Sites framework enabled."""
+        out = StringIO()
+        with self.modify_settings(INSTALLED_APPS={"remove": ["django.contrib.sites"]}):
+            #            with self.assertRaises(ImproperlyConfigured):
+            call_command(
+                "run_anvil_audit",
+                "--no-color",
+                models=["BillingProject"],
+                email="test@example.com",
+                stdout=out,
+            )

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -2075,11 +2075,11 @@ class AccountLinkTest(AnVILAPIMockTestMixin, TestCase):
         # The body contains the correct url.
         self.assertIn(url, mail.outbox[0].body)
 
+    @override_settings(SITE_ID=2)
     @freeze_time("2022-11-22 03:12:34")
     def test_email_is_sent_site_domain(self):
         """An email is sent when the form is submitted correctly."""
-        site = Site.objects.get_current()
-        site.domain = "foobar.com"
+        site = Site.objects.create(domain="foobar.com", name="test")
         site.save()
         email = "test@example.com"
         api_url = self.get_api_url(email)

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -8,6 +8,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Permission, User
 from django.contrib.messages import get_messages
+from django.contrib.sites.models import Site
 from django.core import mail
 from django.core.exceptions import ObjectDoesNotExist, PermissionDenied
 from django.forms import BaseInlineFormSet, HiddenInput
@@ -2067,7 +2068,33 @@ class AccountLinkTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(len(mail.outbox), 1)
         # The subject is correct.
         self.assertEqual(mail.outbox[0].subject, "account activation")
-        url = "http://testserver" + reverse(
+        url = "http://example.com" + reverse(
+            "anvil_consortium_manager:accounts:verify",
+            args=[email_entry.uuid, account_verification_token.make_token(email_entry)],
+        )
+        # The body contains the correct url.
+        self.assertIn(url, mail.outbox[0].body)
+
+    @freeze_time("2022-11-22 03:12:34")
+    def test_email_is_sent_site_domain(self):
+        """An email is sent when the form is submitted correctly."""
+        site = Site.objects.get_current()
+        site.domain = "foobar.com"
+        site.save()
+        email = "test@example.com"
+        api_url = self.get_api_url(email)
+        self.anvil_response_mock.add(
+            responses.GET, api_url, status=200, json=self.get_api_json_response(email)
+        )
+        # Need a client because messages are added.
+        self.client.force_login(self.user)
+        self.client.post(self.get_url(), {"email": email})
+        email_entry = models.UserEmailEntry.objects.get(email=email)
+        # One message has been sent.
+        self.assertEqual(len(mail.outbox), 1)
+        # The subject is correct.
+        self.assertEqual(mail.outbox[0].subject, "account activation")
+        url = "http://foobar.com" + reverse(
             "anvil_consortium_manager:accounts:verify",
             args=[email_entry.uuid, account_verification_token.make_token(email_entry)],
         )

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,6 +17,7 @@ Welcome to django-anvil-consortium-manager's documentation!
    anvil_api
    advanced
    auditing
+   management_commands
 
 .. toctree::
    :maxdepth: 6

--- a/docs/management_commands.rst
+++ b/docs/management_commands.rst
@@ -1,0 +1,11 @@
+Management Commands
+===================
+
+The app provides custom the following management commands.
+
+run_anvil_audit
+---------------
+
+This command runs AnVIL audits for each model type and reports the results.
+Results can either be printed to stdout or as a report sent via email.
+Run ``python manage.py run_anvil_audit --help`` to see available options.

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -53,9 +53,7 @@ Required Settings
   Note that you can have multiple Workspace adapters, but only one Account adapter.
 
 
-4. If you would like to use the templates provided with the app, add the ``"anvil_consortium_manager.context_processors.workspace_adapter"`` context processor to your settings file. This allows the templates to know about which types of workspace adapters that are registered (step 3), and then display links to the correct URLs.
-
-5. Add account linking settings to your settings file.
+4. Add account linking settings to your settings file.
 
   .. code-block:: python
 
@@ -64,10 +62,11 @@ Required Settings
       # Specify the subject for AnVIL account verification emails.
       ANVIL_ACCOUNT_LINK_EMAIL_SUBJECT = "Verify your AnVIL account email"
 
-6. Set up a Site in the sites framework. In your settings file:
-```
-SITE_ID = 1
-```
+5. Set up a Site in the sites framework. In your settings file:
+
+  .. code-block:: python
+
+      SITE_ID = 1
 
 Optional settings
 ~~~~~~~~~~~~~~~~~
@@ -82,9 +81,10 @@ Post-installation
 ~~~~~~~~~~~~~~~~~
 
 1. In your Django root directory, execute the command below to create your database tables:
-```
-python manage.py migrate
-```
+
+  .. code-block:: bash
+
+      python manage.py migrate
 
 2. Start your server and add a site for your domain using the admin interface (e.g. http://localhost:8000/admin/). Make sure ``settings.SITE_ID`` matches the ID for this site.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -20,16 +20,19 @@ You will need a service account credentials file that is registered with Terra. 
 Required Settings
 ~~~~~~~~~~~~~~~~~
 
-1. Add ``anvil_consortium_manager`` to your ``INSTALLED_APPS``.
+1. Add required apps and ``anvil_consortium_manager`` to your ``INSTALLED_APPS`` setting.
 
   .. code-block:: python
 
       INSTALLED_APPS = [
-          # ...
+          # The following apps are required:
+          "django.contrib.messages",
+          "django.contrib.sites",
+          "django-tables2",
+
+          # This app:
           "anvil_consortium_manager",
       ]
-
-  If you would like to use the views and templates provided by the app, then you should also install ``django-tables2`` in your project.
 
 2. Set the ``ANVIL_API_SERVICE_ACCOUNT_FILE`` setting to the path to the service account credentials file.
 
@@ -61,6 +64,10 @@ Required Settings
       # Specify the subject for AnVIL account verification emails.
       ANVIL_ACCOUNT_LINK_EMAIL_SUBJECT = "Verify your AnVIL account email"
 
+6. Set up a Site in the sites framework. In your settings file:
+```
+SITE_ID = 1
+```
 
 Optional settings
 ~~~~~~~~~~~~~~~~~
@@ -70,6 +77,16 @@ If you would like to receive emails when a user links their account, set the ``A
 
       ANVIL_ACCOUNT_VERIFY_NOTIFICATION_EMAIL = "to@example.com"
 
+
+Post-installation
+~~~~~~~~~~~~~~~~~
+
+1. In your Django root directory, execute the command below to create your database tables:
+```
+python manage.py migrate
+```
+
+2. Start your server and add a site for your domain using the admin interface (e.g. http://localhost:8000/admin/). Make sure ``settings.SITE_ID`` matches the ID for this site.
 
 Permissions
 ~~~~~~~~~~~

--- a/example_site/settings.py
+++ b/example_site/settings.py
@@ -22,8 +22,6 @@ ALLOWED_HOSTS = ["*"]
 TIME_ZONE = "America/Los_Angeles"
 # https://docs.djangoproject.com/en/dev/ref/settings/#language-code
 LANGUAGE_CODE = "en-us"
-# https://docs.djangoproject.com/en/dev/ref/settings/#site-id
-SITE_ID = 1
 # https://docs.djangoproject.com/en/dev/ref/settings/#use-i18n
 USE_I18N = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#use-l10n

--- a/example_site/settings.py
+++ b/example_site/settings.py
@@ -22,6 +22,8 @@ ALLOWED_HOSTS = ["*"]
 TIME_ZONE = "America/Los_Angeles"
 # https://docs.djangoproject.com/en/dev/ref/settings/#language-code
 LANGUAGE_CODE = "en-us"
+# https://docs.djangoproject.com/en/dev/ref/settings/#site-id
+SITE_ID = 1
 # https://docs.djangoproject.com/en/dev/ref/settings/#use-i18n
 USE_I18N = True
 # https://docs.djangoproject.com/en/dev/ref/settings/#use-l10n
@@ -69,6 +71,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.admin",
+    "django.contrib.sites",
     "django.forms",
     # Third party apps
     "crispy_forms",


### PR DESCRIPTION
- Send html emails with a rendered audit report in `run_anvil_audit` management command.

Closes #317 