### PR TITLE
Make the WorkspaceDetail View visible to anyone with View permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Add docs dependencies to hatch via pyproject.toml.
 * Add requests as a direct dependency instead of as an extra to google-auth.
+* Rename existing tables to include "Staff" in the name, in preparation for adding tables that are viewable by non-staff users.
+* Modify the WorkspaceDetail view to be viewable by users with anvil_consortium_manager_view permission. A limited set of information is shown to users with this permission compared to those with anvil_consortium_manager_staff_view permission.
 
 ## 0.20.1 (2023-11-09)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.21.0.dev1"
+__version__ = "0.21.0.dev2"

--- a/anvil_consortium_manager/adapters/default.py
+++ b/anvil_consortium_manager/adapters/default.py
@@ -21,5 +21,5 @@ class DefaultWorkspaceAdapter(BaseWorkspaceAdapter):
     workspace_form_class = forms.WorkspaceForm
     workspace_data_model = models.DefaultWorkspaceData
     workspace_data_form_class = forms.DefaultWorkspaceDataForm
-    list_table_class = tables.WorkspaceTable
+    list_table_class = tables.WorkspaceStaffTable
     workspace_detail_template_name = "anvil_consortium_manager/workspace_detail.html"

--- a/anvil_consortium_manager/adapters/default.py
+++ b/anvil_consortium_manager/adapters/default.py
@@ -8,7 +8,7 @@ from .workspace import BaseWorkspaceAdapter
 class DefaultAccountAdapter(BaseAccountAdapter):
     """Default account adapter for use with the app."""
 
-    list_table_class = tables.AccountTable
+    list_table_class = tables.AccountStaffTable
     list_filterset_class = filters.AccountListFilter
 
 

--- a/anvil_consortium_manager/models.py
+++ b/anvil_consortium_manager/models.py
@@ -342,6 +342,11 @@ class Account(TimeStampedModel, ActivatorModel):
                 groups.add(group)
         return groups
 
+    def has_workspace_access(self, workspace):
+        """Return a boolean indicator of whether the workspace can be accessed by this Account."""
+        accessible_workspaces = self.get_accessible_workspaces()
+        return workspace in accessible_workspaces
+
 
 class ManagedGroup(TimeStampedModel):
     """A model to store information about AnVIL Managed Groups."""

--- a/anvil_consortium_manager/models.py
+++ b/anvil_consortium_manager/models.py
@@ -691,15 +691,6 @@ class Workspace(TimeStampedModel):
         is_shared = self.workspacegroupsharing_set.filter(models.Q(group=group) | models.Q(group__in=parents)).exists()
         return is_shared
 
-    def has_access(self, group):
-        """Check if a group has access to a workspace.
-
-        Both criteria need to be met for a group to have access to a workspace:
-        1. The workspace must be shared with the group (or a group that it is in).
-        2. The group (or a group that it is in) must be in all auth domains for the workspace.
-        """
-        return self.is_shared(group) and self.is_in_authorization_domain(group)
-
     def anvil_exists(self):
         """Check if the workspace exists on AnVIL."""
         try:

--- a/anvil_consortium_manager/tables.py
+++ b/anvil_consortium_manager/tables.py
@@ -21,7 +21,7 @@ class BillingProjectStaffTable(tables.Table):
         fields = ("name", "has_app_as_user")
 
 
-class AccountTable(tables.Table):
+class AccountStaffTable(tables.Table):
     """Class to display a BillingProject table."""
 
     email = tables.Column(linkify=True)

--- a/anvil_consortium_manager/tables.py
+++ b/anvil_consortium_manager/tables.py
@@ -104,7 +104,7 @@ class WorkspaceStaffTable(tables.Table):
         return self.registered_names[record.workspace_type]
 
 
-class GroupGroupMembershipTable(tables.Table):
+class GroupGroupMembershipStaffTable(tables.Table):
     """Class to render a GroupGroupMembership table."""
 
     pk = tables.Column(linkify=True, verbose_name="Details", orderable=False)
@@ -121,7 +121,7 @@ class GroupGroupMembershipTable(tables.Table):
         return "See details"
 
 
-class GroupAccountMembershipTable(tables.Table):
+class GroupAccountMembershipStaffTable(tables.Table):
     """Class to render a GroupAccountMembership table."""
 
     pk = tables.Column(linkify=True, verbose_name="Details", orderable=False)

--- a/anvil_consortium_manager/tables.py
+++ b/anvil_consortium_manager/tables.py
@@ -5,7 +5,7 @@ from . import models
 from .adapters.workspace import workspace_adapter_registry
 
 
-class BillingProjectTable(tables.Table):
+class BillingProjectStaffTable(tables.Table):
     """Class to display a BillingProject table."""
 
     name = tables.Column(linkify=True)

--- a/anvil_consortium_manager/tables.py
+++ b/anvil_consortium_manager/tables.py
@@ -76,7 +76,7 @@ class ManagedGroupStaffTable(tables.Table):
             return value
 
 
-class WorkspaceTable(tables.Table):
+class WorkspaceStaffTable(tables.Table):
     """Class to display a Workspace table."""
 
     name = tables.Column(linkify=True, verbose_name="Workspace")

--- a/anvil_consortium_manager/tables.py
+++ b/anvil_consortium_manager/tables.py
@@ -41,7 +41,7 @@ class AccountStaffTable(tables.Table):
             return str(record.user)
 
 
-class ManagedGroupTable(tables.Table):
+class ManagedGroupStaffTable(tables.Table):
     """Class to display a Group table."""
 
     name = tables.Column(linkify=True)

--- a/anvil_consortium_manager/tables.py
+++ b/anvil_consortium_manager/tables.py
@@ -140,7 +140,7 @@ class GroupAccountMembershipStaffTable(tables.Table):
         return "See details"
 
 
-class WorkspaceGroupSharingTable(tables.Table):
+class WorkspaceGroupSharingStaffTable(tables.Table):
     """Class to render a WorkspaceGroupSharing table."""
 
     pk = tables.Column(linkify=True, verbose_name="Details", orderable=False)

--- a/anvil_consortium_manager/tables.py
+++ b/anvil_consortium_manager/tables.py
@@ -76,6 +76,16 @@ class ManagedGroupStaffTable(tables.Table):
             return value
 
 
+class ManagedGroupUserTable(tables.Table):
+    """Class to display a Group table for users with view permission."""
+
+    name = tables.Column()
+
+    class Meta:
+        model = models.ManagedGroup
+        fields = ("name",)
+
+
 class WorkspaceStaffTable(tables.Table):
     """Class to display a Workspace table."""
 

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
@@ -53,6 +53,8 @@
       </div>
     </div>
   </div>
+
+  {% if perms.anvil_consortium_manager.anvil_consortium_manager_staff_view %}
   <div class="my-3">
     <div class="accordion" id="accordionGroups">
       <div class="accordion-item">
@@ -74,6 +76,7 @@
       </div>
     </div>
   </div>
