### PR TITLE
Fix CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -33,9 +33,6 @@ commands =
 [testenv:py{38,39,310}-django{32,41,42}-mysql]
 setenv =
     DBBACKEND = mysql
-    PKG_CONFIG_PATH="/opt/local/lib/mariadb-10.5/pkgconfig/"
-    MYSQLCLIENT_LDFLAGS=`pkg-config --libs libmariadb`
-    MYSQLCLIENT_CFLAGS=`pkg-config --cflags libmariadb`
 
 
 [testenv:py{38,39,310}-django{32,41,42}-sqlite]

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ deps =
     django-coverage-plugin
     freezegun
     django-test-migrations
-    mysql: mysqlclient==2.1.1
+    mysql: mysqlclient
 constrain_package_deps = true
 passenv =
     DBNAME
@@ -33,6 +33,10 @@ commands =
 [testenv:py{38,39,310}-django{32,41,42}-mysql]
 setenv =
     DBBACKEND = mysql
+    PKG_CONFIG_PATH="/opt/local/lib/mariadb-10.5/pkgconfig/"
+    MYSQLCLIENT_LDFLAGS=`pkg-config --libs libmariadb`
+    MYSQLCLIENT_CFLAGS=`pkg-config --cflags libmariadb`
+
 
 [testenv:py{38,39,310}-django{32,41,42}-sqlite]
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -2,12 +2,14 @@
 [tox]
 envlist = py{38,39,310}-django{32,41,42}-{sqlite,mysql}
 isolated_build = true
+# We need 4.4.0 for constrain_package_deps.
+min_version = 4.4.0
 
 [testenv]
 deps =
     django32: Django==3.2.*
     django40: Django==4.0.*
-    django41: Django>=4.1.0,<4.2.0
+    django41: Django==4.1.*
     django42: Django==4.2.*
     responses
     factory-boy
@@ -16,6 +18,7 @@ deps =
     freezegun
     django-test-migrations
     mysql: mysqlclient==2.1.1
+constrain_package_deps = true
 passenv =
     DBNAME
     DBUSER

--- a/tox.ini
+++ b/tox.ini
@@ -27,6 +27,7 @@ passenv =
     DBBACKEND
     DBPORT
 commands =
+    pip freeze
     coverage run -p ./manage.py test anvil_consortium_manager --settings=anvil_consortium_manager.tests.settings.test
 
 [testenv:py{38,39,310}-django{32,41,42}-mysql]

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ deps =
     django-coverage-plugin
     freezegun
     django-test-migrations
-    mysql: mysqlclient
+    mysql: mysqlclient==2.1.1
 passenv =
     DBNAME
     DBUSER

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ isolated_build = true
 deps =
     django32: Django==3.2.*
     django40: Django==4.0.*
-    django41: Django==4.1.*
+    django41: Django>=4.1.0,<4.2.0
     django42: Django==4.2.*
     responses
     factory-boy


### PR DESCRIPTION
CI is breaking for a couple of possible reasons:
- The wrong version of Django is getting installed
- The new version of mysqlclient requires pkg-config or that you set environment variables
- other unknown reasons with confusing errors, but possibly only associated with a single branch (feature/add-search-functionality-for-models)

This PR hopefully fixes the issue with an incorrect version of Django being installed by adding a tox setting (constrain_package_deps). It appears that pkg-config may already be installed in the Docker image we're using, so the second is ok? Unclear if it fixes the third.