### PR TITLE
Ignore groups when not admin in audit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Bugfix: Print the correct number of "ok" instances in audit emails. 0.18 introduced a bug where the email included "0 instance(s) verified even if there was more than one verified instance.
 * Bugfix: ManagedGroupMembershipAudit does not unexpectedly show errors for deactivated accounts that were in the group before they were deactivated.
 * Bugfix: ManagedGroupMembershipAudit now raises the correct exception when instantiated with a ManagedGroup that is not managed by the app.
+* Bugfix: ManagedGroupAudit does not report missing groups where the app is only a member.
 
 ## 0.18 (2023-10-03)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.19dev3"
+__version__ = "0.19dev4"

--- a/anvil_consortium_manager/audit/audit.py
+++ b/anvil_consortium_manager/audit/audit.py
@@ -254,7 +254,9 @@ class ManagedGroupAudit(AnVILAudit):
 
         # Check for groups that exist on AnVIL but not the app.
         for group_name in groups_on_anvil:
-            self.add_result(NotInAppResult(group_name))
+            # Only report the ones where the app is an admin.
+            if "admin" in groups_on_anvil[group_name]:
+                self.add_result(NotInAppResult(group_name))
 
 
 class ManagedGroupMembershipAudit(AnVILAudit):

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -6654,7 +6654,7 @@ class ManagedGroupAuditTest(AnVILAPIMockTestMixin, TestCase):
             responses.GET,
             api_url,
             status=200,
-            json=[self.get_api_group_json("foo", "Member")],
+            json=[self.get_api_group_json("foo", "Admin")],
         )
         self.client.force_login(self.user)
         response = self.client.get(self.get_url())


### PR DESCRIPTION
The ManagedGroupAudit now ignores groups that don't exist in the app where the service account is not a member.

Closes #404 