### PR TITLE
Ignore member groups that are also admins in audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Devel
 
 * Bugfix: Display "not in app" table correctly in emailed AnVIL audit report.
+* Bugfix: Fix failing ManagedGroup.anvil_audit_membership when a group is both a member of and admin of another group.
 
 ## 0.16.1 (2023-06-09)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.16.2dev1"
+__version__ = "0.16.2dev2"

--- a/anvil_consortium_manager/models.py
+++ b/anvil_consortium_manager/models.py
@@ -672,6 +672,13 @@ class ManagedGroup(TimeStampedModel):
                     )
                 else:
                     audit_results.add_verified(membership)
+                # Also remove from members.
+                try:
+                    members_in_anvil.remove(membership.child_group.email.lower())
+                except ValueError:
+                    # The group is not directly listed as a member, so this is ok.
+                    # It is already an admin.
+                    pass
             elif membership.role == GroupGroupMembership.MEMBER:
                 try:
                     members_in_anvil.remove(membership.child_group.email.lower())


### PR DESCRIPTION
When auditing ManagedGroup membership, a group can appear as both an admin and a member of the ManagedGroup in the response from AnVIL. If this occurs and the gropu is an admin, ignore the member record as returned by the API. Add a test to capture this behavior.

Closes #370