+  {% endif %}
 {% endblock after_panel %}
 
 {% block action_buttons %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
@@ -18,7 +18,12 @@
   <span class="badge bg-danger"><span class="fa-solid fa-lock me-2"></span>Locked</span>
   {% endif %}
 
-  <span class="badge bg-{% if has_access %}success{% else %}danger{% endif %}">
+  <span
+    class="badge bg-{% if has_access %}success{% else %}danger{% endif %}"
+    data-bs-toggle="tooltip"
+    data-bs-placement="bottom"
+    data-bs-title="To have access to a workspace, you must be in all of the authorization doains for the workspace and the workspace must be shared with you."
+    >
     <span class="me-2 fa-solid fa-{% if has_access %}lock-open{% else %}lock{% endif %}"></span>
     {% if has_access %}
       You have access to this workspace

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
@@ -7,10 +7,12 @@
 
 
 {% block after_title %}
+  {% if has_access or user.is_superuser %}
   <a class="btn btn-light" href="{{ object.get_anvil_url }}" target="_blank" role="button">
     <span class="fa-solid fa-arrow-up-right-from-square mx-1"></span>
     View on AnVIL
   </a>
+  {% endif %}
 {% endblock after_title %}
 
 {% block pills %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
@@ -10,18 +10,18 @@
   <span class="badge bg-danger"><span class="fa-solid fa-lock me-2"></span>Locked</span>
   {% endif %}
 
-  <span
-    class="badge bg-{% if has_access %}success{% else %}danger{% endif %}"
-    data-bs-toggle="tooltip"
-    data-bs-placement="bottom"
-    data-bs-title="To have access to a workspace, you must be in all of the authorization doains for the workspace and the workspace must be shared with you."
-    >
+  <span class="badge bg-{% if has_access %}success{% else %}danger{% endif %}">
     <span class="me-2 fa-solid fa-{% if has_access %}lock-open{% else %}lock{% endif %}"></span>
     {% if has_access %}
       You have access to this workspace
     {% else %}
       No access to workspace
     {% endif %}
+    <span class="ms-2 fa-solid fa-circle-question"
+    data-bs-toggle="tooltip"
+    data-bs-placement="bottom"
+    data-bs-title="To have access to a workspace, you must be in all of the authorization doains for the workspace and the workspace must be shared with you."
+    ></span>
   </span>
 
   {% if has_access or user.is_superuser %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
@@ -21,7 +21,15 @@
 
 {% block panel %}
 <dl class="row">
-  <dt class="col-sm-2">Billing project</dt> <dd class="col-sm-10"><a href="{{ object.billing_project.get_absolute_url }}">{{ object.billing_project }}</a></dd>
+  <dt class="col-sm-2">Billing project</dt> <dd class="col-sm-10">
+    {% if perms.anvil_consortium_manager.anvil_consortium_manager_staff_view %}
+      <a href="{{ object.billing_project.get_absolute_url }}">
+    {% endif %}
+      {{ object.billing_project }}
+    {% if perms.anvil_consortium_manager.anvil_consortium_manager_staff_view %}
+    </a>
+    {% endif %}
+  </dd>
   <dt class="col-sm-2">Name</dt> <dd class="col-sm-10">{{ object.name }}</dd>
   <dt class="col-sm-2">Date added</dt> <dd class="col-sm-10">{{ object.created }}</dd>
   <dt class="col-sm-2">Date modified</dt> <dd class="col-sm-10">{{ object.modified }}</dd>

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
@@ -17,11 +17,16 @@
   {% if object.is_locked %}
   <span class="badge bg-danger"><span class="fa-solid fa-lock me-2"></span>Locked</span>
   {% endif %}
-  {% if has_access %}
-  <span class="badge bg-success"><span class="fa-solid fa-lock-open me-2"></span>You have access to this workspace</span>
-  {% else %}
-  <span class="badge bg-danger"><span class="fa-solid fa-lock me-2"></span>No access to workspace</span>
-  {% endif %}
+
+  <span class="badge bg-{% if has_access %}success{% else %}danger{% endif %}">
+    <span class="me-2 fa-solid fa-{% if has_access %}lock-open{% else %}lock{% endif %}"></span>
+    {% if has_access %}
+      You have access to this workspace
+    {% else %}
+      No access to workspace
+    {% endif %}
+  </span>
+
 {% endblock pills %}
 
 {% block panel %}
@@ -118,3 +123,12 @@
   {% endif %}
   </p>
 {% endblock action_buttons %}
+
+
+{% block inline_javascript %}
+<script>
+  $(document).ready(function(){
+      $('[data-bs-toggle="tooltip"]').tooltip();
+  });
+</script>
+{% endblock inline_javascript %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
@@ -17,6 +17,11 @@
   {% if object.is_locked %}
   <span class="badge bg-danger"><span class="fa-solid fa-lock me-2"></span>Locked</span>
   {% endif %}
+  {% if has_access %}
+  <span class="badge bg-success"><span class="fa-solid fa-lock-open me-2"></span>You have access to this workspace</span>
+  {% else %}
+  <span class="badge bg-danger"><span class="fa-solid fa-lock me-2"></span>No access to workspace</span>
+  {% endif %}
 {% endblock pills %}
 
 {% block panel %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
@@ -20,7 +20,7 @@
     <span class="ms-2 fa-solid fa-circle-question"
     data-bs-toggle="tooltip"
     data-bs-placement="bottom"
-    data-bs-title="To have access to a workspace, you must be in all of the authorization doains for the workspace and the workspace must be shared with you."
+    data-bs-title="To have access to a workspace, you must have linked an AnVIL account, be in all of the authorization domains for the workspace, and have the workspace shared with you."
     ></span>
   </span>
 

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
@@ -45,8 +45,11 @@
     {% endif %}
   </dd>
   <dt class="col-sm-2">Name</dt> <dd class="col-sm-10">{{ object.name }}</dd>
+
+  {% if perms.anvil_consortium_manager.anvil_consortium_manager_staff_view %}
   <dt class="col-sm-2">Date added</dt> <dd class="col-sm-10">{{ object.created }}</dd>
   <dt class="col-sm-2">Date modified</dt> <dd class="col-sm-10">{{ object.modified }}</dd>
+  {% endif %}
 </dl>
   {% block workspace_data %}
   {% endblock workspace_data %}

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
@@ -5,16 +5,6 @@
 
 {% block title %}{{ workspace_type_display_name }}: {{ object }}{% endblock %}
 
-
-{% block after_title %}
-  {% if has_access or user.is_superuser %}
-  <a class="btn btn-light" href="{{ object.get_anvil_url }}" target="_blank" role="button">
-    <span class="fa-solid fa-arrow-up-right-from-square mx-1"></span>
-    View on AnVIL
-  </a>
-  {% endif %}
-{% endblock after_title %}
-
 {% block pills %}
   {% if object.is_locked %}
   <span class="badge bg-danger"><span class="fa-solid fa-lock me-2"></span>Locked</span>
@@ -33,6 +23,13 @@
       No access to workspace
     {% endif %}
   </span>
+
+  {% if has_access or user.is_superuser %}
+  <a class="badge bg-light text-dark btn btn-light" href="{{ object.get_anvil_url }}" target="_blank" role="button">
+    <span class="fa-solid fa-arrow-up-right-from-square mx-1"></span>
+    View on AnVIL
+  </a>
+  {% endif %}
 
 {% endblock pills %}
 

--- a/anvil_consortium_manager/tests/test_adapters.py
+++ b/anvil_consortium_manager/tests/test_adapters.py
@@ -13,7 +13,7 @@ from ..adapters.workspace import (
 from ..filters import AccountListFilter, BillingProjectListFilter
 from ..forms import DefaultWorkspaceDataForm, WorkspaceForm
 from ..models import Account, DefaultWorkspaceData
-from ..tables import AccountStaffTable, WorkspaceTable
+from ..tables import AccountStaffTable, WorkspaceStaffTable
 from . import factories
 from .test_app import filters, forms, models, tables
 from .test_app.adapters import TestWorkspaceAdapter
@@ -145,7 +145,7 @@ class WorkspaceAdapterTest(TestCase):
 
     def test_list_table_class_default(self):
         """get_list_table_class returns the correct table when using the default adapter."""
-        self.assertEqual(DefaultWorkspaceAdapter().get_list_table_class(), WorkspaceTable)
+        self.assertEqual(DefaultWorkspaceAdapter().get_list_table_class(), WorkspaceStaffTable)
 
     def test_list_table_class_custom(self):
         """get_list_table_class returns the correct table when using a custom adapter."""

--- a/anvil_consortium_manager/tests/test_adapters.py
+++ b/anvil_consortium_manager/tests/test_adapters.py
@@ -13,7 +13,7 @@ from ..adapters.workspace import (
 from ..filters import AccountListFilter, BillingProjectListFilter
 from ..forms import DefaultWorkspaceDataForm, WorkspaceForm
 from ..models import Account, DefaultWorkspaceData
-from ..tables import AccountTable, WorkspaceTable
+from ..tables import AccountStaffTable, WorkspaceTable
 from . import factories
 from .test_app import filters, forms, models, tables
 from .test_app.adapters import TestWorkspaceAdapter
@@ -26,20 +26,20 @@ class AccountAdapterTestCase(TestCase):
         """Return a test adapter class for use in tests."""
 
         class TestAdapter(BaseAccountAdapter):
-            list_table_class = tables.TestAccountTable
+            list_table_class = tables.TestAccountStaffTable
             list_filterset_class = filters.TestAccountListFilter
 
         return TestAdapter
 
     def test_list_table_class_default(self):
         """get_list_table_class returns the correct table when using the default adapter."""
-        self.assertEqual(DefaultAccountAdapter().get_list_table_class(), AccountTable)
+        self.assertEqual(DefaultAccountAdapter().get_list_table_class(), AccountStaffTable)
 
     def test_list_table_class_custom(self):
         """get_list_table_class returns the correct table when using a custom adapter."""
         TestAdapter = self.get_test_adapter()
-        setattr(TestAdapter, "list_table_class", tables.TestAccountTable)
-        self.assertEqual(TestAdapter().get_list_table_class(), tables.TestAccountTable)
+        setattr(TestAdapter, "list_table_class", tables.TestAccountStaffTable)
+        self.assertEqual(TestAdapter().get_list_table_class(), tables.TestAccountStaffTable)
 
     def test_list_table_class_none(self):
         """get_list_table_class raises ImproperlyConfigured when list_table_class is not set."""

--- a/anvil_consortium_manager/tests/test_app/adapters.py
+++ b/anvil_consortium_manager/tests/test_app/adapters.py
@@ -1,7 +1,7 @@
 from anvil_consortium_manager.adapters.account import BaseAccountAdapter
 from anvil_consortium_manager.adapters.workspace import BaseWorkspaceAdapter
 from anvil_consortium_manager.forms import WorkspaceForm
-from anvil_consortium_manager.tables import WorkspaceTable
+from anvil_consortium_manager.tables import WorkspaceStaffTable
 
 from . import filters, forms, models, tables
 
@@ -49,7 +49,7 @@ class TestForeignKeyWorkspaceAdapter(BaseWorkspaceAdapter):
     name = "Test foreign key workspace"
     type = "test_fk"
     description = "Workspace type for testing"
-    list_table_class = WorkspaceTable
+    list_table_class = WorkspaceStaffTable
     workspace_form_class = WorkspaceForm
     workspace_data_model = models.TestForeignKeyWorkspaceData
     workspace_data_form_class = forms.TestForeignKeyWorkspaceDataForm

--- a/anvil_consortium_manager/tests/test_app/adapters.py
+++ b/anvil_consortium_manager/tests/test_app/adapters.py
@@ -31,7 +31,7 @@ class TestWorkspaceAdapter(BaseWorkspaceAdapter):
 class TestAccountAdapter(BaseAccountAdapter):
     """Test adapter for accounts."""
 
-    list_table_class = tables.TestAccountTable
+    list_table_class = tables.TestAccountStaffTable
     list_filterset_class = filters.TestAccountListFilter
 
     def get_autocomplete_queryset(self, queryset, q):

--- a/anvil_consortium_manager/tests/test_app/tables.py
+++ b/anvil_consortium_manager/tests/test_app/tables.py
@@ -13,7 +13,7 @@ class TestWorkspaceDataTable(tables.Table):
         fields = ("testworkspacedata__study_name", "name")
 
 
-class TestAccountTable(tables.Table):
+class TestAccountStaffTable(tables.Table):
     """Table for testing the Account adapter."""
 
     email = tables.columns.Column(linkify=True)

--- a/anvil_consortium_manager/tests/test_models.py
+++ b/anvil_consortium_manager/tests/test_models.py
@@ -1684,46 +1684,6 @@ class WorkspaceGroupSharingMethodsTest(TestCase):
         self.assertFalse(self.workspace.is_shared(self.group))
         self.assertFalse(self.group.is_shared(self.workspace))
 
-    def test_has_access_shared_no_auth_domain(self):
-        """Returns True when the group is shared and there is no auth domain."""
-        factories.WorkspaceGroupSharingFactory.create(workspace=self.workspace, group=self.group)
-        self.assertTrue(self.workspace.has_access(self.group))
-        self.assertTrue(self.group.has_access(self.workspace))
-
-    def test_has_access_not_shared_no_auth_domain(self):
-        """Returns False when the group is not shared and there is no auth domain."""
-        self.assertFalse(self.workspace.has_access(self.group))
-        self.assertFalse(self.group.has_access(self.workspace))
-
-    def test_has_access_shared_in_auth_domain(self):
-        """Returns True when the group is shared and in the auth domain."""
-        self.workspace.authorization_domains.add(self.auth_domain)
-        factories.GroupGroupMembershipFactory.create(parent_group=self.auth_domain, child_group=self.group)
-        factories.WorkspaceGroupSharingFactory.create(workspace=self.workspace, group=self.group)
-        self.assertTrue(self.workspace.has_access(self.group))
-        self.assertTrue(self.group.has_access(self.workspace))
-
-    def test_has_access_shared_not_in_auth_domain(self):
-        """Returns False when the group is shared but not in the auth domain."""
-        self.workspace.authorization_domains.add(self.auth_domain)
-        factories.WorkspaceGroupSharingFactory.create(workspace=self.workspace, group=self.group)
-        self.assertFalse(self.workspace.has_access(self.group))
-        self.assertFalse(self.group.has_access(self.workspace))
-
-    def test_has_access_not_shared_in_auth_domain(self):
-        """Returns False when the group is not shared but in the auth domain."""
-        self.workspace.authorization_domains.add(self.auth_domain)
-        factories.GroupGroupMembershipFactory.create(parent_group=self.auth_domain, child_group=self.group)
-        self.assertFalse(self.workspace.has_access(self.group))
-        self.assertFalse(self.group.has_access(self.workspace))
-
-    def test_has_access_not_shared_not_in_auth_domain(self):
-        """Returns False when the group is not shared and not in the auth domain."""
-        self.workspace.authorization_domains.add(self.auth_domain)
-        factories.WorkspaceGroupSharingFactory.create(workspace=self.workspace, group=self.group)
-        self.assertFalse(self.workspace.has_access(self.group))
-        self.assertFalse(self.group.has_access(self.workspace))
-
 
 class WorkspaceDataTest(TestCase):
     """Tests for the WorkspaceData models (default and base)."""

--- a/anvil_consortium_manager/tests/test_tables.py
+++ b/anvil_consortium_manager/tests/test_tables.py
@@ -144,10 +144,10 @@ class ManagedGroupStaffTableTest(TestCase):
         self.assertEqual(table.rows[0].get_cell("number_accounts"), table.default)
 
 
-class WorkspaceTableTest(TestCase):
+class WorkspaceStaffTableTest(TestCase):
     model = models.Workspace
     model_factory = factories.WorkspaceFactory
-    table_class = tables.WorkspaceTable
+    table_class = tables.WorkspaceStaffTable
 
     def test_row_count_with_no_objects(self):
         table = self.table_class(self.model.objects.all())

--- a/anvil_consortium_manager/tests/test_tables.py
+++ b/anvil_consortium_manager/tests/test_tables.py
@@ -37,10 +37,10 @@ class BillingProjectStaffTableTest(TestCase):
         self.assertEqual(table.rows[2].get_cell("number_workspaces"), 2)
 
 
-class AccountTableTest(TestCase):
+class AccountStaffTableTest(TestCase):
     model = models.Account
     model_factory = factories.AccountFactory
-    table_class = tables.AccountTable
+    table_class = tables.AccountStaffTable
 
     def tearDown(self):
         # One of the testes dynamically sets the get_absolute_url method..

--- a/anvil_consortium_manager/tests/test_tables.py
+++ b/anvil_consortium_manager/tests/test_tables.py
@@ -195,10 +195,10 @@ class WorkspaceStaffTableTest(TestCase):
         # self.assertEqual(table.rows[2].get_cell("number_groups"), 2)
 
 
-class GroupGroupMembershipTableTest(TestCase):
+class GroupGroupMembershipStaffTableTest(TestCase):
     model = models.GroupGroupMembership
     model_factory = factories.GroupGroupMembershipFactory
-    table_class = tables.GroupGroupMembershipTable
+    table_class = tables.GroupGroupMembershipStaffTable
 
     def test_row_count_with_no_objects(self):
         table = self.table_class(self.model.objects.all())
@@ -215,10 +215,10 @@ class GroupGroupMembershipTableTest(TestCase):
         self.assertEqual(len(table.rows), 2)
 
 
-class GroupAccountMembershipTableTest(TestCase):
+class GroupAccountMembershipStaffTableTest(TestCase):
     model = models.GroupAccountMembership
     model_factory = factories.GroupAccountMembershipFactory
-    table_class = tables.GroupAccountMembershipTable
+    table_class = tables.GroupAccountMembershipStaffTable
 
     def test_row_count_with_no_objects(self):
         table = self.table_class(self.model.objects.all())

--- a/anvil_consortium_manager/tests/test_tables.py
+++ b/anvil_consortium_manager/tests/test_tables.py
@@ -6,10 +6,10 @@ from ..adapters.default import DefaultWorkspaceAdapter
 from . import factories
 
 
-class BillingProjectTableTest(TestCase):
+class BillingProjectStaffTableTest(TestCase):
     model = models.BillingProject
     model_factory = factories.BillingProjectFactory
-    table_class = tables.BillingProjectTable
+    table_class = tables.BillingProjectStaffTable
 
     def test_row_count_with_no_objects(self):
         table = self.table_class(self.model.objects.all())

--- a/anvil_consortium_manager/tests/test_tables.py
+++ b/anvil_consortium_manager/tests/test_tables.py
@@ -86,6 +86,26 @@ class AccountStaffTableTest(TestCase):
         self.assertIn("test_profile_testuser", table.rows[0].get_cell("user"))
 
 
+class ManagedGroupUserTableTest(TestCase):
+    model = models.ManagedGroup
+    model_factory = factories.ManagedGroupFactory
+    table_class = tables.ManagedGroupUserTable
+
+    def test_row_count_with_no_objects(self):
+        table = self.table_class(self.model.objects.all())
+        self.assertEqual(len(table.rows), 0)
+
+    def test_row_count_with_one_object(self):
+        self.model_factory.create()
+        table = self.table_class(self.model.objects.all())
+        self.assertEqual(len(table.rows), 1)
+
+    def test_row_count_with_two_objects(self):
+        self.model_factory.create_batch(2)
+        table = self.table_class(self.model.objects.all())
+        self.assertEqual(len(table.rows), 2)
+
+
 class ManagedGroupStaffTableTest(TestCase):
     model = models.ManagedGroup
     model_factory = factories.ManagedGroupFactory

--- a/anvil_consortium_manager/tests/test_tables.py
+++ b/anvil_consortium_manager/tests/test_tables.py
@@ -86,10 +86,10 @@ class AccountStaffTableTest(TestCase):
         self.assertIn("test_profile_testuser", table.rows[0].get_cell("user"))
 
 
-class ManagedGroupTableTest(TestCase):
+class ManagedGroupStaffTableTest(TestCase):
     model = models.ManagedGroup
     model_factory = factories.ManagedGroupFactory
-    table_class = tables.ManagedGroupTable
+    table_class = tables.ManagedGroupStaffTable
 
     def test_row_count_with_no_objects(self):
         table = self.table_class(self.model.objects.all())

--- a/anvil_consortium_manager/tests/test_tables.py
+++ b/anvil_consortium_manager/tests/test_tables.py
@@ -242,10 +242,10 @@ class GroupAccountMembershipStaffTableTest(TestCase):
         self.assertEqual(len(table.rows), 1)
 
 
-class WorkspaceGroupSharingTable(TestCase):
+class WorkspaceGroupSharingStaffTable(TestCase):
     model = models.WorkspaceGroupSharing
     model_factory = factories.WorkspaceGroupSharingFactory
-    table_class = tables.WorkspaceGroupSharingTable
+    table_class = tables.WorkspaceGroupSharingStaffTable
 
     def test_row_count_with_no_objects(self):
         table = self.table_class(self.model.objects.all())

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -1384,7 +1384,7 @@ class AccountDetailTest(TestCase):
         self.assertIn("accessible_workspace_table", response.context_data)
         self.assertIsInstance(
             response.context_data["accessible_workspace_table"],
-            tables.WorkspaceGroupSharingTable,
+            tables.WorkspaceGroupSharingStaffTable,
         )
 
     def test_accessible_workspace_none(self):
@@ -4343,7 +4343,7 @@ class ManagedGroupDetailTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url(obj.name))
         self.assertIn("workspace_table", response.context_data)
-        self.assertIsInstance(response.context_data["workspace_table"], tables.WorkspaceGroupSharingTable)
+        self.assertIsInstance(response.context_data["workspace_table"], tables.WorkspaceGroupSharingStaffTable)
 
     def test_workspace_table_none(self):
         """No workspaces are shown if the group does not have access to any workspaces."""
@@ -6438,7 +6438,7 @@ class WorkspaceDetailTest(TestCase):
         self.assertIn("group_sharing_table", response.context_data)
         self.assertIsInstance(
             response.context_data["group_sharing_table"],
-            tables.WorkspaceGroupSharingTable,
+            tables.WorkspaceGroupSharingStaffTable,
         )
 
     def test_group_sharing_table_none(self):
@@ -20968,7 +20968,7 @@ class WorkspaceGroupSharingListTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url())
         self.assertIn("table", response.context_data)
-        self.assertIsInstance(response.context_data["table"], tables.WorkspaceGroupSharingTable)
+        self.assertIsInstance(response.context_data["table"], tables.WorkspaceGroupSharingStaffTable)
 
     def test_view_with_no_objects(self):
         self.client.force_login(self.user)

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -2778,7 +2778,7 @@ class AccountListTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url())
         self.assertIn("table", response.context_data)
-        self.assertIsInstance(response.context_data["table"], tables.AccountTable)
+        self.assertIsInstance(response.context_data["table"], tables.AccountStaffTable)
 
     def test_view_with_no_objects(self):
         self.client.force_login(self.user)
@@ -2896,7 +2896,7 @@ class AccountListTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url())
         self.assertIn("table", response.context_data)
-        self.assertIsInstance(response.context_data["table"], app_tables.TestAccountTable)
+        self.assertIsInstance(response.context_data["table"], app_tables.TestAccountStaffTable)
         self.assertIsInstance(response.context_data["filter"], TestAccountListFilter)
 
 
@@ -2953,7 +2953,7 @@ class AccountActiveListTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url())
         self.assertIn("table", response.context_data)
-        self.assertIsInstance(response.context_data["table"], tables.AccountTable)
+        self.assertIsInstance(response.context_data["table"], tables.AccountStaffTable)
 
     def test_filterset_class(self):
         factories.AccountFactory.create(email="account_test1@example.com")
@@ -3078,7 +3078,7 @@ class AccountActiveListTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url())
         self.assertIn("table", response.context_data)
-        self.assertIsInstance(response.context_data["table"], app_tables.TestAccountTable)
+        self.assertIsInstance(response.context_data["table"], app_tables.TestAccountStaffTable)
         self.assertIsInstance(response.context_data["filter"], TestAccountListFilter)
 
 
@@ -3135,7 +3135,7 @@ class AccountInactiveListTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url())
         self.assertIn("table", response.context_data)
