### PR TITLE
Print the correct number of "ok" instances in audit email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Devel
 
 * Add filtering in list views.
+* Bugfix: Print the correct number of "ok" instances in audit emails. 0.18 introduced a bug where the email included "0 instance(s) verified even if there was more than one verified instance.
 
 ## 0.18 (2023-10-03)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.19dev1"
+__version__ = "0.19dev2"

--- a/anvil_consortium_manager/management/commands/run_anvil_audit.py
+++ b/anvil_consortium_manager/management/commands/run_anvil_audit.py
@@ -80,7 +80,7 @@ class Command(BaseCommand):
                     "anvil_consortium_manager/email_audit_report.html",
                     context={
                         "model_name": audit_name,
-                        "verified_results": len(audit_results.get_verified_results()),
+                        "verified_results": audit_results.get_verified_results(),
                         "errors_table": ErrorTableWithLink(
                             audit_results.get_error_results()
                         ),

--- a/anvil_consortium_manager/tests/test_commands.py
+++ b/anvil_consortium_manager/tests/test_commands.py
@@ -149,6 +149,8 @@ class RunAnvilAuditTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(pprint.pformat(audit_results.export()), email.body)
         # HTML body.
         self.assertEqual(len(email.alternatives), 1)
+        # Check that the number of "ok" instances is correct in email body.
+        self.assertIn("1 instance(s) verified", email.alternatives[0][0])
 
     def test_command_run_audit_ok_email_errors_only(self):
         """Test command output when email and errors_only is set."""


### PR DESCRIPTION
Previously, this was printing 0 due to a bug. Now it prints the correct number. Add a test to check for this behavior.

Closes #406 