### PR TITLE
Modify autocomplete for ManagedGroups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Bugfix: ManagedGroupMembershipAudit does not unexpectedly show errors for deactivated accounts that were in the group before they were deactivated.
 * Bugfix: ManagedGroupMembershipAudit now raises the correct exception when instantiated with a ManagedGroup that is not managed by the app.
 * Bugfix: ManagedGroupAudit does not report missing groups where the app is only a member.
+* Bugfix: Allow groups not managed by the app to be added as child groups of another group, and allow workspaces to be shared with them.
 
 ## 0.18 (2023-10-03)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.19dev4"
+__version__ = "0.19dev5"

--- a/anvil_consortium_manager/forms.py
+++ b/anvil_consortium_manager/forms.py
@@ -3,7 +3,7 @@
 from crispy_bootstrap5.bootstrap5 import FloatingField
 from crispy_forms import layout
 from crispy_forms.helper import FormHelper
-from dal import autocomplete
+from dal import autocomplete, forward
 from django import VERSION as DJANGO_VERSION
 from django import forms
 from django.conf import settings
@@ -335,6 +335,7 @@ class GroupGroupMembershipForm(Bootstrap5MediaFormMixin, forms.ModelForm):
         widget=autocomplete.ModelSelect2(
             url="anvil_consortium_manager:managed_groups:autocomplete",
             attrs={"data-theme": "bootstrap-5"},
+            forward=(forward.Const(True, "only_managed_by_app"),),
         ),
         help_text="Select the group to add the child group to. Only groups that are managed by this app are shown.",
     )
@@ -374,6 +375,7 @@ class GroupAccountMembershipForm(Bootstrap5MediaFormMixin, forms.ModelForm):
             attrs={
                 "data-theme": "bootstrap-5",
             },
+            forward=(forward.Const(True, "only_managed_by_app"),),
         ),
     )
 

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -1003,10 +1003,14 @@ class ManagedGroupAutocomplete(
 
     def get_queryset(self):
         # Filter out unathorized users, or does the auth mixin do that?
-        qs = models.ManagedGroup.objects.filter(is_managed_by_app=True).order_by("name")
+        qs = models.ManagedGroup.objects.order_by("name")
+
+        only_managed_by_app = self.forwarded.get("only_managed_by_app", None)
 
         if self.q:
             qs = qs.filter(name__icontains=self.q)
+        if only_managed_by_app:
+            qs = qs.filter(is_managed_by_app=True)
 
         return qs
 


### PR DESCRIPTION
* Optionally allow the user to specify that ManagedGroupAutocomplete should only return groups that are managed by the app using a forwarded value.
* Modify the GroupGroupMembershipForm to pass  only_managed_by_app forwarded value to autocomplete for the parent group.
* Modify the GroupAccountMembershipForm to pass  only_managed_by_app forwarded value to autocomplete for the group.

This allows child groups to be added as members of another group, and also allows workspaces to be shared with them.

Closes #399 