-        self.assertIsInstance(response.context_data["table"], tables.AccountTable)
+        self.assertIsInstance(response.context_data["table"], tables.AccountStaffTable)
 
     def test_filterset_class(self):
         factories.AccountFactory.create(email="account_test1@example.com")
@@ -3254,7 +3254,7 @@ class AccountInactiveListTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url())
         self.assertIn("table", response.context_data)
-        self.assertIsInstance(response.context_data["table"], app_tables.TestAccountTable)
+        self.assertIsInstance(response.context_data["table"], app_tables.TestAccountStaffTable)
         self.assertIsInstance(response.context_data["filter"], TestAccountListFilter)
 
 

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -760,7 +760,7 @@ class BillingProjectDetailTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url(obj.name))
         self.assertIn("workspace_table", response.context_data)
-        self.assertIsInstance(response.context_data["workspace_table"], tables.WorkspaceTable)
+        self.assertIsInstance(response.context_data["workspace_table"], tables.WorkspaceStaffTable)
 
     def test_workspace_table_none(self):
         """No workspaces are shown if the billing project does not have any workspaces."""
@@ -4496,7 +4496,7 @@ class ManagedGroupDetailTest(TestCase):
         self.assertIn("workspace_authorization_domain_table", response.context_data)
         self.assertIsInstance(
             response.context_data["workspace_authorization_domain_table"],
-            tables.WorkspaceTable,
+            tables.WorkspaceStaffTable,
         )
 
     def test_workspace_auth_domain_table_none(self):
