### PR TITLE
Fix unexpected errors with deactivated accounts and managed group membership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add filtering in list views.
 * Bugfix: Print the correct number of "ok" instances in audit emails. 0.18 introduced a bug where the email included "0 instance(s) verified even if there was more than one verified instance.
 * Bugfix: ManagedGroupMembershipAudit does not unexpectedly show errors for deactivated accounts that were in the group before they were deactivated.
+* Bugfix: ManagedGroupMembershipAudit now raises the correct exception when instantiated with a ManagedGroup that is not managed by the app.
 
 ## 0.18 (2023-10-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add filtering in list views.
 * Bugfix: Print the correct number of "ok" instances in audit emails. 0.18 introduced a bug where the email included "0 instance(s) verified even if there was more than one verified instance.
+* Bugfix: ManagedGroupMembershipAudit does not unexpectedly show errors for deactivated accounts that were in the group before they were deactivated.
 
 ## 0.18 (2023-10-03)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.19dev2"
+__version__ = "0.19dev3"

--- a/anvil_consortium_manager/audit/audit.py
+++ b/anvil_consortium_manager/audit/audit.py
@@ -287,7 +287,7 @@ class ManagedGroupMembershipAudit(AnVILAudit):
         super().__init__(*args, **kwargs)
         if not managed_group.is_managed_by_app:
             raise exceptions.AnVILNotGroupAdminError(
-                "group {} is not managed by app".format(self.name)
+                "group {} is not managed by app".format(managed_group.name)
             )
         self.managed_group = managed_group
 

--- a/anvil_consortium_manager/tests/test_audit.py
+++ b/anvil_consortium_manager/tests/test_audit.py
@@ -2,7 +2,7 @@ import responses
 from django.test import TestCase
 from faker import Faker
 
-from .. import models
+from .. import exceptions, models
 from ..audit import audit
 from . import api_factories, factories
 from .utils import AnVILAPIMockTestMixin
@@ -1475,6 +1475,11 @@ class ManagedGroupMembershipAuditTest(AnVILAPIMockTestMixin, TestCase):
         return (
             self.api_client.sam_entry_point + "/api/groups/v1/" + group_name + "/admin"
         )
+
+    def test_group_not_managed_by_app(self):
+        group = factories.ManagedGroupFactory.create(is_managed_by_app=False)
+        with self.assertRaises(exceptions.AnVILNotGroupAdminError):
+            audit.ManagedGroupMembershipAudit(group)
 
     def test_no_members(self):
         """audit works correctly if this group has no members."""


### PR DESCRIPTION
* Update the ManagedGroupMembershipAudit to consider account status when checking membership. It now does not show audit errors for a deactivated account when the record of a group membership exists in the app but not on AnVIL, and does show audit errors if the deactivated account is in the group on AnVIL.

Closes #404 