### PR TITLE
Fix AnVIL audit when service account is not directly a group admin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Devel
 
 * Bugfix: correctly import AnVIL groups when the service account is both a member and an admin of the group.
+* Bugfix: Fix failing ManagedGroup.anvil_audit_memership when the service account is not directly an admin of the group (but is via membership in another group).
 
 ## 0.16 (2023-06-01)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.16.1dev1"
+__version__ = "0.16.1dev2"

--- a/anvil_consortium_manager/models.py
+++ b/anvil_consortium_manager/models.py
@@ -622,9 +622,13 @@ class ManagedGroup(TimeStampedModel):
         # Convert to case-insensitive emails.
         admins_in_anvil = [x.lower() for x in response.json()]
         # Remove the service account as admin.
-        admins_in_anvil.remove(
-            api_client.auth_session.credentials.service_account_email.lower()
-        )
+        try:
+            admins_in_anvil.remove(
+                api_client.auth_session.credentials.service_account_email.lower()
+            )
+        except ValueError:
+            # Not listed as an admin -- this is ok because it could be via group membership.
+            pass
         # Sometimes the service account is also listed as a member. Remove that too.
         try:
             members_in_anvil.remove(


### PR DESCRIPTION
Fix the AnVIL membership audit for a ManagedGroup when the service account running the app is not directly an admin of the group (for example, when another group is an admin and the service account is a member of the other group).

Closes #362 