@@ -10761,7 +10761,7 @@ class WorkspaceListTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url())
         self.assertIn("table", response.context_data)
-        self.assertIsInstance(response.context_data["table"], tables.WorkspaceTable)
+        self.assertIsInstance(response.context_data["table"], tables.WorkspaceStaffTable)
 
     def test_view_with_no_objects(self):
         self.client.force_login(self.user)
@@ -10934,7 +10934,7 @@ class WorkspaceListByTypeTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url(self.workspace_type))
         self.assertIn("table", response.context_data)
-        self.assertIsInstance(response.context_data["table"], tables.WorkspaceTable)
+        self.assertIsInstance(response.context_data["table"], tables.WorkspaceStaffTable)
 
     def test_view_with_no_objects(self):
         self.client.force_login(self.user)

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -6535,6 +6535,19 @@ class WorkspaceDetailTest(TestCase):
         self.assertIn(group_1, table.data)
         self.assertIn(group_2, table.data)
 
+    def test_auth_domain_table_view_permission(self):
+        """Auth domain table has correct class when user has view permission only."""
+        user = User.objects.create_user(username="test-limited", password="test-limited")
+        user.user_permissions.add(
+            Permission.objects.get(codename=models.AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME)
+        )
+        workspace = factories.DefaultWorkspaceDataFactory.create()
+        factories.WorkspaceAuthorizationDomainFactory.create(workspace=workspace.workspace)
+        self.client.force_login(user)
+        response = self.client.get(workspace.get_absolute_url())
+        self.assertIn("authorization_domain_table", response.context_data)
+        self.assertIsInstance(response.context_data["authorization_domain_table"], tables.ManagedGroupUserTable)
+
     def test_shows_auth_domains_for_only_that_workspace(self):
         """Only shows auth domains for this workspace."""
         workspace = factories.DefaultWorkspaceDataFactory.create(workspace__name="workspace-1")

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -1299,7 +1299,7 @@ class AccountDetailTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url(obj.uuid))
         self.assertIn("group_table", response.context_data)
-        self.assertIsInstance(response.context_data["group_table"], tables.GroupAccountMembershipTable)
+        self.assertIsInstance(response.context_data["group_table"], tables.GroupAccountMembershipStaffTable)
 
     def test_group_account_membership_none(self):
         """No groups are shown if the account is not part of any groups."""
@@ -4389,7 +4389,7 @@ class ManagedGroupDetailTest(TestCase):
         self.assertIn("active_account_table", response.context_data)
         self.assertIsInstance(
             response.context_data["active_account_table"],
-            tables.GroupAccountMembershipTable,
+            tables.GroupAccountMembershipStaffTable,
         )
 
     def test_active_account_table_none(self):
@@ -4434,7 +4434,7 @@ class ManagedGroupDetailTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url(obj.name))
         self.assertIn("group_table", response.context_data)
-        self.assertIsInstance(response.context_data["group_table"], tables.GroupGroupMembershipTable)
+        self.assertIsInstance(response.context_data["group_table"], tables.GroupGroupMembershipStaffTable)
 
     def test_group_table_none(self):
         """No groups are shown if the group has no member groups."""
@@ -4552,7 +4552,7 @@ class ManagedGroupDetailTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url(obj.name))
         self.assertIn("parent_table", response.context_data)
-        self.assertIsInstance(response.context_data["parent_table"], tables.GroupGroupMembershipTable)
+        self.assertIsInstance(response.context_data["parent_table"], tables.GroupGroupMembershipStaffTable)
 
     def test_parent_table_none(self):
         """No groups are shown if the group is not a part of any other groups."""
@@ -14417,7 +14417,7 @@ class GroupGroupMembershipListTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url())
         self.assertIn("table", response.context_data)
-        self.assertIsInstance(response.context_data["table"], tables.GroupGroupMembershipTable)
+        self.assertIsInstance(response.context_data["table"], tables.GroupGroupMembershipStaffTable)
 
     def test_view_with_no_objects(self):
         self.client.force_login(self.user)
@@ -16974,7 +16974,7 @@ class GroupAccountMembershipListTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url())
         self.assertIn("table", response.context_data)
-        self.assertIsInstance(response.context_data["table"], tables.GroupAccountMembershipTable)
+        self.assertIsInstance(response.context_data["table"], tables.GroupAccountMembershipStaffTable)
 
     def test_view_with_no_objects(self):
         self.client.force_login(self.user)
@@ -17042,7 +17042,7 @@ class GroupAccountMembershipActiveListTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url())
         self.assertIn("table", response.context_data)
-        self.assertIsInstance(response.context_data["table"], tables.GroupAccountMembershipTable)
+        self.assertIsInstance(response.context_data["table"], tables.GroupAccountMembershipStaffTable)
 
     def test_view_with_no_objects(self):
         self.client.force_login(self.user)
@@ -17130,7 +17130,7 @@ class GroupAccountMembershipInactiveListTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url())
         self.assertIn("table", response.context_data)
-        self.assertIsInstance(response.context_data["table"], tables.GroupAccountMembershipTable)
+        self.assertIsInstance(response.context_data["table"], tables.GroupAccountMembershipStaffTable)
 
     def test_view_with_no_objects(self):
         self.client.force_login(self.user)

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -6981,6 +6981,24 @@ class WorkspaceDetailTest(TestCase):
         self.assertContains(response, "View on AnVIL")
         self.assertContains(response, obj.workspace.get_anvil_url())
 
+    def test_dates_present_for_staff_view_permission(self):
+        obj = factories.DefaultWorkspaceDataFactory.create()
+        self.client.force_login(self.user)
+        response = self.client.get(obj.get_absolute_url())
+        self.assertContains(response, "Date added")
+        self.assertContains(response, "Date modified")
+
+    def test_no_dates_for_view_permission(self):
+        obj = factories.DefaultWorkspaceDataFactory.create()
+        view_user = User.objects.create_user(username="view", password="test")
+        view_user.user_permissions.add(
+            Permission.objects.get(codename=models.AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME),
+        )
+        self.client.force_login(view_user)
+        response = self.client.get(obj.get_absolute_url())
+        self.assertNotContains(response, "Date added")
+        self.assertNotContains(response, "Date modified")
+
 
 class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
     api_success_code = 201

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -6467,6 +6467,18 @@ class WorkspaceDetailTest(TestCase):
         self.assertIn("group_sharing_table", response.context_data)
         self.assertEqual(len(response.context_data["group_sharing_table"].rows), 2)
 
+    def test_group_sharing_table_view_permission(self):
+        """Workspace-group sharing table is not present in context when user has view permission only."""
+        user = User.objects.create_user(username="test-limited", password="test-limited")
+        user.user_permissions.add(
+            Permission.objects.get(codename=models.AnVILProjectManagerAccess.VIEW_PERMISSION_CODENAME)
+        )
+        workspace = factories.DefaultWorkspaceDataFactory.create()
+        self.client.force_login(user)
+        response = self.client.get(workspace.get_absolute_url())
+        self.assertNotIn("group_sharing_table", response.context_data)
+        self.assertNotContains(response, "View groups that this workspace is shared with")
+
     def test_shows_workspace_group_sharing_for_only_that_workspace(self):
         """Only shows groups that this workspace has been shared with."""
         workspace = factories.DefaultWorkspaceDataFactory.create(workspace__name="workspace-1")

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -6556,6 +6556,17 @@ class WorkspaceDetailTest(TestCase):
                 },
             ),
         )
+        # Billing project link
+        self.assertContains(
+            response,
+            reverse(
+                "anvil_consortium_manager:billing_projects:detail",
+                kwargs={
+                    "slug": obj.workspace.billing_project.name,
+                },
+            ),
+        )
+        # Action buttons
         self.assertContains(
             response,
             reverse(
@@ -6619,6 +6630,17 @@ class WorkspaceDetailTest(TestCase):
                 },
             ),
         )
+        # Billing project link
+        self.assertContains(
+            response,
+            reverse(
+                "anvil_consortium_manager:billing_projects:detail",
+                kwargs={
+                    "slug": obj.workspace.billing_project.name,
+                },
+            ),
+        )
+        # Action buttons
         self.assertNotContains(
             response,
             reverse(
@@ -6672,6 +6694,17 @@ class WorkspaceDetailTest(TestCase):
         response = self.client.get(obj.get_absolute_url())
         self.assertIn("show_edit_links", response.context_data)
         self.assertFalse(response.context_data["show_edit_links"])
+        # Billing project link
+        self.assertNotContains(
+            response,
+            reverse(
+                "anvil_consortium_manager:billing_projects:detail",
+                kwargs={
+                    "slug": obj.workspace.billing_project.name,
+                },
+            ),
+        )
+        # Action buttons
         self.assertNotContains(
             response,
             reverse(

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -858,7 +858,7 @@ class BillingProjectListTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url())
         self.assertIn("table", response.context_data)
-        self.assertIsInstance(response.context_data["table"], tables.BillingProjectTable)
+        self.assertIsInstance(response.context_data["table"], tables.BillingProjectStaffTable)
 
     def test_view_with_no_objects(self):
         self.client.force_login(self.user)

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -5020,7 +5020,7 @@ class ManagedGroupListTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url())
         self.assertIn("table", response.context_data)
-        self.assertIsInstance(response.context_data["table"], tables.ManagedGroupTable)
+        self.assertIsInstance(response.context_data["table"], tables.ManagedGroupStaffTable)
 
     def test_view_with_no_objects(self):
         self.client.force_login(self.user)
@@ -6485,7 +6485,7 @@ class WorkspaceDetailTest(TestCase):
         self.assertIn("authorization_domain_table", response.context_data)
         self.assertIsInstance(
             response.context_data["authorization_domain_table"],
-            tables.ManagedGroupTable,
+            tables.ManagedGroupStaffTable,
         )
 
     def test_auth_domain_table_none(self):

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -973,6 +973,9 @@ class WorkspaceDetail(
             context["group_sharing_table"] = tables.WorkspaceGroupSharingStaffTable(
                 self.object.workspacegroupsharing_set.all(), exclude="workspace"
             )
+        context["has_access"] = hasattr(
+            self.request.user, "account"
+        ) and self.request.user.account.has_workspace_access(self.object)
         return context
 
     def get_template_names(self):

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -167,7 +167,7 @@ class BillingProjectDetail(auth.AnVILConsortiumManagerStaffViewRequired, SingleT
 
 class BillingProjectList(auth.AnVILConsortiumManagerStaffViewRequired, SingleTableMixin, FilterView):
     model = models.BillingProject
-    table_class = tables.BillingProjectTable
+    table_class = tables.BillingProjectStaffTable
     ordering = ("name",)
     template_name = "anvil_consortium_manager/billingproject_list.html"
 

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -743,7 +743,7 @@ class ManagedGroupUpdate(
 
 class ManagedGroupList(auth.AnVILConsortiumManagerStaffViewRequired, SingleTableMixin, FilterView):
     model = models.ManagedGroup
-    table_class = tables.ManagedGroupTable
+    table_class = tables.ManagedGroupStaffTable
     ordering = ("name",)
     template_name = "anvil_consortium_manager/managedgroup_list.html"
 
@@ -963,7 +963,7 @@ class WorkspaceDetail(
         context["group_sharing_table"] = tables.WorkspaceGroupSharingTable(
             self.object.workspacegroupsharing_set.all(), exclude="workspace"
         )
-        context["authorization_domain_table"] = tables.ManagedGroupTable(
+        context["authorization_domain_table"] = tables.ManagedGroupStaffTable(
             self.object.authorization_domains.all(),
             exclude=["workspace", "number_groups", "number_accounts"],
         )

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -960,15 +960,19 @@ class WorkspaceDetail(
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["workspace_data_object"] = self.get_workspace_data_object()
-        context["group_sharing_table"] = tables.WorkspaceGroupSharingStaffTable(
-            self.object.workspacegroupsharing_set.all(), exclude="workspace"
-        )
         context["authorization_domain_table"] = tables.ManagedGroupStaffTable(
             self.object.authorization_domains.all(),
             exclude=["workspace", "number_groups", "number_accounts"],
         )
         edit_permission_codename = models.AnVILProjectManagerAccess.STAFF_EDIT_PERMISSION_CODENAME
-        context["show_edit_links"] = self.request.user.has_perm("anvil_consortium_manager." + edit_permission_codename)
+        has_edit_perms = self.request.user.has_perm("anvil_consortium_manager." + edit_permission_codename)
+        context["show_edit_links"] = has_edit_perms
+        staff_view_permission_codename = models.AnVILProjectManagerAccess.STAFF_VIEW_PERMISSION_CODENAME
+        has_staff_view_perms = self.request.user.has_perm("anvil_consortium_manager." + staff_view_permission_codename)
+        if has_staff_view_perms:
+            context["group_sharing_table"] = tables.WorkspaceGroupSharingStaffTable(
+                self.object.workspacegroupsharing_set.all(), exclude="workspace"
+            )
         return context
 
     def get_template_names(self):

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -210,7 +210,7 @@ class AccountDetail(
         context["show_deactivate_button"] = not context["is_inactive"]
         context["show_reactivate_button"] = context["is_inactive"]
 
-        context["group_table"] = tables.GroupAccountMembershipTable(
+        context["group_table"] = tables.GroupAccountMembershipStaffTable(
             self.object.groupaccountmembership_set.all(),
             exclude=["account", "is_service_account"],
         )
@@ -482,7 +482,7 @@ class AccountDeactivate(
     success_message = "Successfully deactivated Account in app."
 
     def get_table(self):
-        return tables.GroupAccountMembershipTable(
+        return tables.GroupAccountMembershipStaffTable(
             self.object.groupaccountmembership_set.all(),
             exclude=["account", "is_service_account"],
         )
@@ -548,7 +548,7 @@ class AccountReactivate(
         # exceptions.AnVILRemoveAccountFromGroupError
 
     def get_table(self):
-        return tables.GroupAccountMembershipTable(
+        return tables.GroupAccountMembershipStaffTable(
             self.object.groupaccountmembership_set.all(),
             exclude=["account", "is_service_account"],
         )
@@ -685,18 +685,18 @@ class ManagedGroupDetail(
         context["workspace_table"] = tables.WorkspaceGroupSharingTable(
             self.object.workspacegroupsharing_set.all(), exclude="group"
         )
-        context["active_account_table"] = tables.GroupAccountMembershipTable(
+        context["active_account_table"] = tables.GroupAccountMembershipStaffTable(
             self.object.groupaccountmembership_set.filter(account__status=models.Account.ACTIVE_STATUS),
             exclude="group",
         )
-        context["inactive_account_table"] = tables.GroupAccountMembershipTable(
+        context["inactive_account_table"] = tables.GroupAccountMembershipStaffTable(
             self.object.groupaccountmembership_set.filter(account__status=models.Account.INACTIVE_STATUS),
             exclude="group",
         )
-        context["group_table"] = tables.GroupGroupMembershipTable(
+        context["group_table"] = tables.GroupGroupMembershipStaffTable(
             self.object.child_memberships.all(), exclude="parent_group"
         )
-        context["parent_table"] = tables.GroupGroupMembershipTable(
+        context["parent_table"] = tables.GroupGroupMembershipStaffTable(
             self.object.parent_memberships.all(), exclude="child_group"
         )
         edit_permission_codename = models.AnVILProjectManagerAccess.STAFF_EDIT_PERMISSION_CODENAME
@@ -1909,7 +1909,7 @@ class GroupGroupMembershipCreateByParentChild(GroupGroupMembershipCreate):
 
 class GroupGroupMembershipList(auth.AnVILConsortiumManagerStaffViewRequired, SingleTableView):
     model = models.GroupGroupMembership
-    table_class = tables.GroupGroupMembershipTable
+    table_class = tables.GroupGroupMembershipStaffTable
 
 
 class GroupGroupMembershipDelete(auth.AnVILConsortiumManagerStaffEditRequired, SuccessMessageMixin, DeleteView):
@@ -2209,14 +2209,14 @@ class GroupAccountMembershipList(auth.AnVILConsortiumManagerStaffViewRequired, S
     """Show a list of all group memberships regardless of account active/inactive status."""
 
     model = models.GroupAccountMembership
-    table_class = tables.GroupAccountMembershipTable
+    table_class = tables.GroupAccountMembershipStaffTable
 
 
 class GroupAccountMembershipActiveList(auth.AnVILConsortiumManagerStaffViewRequired, SingleTableView):
     """Show a list of all group memberships for active accounts."""
 
     model = models.GroupAccountMembership
-    table_class = tables.GroupAccountMembershipTable
+    table_class = tables.GroupAccountMembershipStaffTable
     ordering = (
         "group__name",
         "account__email",
@@ -2230,7 +2230,7 @@ class GroupAccountMembershipInactiveList(auth.AnVILConsortiumManagerStaffViewReq
     """Show a list of all group memberships for inactive accounts."""
 
     model = models.GroupAccountMembership
-    table_class = tables.GroupAccountMembershipTable
+    table_class = tables.GroupAccountMembershipStaffTable
     ordering = (
         "group__name",
         "account__email",

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -155,7 +155,7 @@ class BillingProjectDetail(auth.AnVILConsortiumManagerStaffViewRequired, SingleT
     context_table_name = "workspace_table"
 
     def get_table(self):
-        return tables.WorkspaceTable(self.object.workspace_set.all(), exclude="billing_project")
+        return tables.WorkspaceStaffTable(self.object.workspace_set.all(), exclude="billing_project")
 
     def get_context_data(self, **kwargs):
         """Add show_edit_links to context data."""
@@ -674,7 +674,7 @@ class ManagedGroupDetail(
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context["workspace_authorization_domain_table"] = tables.WorkspaceTable(
+        context["workspace_authorization_domain_table"] = tables.WorkspaceStaffTable(
             self.object.workspace_set.all(),
             exclude=(
                 "number_groups",
@@ -1470,7 +1470,7 @@ class WorkspaceList(auth.AnVILConsortiumManagerStaffViewRequired, SingleTableMix
     """Display a list of all workspaces using the default table."""
 
     model = models.Workspace
-    table_class = tables.WorkspaceTable
+    table_class = tables.WorkspaceStaffTable
     ordering = (
         "billing_project__name",
         "name",

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -220,7 +220,7 @@ class AccountDetail(
             group__in=self.object.get_all_groups(),
         ).order_by("workspace", "group")
 
-        context["accessible_workspace_table"] = tables.WorkspaceGroupSharingTable(workspace_sharing)
+        context["accessible_workspace_table"] = tables.WorkspaceGroupSharingStaffTable(workspace_sharing)
         return context
 
 
@@ -682,7 +682,7 @@ class ManagedGroupDetail(
                 "billing_project",
             ),
         )
-        context["workspace_table"] = tables.WorkspaceGroupSharingTable(
+        context["workspace_table"] = tables.WorkspaceGroupSharingStaffTable(
             self.object.workspacegroupsharing_set.all(), exclude="group"
         )
         context["active_account_table"] = tables.GroupAccountMembershipStaffTable(
@@ -960,7 +960,7 @@ class WorkspaceDetail(
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["workspace_data_object"] = self.get_workspace_data_object()
-        context["group_sharing_table"] = tables.WorkspaceGroupSharingTable(
+        context["group_sharing_table"] = tables.WorkspaceGroupSharingStaffTable(
             self.object.workspacegroupsharing_set.all(), exclude="workspace"
         )
         context["authorization_domain_table"] = tables.ManagedGroupStaffTable(
@@ -2598,7 +2598,7 @@ class WorkspaceGroupSharingUpdate(auth.AnVILConsortiumManagerStaffEditRequired, 
 
 class WorkspaceGroupSharingList(auth.AnVILConsortiumManagerStaffViewRequired, SingleTableView):
     model = models.WorkspaceGroupSharing
-    table_class = tables.WorkspaceGroupSharingTable
+    table_class = tables.WorkspaceGroupSharingStaffTable
 
 
 class WorkspaceGroupSharingDelete(auth.AnVILConsortiumManagerStaffEditRequired, SuccessMessageMixin, DeleteView):

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -53,10 +53,10 @@ You must also define a form containing the additional fields. You must include t
             fields = ("study_name", "consent_code", workspace")
 
 
-Optionally, you can define a new ``django-tables2`` table to use in place of the default ``WorkspaceTable`` that comes with the app.
+Optionally, you can define a new ``django-tables2`` table to use in place of the default ``WorkspaceStaffTable`` that comes with the app.
 This is helpful if you would like to display fields from your custom workspace data model in the :class:`~anvil_consortium_manager.models.Workspace` list view.
 This table will need to operate on the :class:`~anvil_consortium_manager.models.Workspace` model, but it can include fields from your custom workspace data model.
-If you do not want to define a custom table, you can use the default table provided by the app: :class:`anvil_consortium_manager.tables.WorkspaceTable`.
+If you do not want to define a custom table, you can use the default table provided by the app: :class:`anvil_consortium_manager.tables.WorkspaceStaffTable`.
 
 .. code-block:: python
 
@@ -93,7 +93,7 @@ Here is example of the custom adapter for ``my_app`` with the model, form and ta
     from anvil_consortium_manager.forms import WorkspaceForm
     from my_app.models import CustomWorkspaceData
     from my_app.forms import CustomWorkspaceDataForm
-    from my_app.tables import CustomWorkspaceTable
+    from my_app.tables import CustomWorkspaceStaffTable
 
     class CustomWorkspaceAdapter(BaseWorkspaceAdapter):
         name = "Custom workspace"

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -12,7 +12,7 @@ By default, the app uses :class:`~anvil_consortium_manager.adapters.default.Defa
 To customize app behavior for accounts, you must subclass :class:`~anvil_consortium_manager.adapters.account.BaseAccountAdapter`
 and set the following attributes:
 
-- ``list_table_class``: an attribute set to the class of the table used to display accounts in the :class:`~anvil_consortium_manager.views.AccountList` view. The default adapter uses :class:`anvil_consortium_manager.tables.AccountTable`.
+- ``list_table_class``: an attribute set to the class of the table used to display accounts in the :class:`~anvil_consortium_manager.views.AccountList` view. The default adapter uses :class:`anvil_consortium_manager.tables.AccountStaffTable`.
 - ``list_filterset_class``: an attribute set to the class of the table used to filter accounts in the :class:`~anvil_consortium_manager.views.AccountList` view. The default adapter uses :class:`anvil_consortium_manager.filters.AccountListFilter`. This must subclass ``FilterSet`` from `django-filter <https://django-filter.readthedocs.io/en/stable/>`_.
 
 Optionally, you can override the following methods:


### PR DESCRIPTION
- Add a badge indicating if the user's linked Account has access
- Hide buttons and links unless the user has StaffView
- Hide date added and date modified if you do not have StaffView permission.
- Rename existing tables to include "Staff" in the name
- Add a ManagedGroupUserTable that can be shown to users without staff permission