### PR TITLE
Allow users with View permission to see the Workspace lists and WorkspaceLanding page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 * Add docs dependencies to hatch via pyproject.toml.
 * Add requests as a direct dependency instead of as an extra to google-auth.
 * Rename existing tables to include "Staff" in the name, in preparation for adding tables that are viewable by non-staff users.
-* Modify the WorkspaceDetail view to be viewable by users with anvil_consortium_manager_view permission. A limited set of information is shown to users with this permission compared to those with anvil_consortium_manager_staff_view permission.
+* Rename the `list_table_class` property of Workspace adapters to `list_table_class_staff_view`.
+* Add a new required `list_table_class_view` property to Workspace adapters. This table will be shown to users with anvil_consortium_manager_view permission, and `list_table_class_staff_view` will be shown to users with anvil_consortium_manager_staff_view permission.
+* Allow users with anvil_consortium_manager_view permission to see the `WorkspaceDetail`, `WorkspaceList`, `WorkspaceListByType`, and `WorkspaceLanding` views.
 
 ## 0.20.1 (2023-11-09)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.21.0.dev2"
+__version__ = "0.21.0.dev3"

--- a/anvil_consortium_manager/adapters/default.py
+++ b/anvil_consortium_manager/adapters/default.py
@@ -21,5 +21,5 @@ class DefaultWorkspaceAdapter(BaseWorkspaceAdapter):
     workspace_form_class = forms.WorkspaceForm
     workspace_data_model = models.DefaultWorkspaceData
     workspace_data_form_class = forms.DefaultWorkspaceDataForm
-    list_table_class = tables.WorkspaceStaffTable
+    staff_list_table_class = tables.WorkspaceStaffTable
     workspace_detail_template_name = "anvil_consortium_manager/workspace_detail.html"

--- a/anvil_consortium_manager/adapters/default.py
+++ b/anvil_consortium_manager/adapters/default.py
@@ -21,5 +21,5 @@ class DefaultWorkspaceAdapter(BaseWorkspaceAdapter):
     workspace_form_class = forms.WorkspaceForm
     workspace_data_model = models.DefaultWorkspaceData
     workspace_data_form_class = forms.DefaultWorkspaceDataForm
-    staff_list_table_class = tables.WorkspaceStaffTable
+    list_table_class_staff_view = tables.WorkspaceStaffTable
     workspace_detail_template_name = "anvil_consortium_manager/workspace_detail.html"

--- a/anvil_consortium_manager/adapters/default.py
+++ b/anvil_consortium_manager/adapters/default.py
@@ -22,4 +22,5 @@ class DefaultWorkspaceAdapter(BaseWorkspaceAdapter):
     workspace_data_model = models.DefaultWorkspaceData
     workspace_data_form_class = forms.DefaultWorkspaceDataForm
     list_table_class_staff_view = tables.WorkspaceStaffTable
+    list_table_class_view = tables.WorkspaceUserTable
     workspace_detail_template_name = "anvil_consortium_manager/workspace_detail.html"

--- a/anvil_consortium_manager/adapters/workspace.py
+++ b/anvil_consortium_manager/adapters/workspace.py
@@ -33,8 +33,8 @@ class BaseWorkspaceAdapter(ABC):
         ...
 
     @abstractproperty
-    def list_table_class(self):
-        """Table class to use in a list of workspaces."""
+    def staff_list_table_class(self):
+        """Table class to use in a list of workspaces for staff."""
         ...
 
     @abstractproperty
@@ -75,11 +75,11 @@ class BaseWorkspaceAdapter(ABC):
             raise ImproperlyConfigured("Set `description`.")
         return self.description
 
-    def get_list_table_class(self):
-        """Return the table class to use for the WorkspaceListByType view."""
-        if not self.list_table_class:
-            raise ImproperlyConfigured("Set `list_table_class` in `{}`.".format(type(self)))
-        return self.list_table_class
+    def get_staff_list_table_class(self):
+        """Return the table class to use for the WorkspaceListByType view for staff."""
+        if not self.staff_list_table_class:
+            raise ImproperlyConfigured("Set `staff_list_table_class` in `{}`.".format(type(self)))
+        return self.staff_list_table_class
 
     def get_workspace_form_class(self):
         """Return the form used to create a `Workspace`."""

--- a/anvil_consortium_manager/adapters/workspace.py
+++ b/anvil_consortium_manager/adapters/workspace.py
@@ -81,6 +81,12 @@ class BaseWorkspaceAdapter(ABC):
             raise ImproperlyConfigured("Set `list_table_class_staff_view` in `{}`.".format(type(self)))
         return self.list_table_class_staff_view
 
+    def get_list_table_class_view(self):
+        """Return the table class to use for the WorkspaceListByType view for non-staff users."""
+        if not self.list_table_class_view:
+            raise ImproperlyConfigured("Set `list_table_class_view` in `{}`.".format(type(self)))
+        return self.list_table_class_view
+
     def get_workspace_form_class(self):
         """Return the form used to create a `Workspace`."""
         if not self.workspace_form_class:

--- a/anvil_consortium_manager/adapters/workspace.py
+++ b/anvil_consortium_manager/adapters/workspace.py
@@ -33,8 +33,8 @@ class BaseWorkspaceAdapter(ABC):
         ...
 
     @abstractproperty
-    def staff_list_table_class(self):
-        """Table class to use in a list of workspaces for staff."""
+    def list_table_class_staff_view(self):
+        """Table class to use in a list of workspaces for users with staff view permission."""
         ...
 
     @abstractproperty
@@ -75,11 +75,11 @@ class BaseWorkspaceAdapter(ABC):
             raise ImproperlyConfigured("Set `description`.")
         return self.description
 
-    def get_staff_list_table_class(self):
+    def get_list_table_class_staff_view(self):
         """Return the table class to use for the WorkspaceListByType view for staff."""
-        if not self.staff_list_table_class:
-            raise ImproperlyConfigured("Set `staff_list_table_class` in `{}`.".format(type(self)))
-        return self.staff_list_table_class
+        if not self.list_table_class_staff_view:
+            raise ImproperlyConfigured("Set `list_table_class_staff_view` in `{}`.".format(type(self)))
+        return self.list_table_class_staff_view
 
     def get_workspace_form_class(self):
         """Return the form used to create a `Workspace`."""

--- a/anvil_consortium_manager/tables.py
+++ b/anvil_consortium_manager/tables.py
@@ -86,27 +86,6 @@ class ManagedGroupUserTable(tables.Table):
         fields = ("name",)
 
 
-class WorkspaceUserTable(tables.Table):
-    """Class to display a Workspace table."""
-
-    name = tables.Column(linkify=True, verbose_name="Workspace")
-    billing_project = tables.Column()
-    workspace_type = tables.Column()
-
-    class Meta:
-        model = models.Workspace
-        fields = ("name", "billing_project", "workspace_type")
-        order_by = ("name",)
-
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self.registered_names = workspace_adapter_registry.get_registered_names()
-
-    def render_workspace_type(self, record):
-        """Show the name of the workspace specified in the adapter for this workspace type."""
-        return self.registered_names[record.workspace_type]
-
-
 class WorkspaceStaffTable(tables.Table):
     """Class to display a Workspace table."""
 

--- a/anvil_consortium_manager/tables.py
+++ b/anvil_consortium_manager/tables.py
@@ -86,6 +86,27 @@ class ManagedGroupUserTable(tables.Table):
         fields = ("name",)
 
 
+class WorkspaceUserTable(tables.Table):
+    """Class to display a Workspace table."""
+
+    name = tables.Column(linkify=True, verbose_name="Workspace")
+    billing_project = tables.Column()
+    workspace_type = tables.Column()
+
+    class Meta:
+        model = models.Workspace
+        fields = ("name", "billing_project", "workspace_type")
+        order_by = ("name",)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.registered_names = workspace_adapter_registry.get_registered_names()
+
+    def render_workspace_type(self, record):
+        """Show the name of the workspace specified in the adapter for this workspace type."""
+        return self.registered_names[record.workspace_type]
+
+
 class WorkspaceStaffTable(tables.Table):
     """Class to display a Workspace table."""
 

--- a/anvil_consortium_manager/tables.py
+++ b/anvil_consortium_manager/tables.py
@@ -114,6 +114,27 @@ class WorkspaceStaffTable(tables.Table):
         return self.registered_names[record.workspace_type]
 
 
+class WorkspaceUserTable(tables.Table):
+    """Class to display a Workspace table for users with view permission."""
+
+    name = tables.Column(linkify=True, verbose_name="Workspace")
+    billing_project = tables.Column()
+    workspace_type = tables.Column()
+
+    class Meta:
+        model = models.Workspace
+        fields = ("name", "billing_project", "workspace_type")
+        order_by = ("name",)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.registered_names = workspace_adapter_registry.get_registered_names()
+
+    def render_workspace_type(self, record):
+        """Show the name of the workspace specified in the adapter for this workspace type."""
+        return self.registered_names[record.workspace_type]
+
+
 class GroupGroupMembershipStaffTable(tables.Table):
     """Class to render a GroupGroupMembership table."""
 

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_landing_page.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_landing_page.html
@@ -8,6 +8,17 @@
 
 <h1 class="pb-2 border-bottom">Workspace types</h1>
 
+<div class="my-3 p-3 bg-light border rounded shadow-sm">
+  {% block workspace_types_explanation %}
+  <p>
+    The following boxes show different workspace types that have are associated with the consortium.
+    Different information is stored about each workspace type.
+    Click on the links in the boxes to see information about workspaces of that type.
+  </p>
+  {% endblock workspace_types_explanation %}
+  </div>
+
+
 
 <div class="album py-2">
   <div class="container">

--- a/anvil_consortium_manager/tests/test_adapters.py
+++ b/anvil_consortium_manager/tests/test_adapters.py
@@ -350,6 +350,21 @@ class WorkspaceAdapterTest(TestCase):
 class WorkspaceAdapterRegistryTest(TestCase):
     """Tests for the WorkspaceAdapterRegstry model."""
 
+    def get_test_adapter(self):
+        """Return a test adapter class for use in tests."""
+
+        class Adapter(BaseWorkspaceAdapter):
+            name = "Test"
+            type = "test"
+            description = "test desc"
+            staff_list_table_class = tables.TestWorkspaceDataTable
+            workspace_form_class = forms.WorkspaceForm
+            workspace_data_model = models.TestWorkspaceData
+            workspace_data_form_class = forms.TestWorkspaceDataForm
+            workspace_detail_template_name = "custom/workspace_detail.html"
+
+        return Adapter
+
     def test_can_register_adapter(self):
         """Can register an adapter."""
         registry = WorkspaceAdapterRegistry()
@@ -361,26 +376,15 @@ class WorkspaceAdapterRegistryTest(TestCase):
     def test_register_two_adapters(self):
         """Cannot register an adapter with the same type as another registered adapter."""
         registry = WorkspaceAdapterRegistry()
+        AdapterSuperclass = self.get_test_adapter()
 
-        class Adapter1(BaseWorkspaceAdapter):
-            name = None
+        class Adapter1(AdapterSuperclass):
             type = "adapter1"
             description = "one"
-            staff_list_table_class = None
-            workspace_form_class = None
-            workspace_data_model = None
-            workspace_data_form_class = None
-            workspace_detail_template_name = None
 
-        class Adapter2(BaseWorkspaceAdapter):
-            name = None
+        class Adapter2(AdapterSuperclass):
             type = "adapter2"
             description = "two"
-            staff_list_table_class = None
-            workspace_form_class = None
-            workspace_data_model = None
-            workspace_data_form_class = None
-            workspace_detail_template_name = None
 
         registry.register(Adapter1)
         registry.register(Adapter2)
@@ -393,16 +397,11 @@ class WorkspaceAdapterRegistryTest(TestCase):
     def test_cannot_register_adapter_twice(self):
         """Cannot register the same adapter twice."""
         registry = WorkspaceAdapterRegistry()
+        AdapterSuperclass = self.get_test_adapter()
 
-        class TestAdapter(BaseWorkspaceAdapter):
-            name = None
+        class TestAdapter(AdapterSuperclass):
             type = "adapter_type"
             description = "desc"
-            staff_list_table_class = None
-            workspace_form_class = None
-            workspace_data_model = None
-            workspace_data_form_class = None
-            workspace_detail_template_name = None
 
         registry.register(TestAdapter)
         with self.assertRaises(AdapterAlreadyRegisteredError):
@@ -415,25 +414,15 @@ class WorkspaceAdapterRegistryTest(TestCase):
         """Cannot register an adapter with the same type as another registered adapter."""
         registry = WorkspaceAdapterRegistry()
 
-        class Adapter1(BaseWorkspaceAdapter):
-            name = None
-            type = "adapter_type"
-            description = "desc"
-            staff_list_table_class = None
-            workspace_form_class = None
-            workspace_data_model = None
-            workspace_data_form_class = None
-            workspace_detail_template_name = None
+        AdapterSuperclass = self.get_test_adapter()
 
-        class Adapter2(BaseWorkspaceAdapter):
-            name = None
+        class Adapter1(AdapterSuperclass):
             type = "adapter_type"
             description = "desc"
-            staff_list_table_class = None
-            workspace_form_class = None
-            workspace_data_model = None
-            workspace_data_form_class = None
-            workspace_detail_template_name = None
+
+        class Adapter2(AdapterSuperclass):
+            type = "adapter_type"
+            description = "desc"
 
         registry.register(Adapter1)
         with self.assertRaises(AdapterAlreadyRegisteredError):
@@ -463,15 +452,11 @@ class WorkspaceAdapterRegistryTest(TestCase):
         """Cannot unregister an adapter that has not been registered yet."""
         registry = WorkspaceAdapterRegistry()
 
-        class TestAdapter(BaseWorkspaceAdapter):
-            name = None
+        AdapterSuperclass = self.get_test_adapter()
+
+        class TestAdapter(AdapterSuperclass):
             type = "adapter_type"
             description = "desc"
-            staff_list_table_class = None
-            workspace_form_class = None
-            workspace_data_model = None
-            workspace_data_form_class = None
-            workspace_detail_template_name = None
 
         with self.assertRaises(AdapterNotRegisteredError):
             registry.unregister(TestAdapter)
@@ -481,25 +466,15 @@ class WorkspaceAdapterRegistryTest(TestCase):
         """Cannot unregister an adapter with the same type as another registered adapter."""
         registry = WorkspaceAdapterRegistry()
 
-        class Adapter1(BaseWorkspaceAdapter):
-            name = None
-            type = "adapter_type"
-            description = "desc"
-            staff_list_table_class = None
-            workspace_form_class = None
-            workspace_data_model = None
-            workspace_data_form_class = None
-            workspace_detail_template_name = None
+        AdapterSuperclass = self.get_test_adapter()
 
-        class Adapter2(BaseWorkspaceAdapter):
-            name = None
+        class Adapter1(AdapterSuperclass):
             type = "adapter_type"
             description = "desc"
-            staff_list_table_class = None
-            workspace_form_class = None
-            workspace_data_model = None
-            workspace_data_form_class = None
-            workspace_detail_template_name = None
+
+        class Adapter2(AdapterSuperclass):
+            type = "adapter_type"
+            description = "desc"
 
         registry.register(Adapter1)
         with self.assertRaises(AdapterNotRegisteredError):
@@ -527,49 +502,34 @@ class WorkspaceAdapterRegistryTest(TestCase):
         """get_registered_adapters returns the correct dictionary when one adapter is registered."""
         registry = WorkspaceAdapterRegistry()
 
-        class Adapter(BaseWorkspaceAdapter):
-            name = None
+        AdapterSuperclass = self.get_test_adapter()
+
+        class TestAdapter(AdapterSuperclass):
             type = "adapter"
             description = "desc"
-            staff_list_table_class = None
-            workspace_form_class = None
-            workspace_data_model = None
-            workspace_data_form_class = None
-            workspace_detail_template_name = None
 
-        registry.register(Adapter)
-        self.assertEqual(registry.get_registered_adapters(), {"adapter": Adapter})
+        registry.register(TestAdapter)
+        self.assertEqual(registry.get_registered_adapters(), {"adapter": TestAdapter})
 
     def test_get_registered_apdaters_two(self):
         """get_registered_adapters returns the correct dictionary when two adapters are registered."""
 
         registry = WorkspaceAdapterRegistry()
+        AdapterSuperclass = self.get_test_adapter()
 
-        class Adapter1(BaseWorkspaceAdapter):
-            name = None
+        class TestAdapter1(AdapterSuperclass):
             type = "adapter1"
             description = "desc"
-            staff_list_table_class = None
-            workspace_form_class = None
-            workspace_data_model = None
-            workspace_data_form_class = None
-            workspace_detail_template_name = None
 
-        class Adapter2(BaseWorkspaceAdapter):
-            name = None
+        class TestAdapter2(AdapterSuperclass):
             type = "adapter2"
             description = "desc"
-            staff_list_table_class = None
-            workspace_form_class = None
-            workspace_data_model = None
-            workspace_data_form_class = None
-            workspace_detail_template_name = None
 
-        registry.register(Adapter1)
-        registry.register(Adapter2)
+        registry.register(TestAdapter1)
+        registry.register(TestAdapter2)
         self.assertEqual(
             registry.get_registered_adapters(),
-            {"adapter1": Adapter1, "adapter2": Adapter2},
+            {"adapter1": TestAdapter1, "adapter2": TestAdapter2},
         )
 
     def test_get_registered_names_zero(self):
@@ -580,26 +540,23 @@ class WorkspaceAdapterRegistryTest(TestCase):
     def test_get_registered_names_one(self):
         """get_registered_names returns the correct dictionary when one adapter is registered."""
         registry = WorkspaceAdapterRegistry()
+        AdapterSuperclass = self.get_test_adapter()
 
-        class Adapter(BaseWorkspaceAdapter):
+        class TestAdapter(AdapterSuperclass):
             name = "Adapter"
             type = "adapter"
             description = "desc"
-            staff_list_table_class = None
-            workspace_form_class = None
-            workspace_data_model = None
-            workspace_data_form_class = None
-            workspace_detail_template_name = None
 
-        registry.register(Adapter)
+        registry.register(TestAdapter)
         self.assertEqual(registry.get_registered_names(), {"adapter": "Adapter"})
 
     def test_get_registered_names_two(self):
         """get_registered_names returns the correct dictionary when two adapters are registered."""
 
         registry = WorkspaceAdapterRegistry()
+        AdapterSuperclass = self.get_test_adapter()
 
-        class Adapter1(BaseWorkspaceAdapter):
+        class TestAdapter1(AdapterSuperclass):
             name = "Adapter 1"
             type = "adapter1"
             description = "desc"
@@ -609,18 +566,13 @@ class WorkspaceAdapterRegistryTest(TestCase):
             workspace_data_form_class = None
             workspace_detail_template_name = None
 
-        class Adapter2(BaseWorkspaceAdapter):
+        class TestAdapter2(AdapterSuperclass):
             name = "Adapter 2"
             type = "adapter2"
             description = "desc"
-            staff_list_table_class = None
-            workspace_form_class = None
-            workspace_data_model = None
-            workspace_data_form_class = None
-            workspace_detail_template_name = None
 
-        registry.register(Adapter1)
-        registry.register(Adapter2)
+        registry.register(TestAdapter1)
+        registry.register(TestAdapter2)
         self.assertEqual(
             registry.get_registered_names(),
             {"adapter1": "Adapter 1", "adapter2": "Adapter 2"},

--- a/anvil_consortium_manager/tests/test_adapters.py
+++ b/anvil_consortium_manager/tests/test_adapters.py
@@ -135,7 +135,7 @@ class WorkspaceAdapterTest(TestCase):
             name = "Test"
             type = "test"
             description = "test desc"
-            staff_list_table_class = tables.TestWorkspaceDataTable
+            list_table_class_staff_view = tables.TestWorkspaceDataTable
             workspace_form_class = forms.WorkspaceForm
             workspace_data_model = models.TestWorkspaceData
             workspace_data_form_class = forms.TestWorkspaceDataForm
@@ -143,22 +143,22 @@ class WorkspaceAdapterTest(TestCase):
 
         return TestAdapter
 
-    def test_staff_list_table_class_default(self):
+    def test_list_table_class_staff_view_default(self):
         """get_list_table_class returns the correct table when using the default adapter."""
-        self.assertEqual(DefaultWorkspaceAdapter().get_staff_list_table_class(), WorkspaceStaffTable)
+        self.assertEqual(DefaultWorkspaceAdapter().get_list_table_class_staff_view(), WorkspaceStaffTable)
 
-    def test_staff_list_table_class_custom(self):
+    def test_list_table_class_staff_view_custom(self):
         """get_list_table_class returns the correct table when using a custom adapter."""
         TestAdapter = self.get_test_adapter()
-        setattr(TestAdapter, "staff_list_table_class", tables.TestWorkspaceDataTable)
-        self.assertEqual(TestAdapter().get_staff_list_table_class(), tables.TestWorkspaceDataTable)
+        setattr(TestAdapter, "list_table_class_staff_view", tables.TestWorkspaceDataTable)
+        self.assertEqual(TestAdapter().get_list_table_class_staff_view(), tables.TestWorkspaceDataTable)
 
-    def test_staff_list_table_class_none(self):
+    def test_list_table_class_staff_view_none(self):
         """get_list_table_class raises ImproperlyConfigured when list_table_class is not set."""
         TestAdapter = self.get_test_adapter()
-        setattr(TestAdapter, "staff_list_table_class", None)
+        setattr(TestAdapter, "list_table_class_staff_view", None)
         with self.assertRaises(ImproperlyConfigured):
-            TestAdapter().get_staff_list_table_class()
+            TestAdapter().get_list_table_class_staff_view()
 
     def test_get_workspace_form_class_default(self):
         """get_workspace_form_class returns the correct form when using the default adapter."""
@@ -357,7 +357,7 @@ class WorkspaceAdapterRegistryTest(TestCase):
             name = "Test"
             type = "test"
             description = "test desc"
-            staff_list_table_class = tables.TestWorkspaceDataTable
+            list_table_class_staff_view = tables.TestWorkspaceDataTable
             workspace_form_class = forms.WorkspaceForm
             workspace_data_model = models.TestWorkspaceData
             workspace_data_form_class = forms.TestWorkspaceDataForm
@@ -560,7 +560,7 @@ class WorkspaceAdapterRegistryTest(TestCase):
             name = "Adapter 1"
             type = "adapter1"
             description = "desc"
-            staff_list_table_class = None
+            list_table_class_staff_view = None
             workspace_form_class = None
             workspace_data_model = None
             workspace_data_form_class = None

--- a/anvil_consortium_manager/tests/test_adapters.py
+++ b/anvil_consortium_manager/tests/test_adapters.py
@@ -13,7 +13,7 @@ from ..adapters.workspace import (
 from ..filters import AccountListFilter, BillingProjectListFilter
 from ..forms import DefaultWorkspaceDataForm, WorkspaceForm
 from ..models import Account, DefaultWorkspaceData
-from ..tables import AccountStaffTable, WorkspaceStaffTable
+from ..tables import AccountStaffTable, WorkspaceStaffTable, WorkspaceUserTable
 from . import factories
 from .test_app import filters, forms, models, tables
 from .test_app.adapters import TestWorkspaceAdapter
@@ -135,7 +135,8 @@ class WorkspaceAdapterTest(TestCase):
             name = "Test"
             type = "test"
             description = "test desc"
-            list_table_class_staff_view = tables.TestWorkspaceDataTable
+            list_table_class_staff_view = tables.TestWorkspaceDataStaffTable
+            list_table_class_view = tables.TestWorkspaceDataUserTable
             workspace_form_class = forms.WorkspaceForm
             workspace_data_model = models.TestWorkspaceData
             workspace_data_form_class = forms.TestWorkspaceDataForm
@@ -150,8 +151,8 @@ class WorkspaceAdapterTest(TestCase):
     def test_list_table_class_staff_view_custom(self):
         """get_list_table_class returns the correct table when using a custom adapter."""
         TestAdapter = self.get_test_adapter()
-        setattr(TestAdapter, "list_table_class_staff_view", tables.TestWorkspaceDataTable)
-        self.assertEqual(TestAdapter().get_list_table_class_staff_view(), tables.TestWorkspaceDataTable)
+        setattr(TestAdapter, "list_table_class_staff_view", tables.TestWorkspaceDataStaffTable)
+        self.assertEqual(TestAdapter().get_list_table_class_staff_view(), tables.TestWorkspaceDataStaffTable)
 
     def test_list_table_class_staff_view_none(self):
         """get_list_table_class raises ImproperlyConfigured when list_table_class is not set."""
@@ -159,6 +160,23 @@ class WorkspaceAdapterTest(TestCase):
         setattr(TestAdapter, "list_table_class_staff_view", None)
         with self.assertRaises(ImproperlyConfigured):
             TestAdapter().get_list_table_class_staff_view()
+
+    def test_list_table_class_view_default(self):
+        """get_list_table_class returns the correct table when using the default adapter."""
+        self.assertEqual(DefaultWorkspaceAdapter().get_list_table_class_view(), WorkspaceUserTable)
+
+    def test_list_table_class_view_custom(self):
+        """get_list_table_class returns the correct table when using a custom adapter."""
+        TestAdapter = self.get_test_adapter()
+        setattr(TestAdapter, "list_table_class_view", tables.TestWorkspaceDataUserTable)
+        self.assertEqual(TestAdapter().get_list_table_class_view(), tables.TestWorkspaceDataUserTable)
+
+    def test_list_table_class_view_none(self):
+        """get_list_table_class raises ImproperlyConfigured when list_table_class is not set."""
+        TestAdapter = self.get_test_adapter()
+        setattr(TestAdapter, "list_table_class_view", None)
+        with self.assertRaises(ImproperlyConfigured):
+            TestAdapter().get_list_table_class_view()
 
     def test_get_workspace_form_class_default(self):
         """get_workspace_form_class returns the correct form when using the default adapter."""
@@ -357,7 +375,8 @@ class WorkspaceAdapterRegistryTest(TestCase):
             name = "Test"
             type = "test"
             description = "test desc"
-            list_table_class_staff_view = tables.TestWorkspaceDataTable
+            list_table_class_staff_view = tables.TestWorkspaceDataStaffTable
+            list_table_class_view = tables.TestWorkspaceDataUserTable
             workspace_form_class = forms.WorkspaceForm
             workspace_data_model = models.TestWorkspaceData
             workspace_data_form_class = forms.TestWorkspaceDataForm

--- a/anvil_consortium_manager/tests/test_adapters.py
+++ b/anvil_consortium_manager/tests/test_adapters.py
@@ -135,7 +135,7 @@ class WorkspaceAdapterTest(TestCase):
             name = "Test"
             type = "test"
             description = "test desc"
-            list_table_class = tables.TestWorkspaceDataTable
+            staff_list_table_class = tables.TestWorkspaceDataTable
             workspace_form_class = forms.WorkspaceForm
             workspace_data_model = models.TestWorkspaceData
             workspace_data_form_class = forms.TestWorkspaceDataForm
@@ -143,22 +143,22 @@ class WorkspaceAdapterTest(TestCase):
 
         return TestAdapter
 
-    def test_list_table_class_default(self):
+    def test_staff_list_table_class_default(self):
         """get_list_table_class returns the correct table when using the default adapter."""
-        self.assertEqual(DefaultWorkspaceAdapter().get_list_table_class(), WorkspaceStaffTable)
+        self.assertEqual(DefaultWorkspaceAdapter().get_staff_list_table_class(), WorkspaceStaffTable)
 
-    def test_list_table_class_custom(self):
+    def test_staff_list_table_class_custom(self):
         """get_list_table_class returns the correct table when using a custom adapter."""
         TestAdapter = self.get_test_adapter()
-        setattr(TestAdapter, "list_table_class", tables.TestWorkspaceDataTable)
-        self.assertEqual(TestAdapter().get_list_table_class(), tables.TestWorkspaceDataTable)
+        setattr(TestAdapter, "staff_list_table_class", tables.TestWorkspaceDataTable)
+        self.assertEqual(TestAdapter().get_staff_list_table_class(), tables.TestWorkspaceDataTable)
 
-    def test_list_table_class_none(self):
+    def test_staff_list_table_class_none(self):
         """get_list_table_class raises ImproperlyConfigured when list_table_class is not set."""
         TestAdapter = self.get_test_adapter()
-        setattr(TestAdapter, "list_table_class", None)
+        setattr(TestAdapter, "staff_list_table_class", None)
         with self.assertRaises(ImproperlyConfigured):
-            TestAdapter().get_list_table_class()
+            TestAdapter().get_staff_list_table_class()
 
     def test_get_workspace_form_class_default(self):
         """get_workspace_form_class returns the correct form when using the default adapter."""
@@ -366,7 +366,7 @@ class WorkspaceAdapterRegistryTest(TestCase):
             name = None
             type = "adapter1"
             description = "one"
-            list_table_class = None
+            staff_list_table_class = None
             workspace_form_class = None
             workspace_data_model = None
             workspace_data_form_class = None
@@ -376,7 +376,7 @@ class WorkspaceAdapterRegistryTest(TestCase):
             name = None
             type = "adapter2"
             description = "two"
-            list_table_class = None
+            staff_list_table_class = None
             workspace_form_class = None
             workspace_data_model = None
             workspace_data_form_class = None
@@ -398,7 +398,7 @@ class WorkspaceAdapterRegistryTest(TestCase):
             name = None
             type = "adapter_type"
             description = "desc"
-            list_table_class = None
+            staff_list_table_class = None
             workspace_form_class = None
             workspace_data_model = None
             workspace_data_form_class = None
@@ -419,7 +419,7 @@ class WorkspaceAdapterRegistryTest(TestCase):
             name = None
             type = "adapter_type"
             description = "desc"
-            list_table_class = None
+            staff_list_table_class = None
             workspace_form_class = None
             workspace_data_model = None
             workspace_data_form_class = None
@@ -429,7 +429,7 @@ class WorkspaceAdapterRegistryTest(TestCase):
             name = None
             type = "adapter_type"
             description = "desc"
-            list_table_class = None
+            staff_list_table_class = None
             workspace_form_class = None
             workspace_data_model = None
             workspace_data_form_class = None
@@ -467,7 +467,7 @@ class WorkspaceAdapterRegistryTest(TestCase):
             name = None
             type = "adapter_type"
             description = "desc"
-            list_table_class = None
+            staff_list_table_class = None
             workspace_form_class = None
             workspace_data_model = None
             workspace_data_form_class = None
@@ -485,7 +485,7 @@ class WorkspaceAdapterRegistryTest(TestCase):
             name = None
             type = "adapter_type"
             description = "desc"
-            list_table_class = None
+            staff_list_table_class = None
             workspace_form_class = None
             workspace_data_model = None
             workspace_data_form_class = None
@@ -495,7 +495,7 @@ class WorkspaceAdapterRegistryTest(TestCase):
             name = None
             type = "adapter_type"
             description = "desc"
-            list_table_class = None
+            staff_list_table_class = None
             workspace_form_class = None
             workspace_data_model = None
             workspace_data_form_class = None
@@ -531,7 +531,7 @@ class WorkspaceAdapterRegistryTest(TestCase):
             name = None
             type = "adapter"
             description = "desc"
-            list_table_class = None
+            staff_list_table_class = None
             workspace_form_class = None
             workspace_data_model = None
             workspace_data_form_class = None
@@ -549,7 +549,7 @@ class WorkspaceAdapterRegistryTest(TestCase):
             name = None
             type = "adapter1"
             description = "desc"
-            list_table_class = None
+            staff_list_table_class = None
             workspace_form_class = None
             workspace_data_model = None
             workspace_data_form_class = None
@@ -559,7 +559,7 @@ class WorkspaceAdapterRegistryTest(TestCase):
             name = None
             type = "adapter2"
             description = "desc"
-            list_table_class = None
+            staff_list_table_class = None
             workspace_form_class = None
             workspace_data_model = None
             workspace_data_form_class = None
@@ -585,7 +585,7 @@ class WorkspaceAdapterRegistryTest(TestCase):
             name = "Adapter"
             type = "adapter"
             description = "desc"
-            list_table_class = None
+            staff_list_table_class = None
             workspace_form_class = None
             workspace_data_model = None
             workspace_data_form_class = None
@@ -603,7 +603,7 @@ class WorkspaceAdapterRegistryTest(TestCase):
             name = "Adapter 1"
             type = "adapter1"
             description = "desc"
-            list_table_class = None
+            staff_list_table_class = None
             workspace_form_class = None
             workspace_data_model = None
             workspace_data_form_class = None
@@ -613,7 +613,7 @@ class WorkspaceAdapterRegistryTest(TestCase):
             name = "Adapter 2"
             type = "adapter2"
             description = "desc"
-            list_table_class = None
+            staff_list_table_class = None
             workspace_form_class = None
             workspace_data_model = None
             workspace_data_form_class = None

--- a/anvil_consortium_manager/tests/test_app/adapters.py
+++ b/anvil_consortium_manager/tests/test_app/adapters.py
@@ -1,7 +1,7 @@
 from anvil_consortium_manager.adapters.account import BaseAccountAdapter
 from anvil_consortium_manager.adapters.workspace import BaseWorkspaceAdapter
 from anvil_consortium_manager.forms import WorkspaceForm
-from anvil_consortium_manager.tables import WorkspaceStaffTable
+from anvil_consortium_manager.tables import WorkspaceStaffTable, WorkspaceUserTable
 
 from . import filters, forms, models, tables
 
@@ -12,7 +12,8 @@ class TestWorkspaceAdapter(BaseWorkspaceAdapter):
     name = "Test workspace"
     type = "test"
     description = "Workspace type for testing"
-    list_table_class_staff_view = tables.TestWorkspaceDataTable
+    list_table_class_staff_view = tables.TestWorkspaceDataStaffTable
+    list_table_class_view = tables.TestWorkspaceDataUserTable
     workspace_form_class = forms.TestWorkspaceForm
     workspace_data_model = models.TestWorkspaceData
     workspace_data_form_class = forms.TestWorkspaceDataForm
@@ -50,6 +51,7 @@ class TestForeignKeyWorkspaceAdapter(BaseWorkspaceAdapter):
     type = "test_fk"
     description = "Workspace type for testing"
     list_table_class_staff_view = WorkspaceStaffTable
+    list_table_class_view = WorkspaceUserTable
     workspace_form_class = WorkspaceForm
     workspace_data_model = models.TestForeignKeyWorkspaceData
     workspace_data_form_class = forms.TestForeignKeyWorkspaceDataForm

--- a/anvil_consortium_manager/tests/test_app/adapters.py
+++ b/anvil_consortium_manager/tests/test_app/adapters.py
@@ -12,7 +12,7 @@ class TestWorkspaceAdapter(BaseWorkspaceAdapter):
     name = "Test workspace"
     type = "test"
     description = "Workspace type for testing"
-    staff_list_table_class = tables.TestWorkspaceDataTable
+    list_table_class_staff_view = tables.TestWorkspaceDataTable
     workspace_form_class = forms.TestWorkspaceForm
     workspace_data_model = models.TestWorkspaceData
     workspace_data_form_class = forms.TestWorkspaceDataForm
@@ -49,7 +49,7 @@ class TestForeignKeyWorkspaceAdapter(BaseWorkspaceAdapter):
     name = "Test foreign key workspace"
     type = "test_fk"
     description = "Workspace type for testing"
-    staff_list_table_class = WorkspaceStaffTable
+    list_table_class_staff_view = WorkspaceStaffTable
     workspace_form_class = WorkspaceForm
     workspace_data_model = models.TestForeignKeyWorkspaceData
     workspace_data_form_class = forms.TestForeignKeyWorkspaceDataForm

--- a/anvil_consortium_manager/tests/test_app/adapters.py
+++ b/anvil_consortium_manager/tests/test_app/adapters.py
@@ -12,7 +12,7 @@ class TestWorkspaceAdapter(BaseWorkspaceAdapter):
     name = "Test workspace"
     type = "test"
     description = "Workspace type for testing"
-    list_table_class = tables.TestWorkspaceDataTable
+    staff_list_table_class = tables.TestWorkspaceDataTable
     workspace_form_class = forms.TestWorkspaceForm
     workspace_data_model = models.TestWorkspaceData
     workspace_data_form_class = forms.TestWorkspaceDataForm
@@ -49,7 +49,7 @@ class TestForeignKeyWorkspaceAdapter(BaseWorkspaceAdapter):
     name = "Test foreign key workspace"
     type = "test_fk"
     description = "Workspace type for testing"
-    list_table_class = WorkspaceStaffTable
+    staff_list_table_class = WorkspaceStaffTable
     workspace_form_class = WorkspaceForm
     workspace_data_model = models.TestForeignKeyWorkspaceData
     workspace_data_form_class = forms.TestForeignKeyWorkspaceDataForm

--- a/anvil_consortium_manager/tests/test_app/tables.py
+++ b/anvil_consortium_manager/tests/test_app/tables.py
@@ -3,7 +3,17 @@ import django_tables2 as tables
 from anvil_consortium_manager import models as acm_models
 
 
-class TestWorkspaceDataTable(tables.Table):
+class TestWorkspaceDataStaffTable(tables.Table):
+    """Table for testing the Workspace adapter."""
+
+    name = tables.columns.Column(linkify=True)
+
+    class Meta:
+        model = acm_models.Workspace
+        fields = ("testworkspacedata__study_name", "name")
+
+
+class TestWorkspaceDataUserTable(tables.Table):
     """Table for testing the Workspace adapter."""
 
     name = tables.columns.Column(linkify=True)

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -6225,8 +6225,8 @@ class WorkspaceLandingPageTest(TestCase):
         """Set up test class."""
         self.factory = RequestFactory()
         # Create a user with view permission.
-        self.view_user = User.objects.create_user(username="test_view", password="view")
-        self.view_user.user_permissions.add(
+        self.staff_view_user = User.objects.create_user(username="test_view", password="view")
+        self.staff_view_user.user_permissions.add(
             Permission.objects.get(codename=models.AnVILProjectManagerAccess.STAFF_VIEW_PERMISSION_CODENAME)
         )
         # Create a user with edit permission.
@@ -6259,7 +6259,7 @@ class WorkspaceLandingPageTest(TestCase):
 
     def test_status_code_with_view_permission(self):
         """Returns successful response code."""
-        self.client.force_login(self.view_user)
+        self.client.force_login(self.staff_view_user)
         response = self.client.get(self.get_url())
         self.assertEqual(response.status_code, 200)
 
@@ -6276,13 +6276,13 @@ class WorkspaceLandingPageTest(TestCase):
 
     def test_status_code_with_edit_permission(self):
         """Returns successful response code."""
-        self.client.force_login(self.view_user)
+        self.client.force_login(self.staff_view_user)
         response = self.client.get(self.get_url())
         self.assertEqual(response.status_code, 200)
 
     def test_view_permission(self):
         """Links to edit required do not appear in the page when user only has view permission."""
-        self.client.force_login(self.view_user)
+        self.client.force_login(self.staff_view_user)
         response = self.client.get(self.get_url())
         self.assertIn("show_edit_links", response.context_data)
         self.assertFalse(response.context_data["show_edit_links"])
@@ -6338,7 +6338,7 @@ class WorkspaceLandingPageTest(TestCase):
 
     def test_one_registered_workspace_in_context(self):
         """One registered workspace in context when only DefaultWorkspaceAdapter is registered"""
-        self.client.force_login(self.view_user)
+        self.client.force_login(self.staff_view_user)
         response = self.client.get(self.get_url())
         self.assertIn("registered_workspace_adapters", response.context_data)
         self.assertEqual(len(response.context_data["registered_workspace_adapters"]), 1)
@@ -6346,7 +6346,7 @@ class WorkspaceLandingPageTest(TestCase):
     def test_two_registered_workspaces_in_context(self):
         """Two registered workspaces in context when two workspace adapters are registered"""
         workspace_adapter_registry.register(TestWorkspaceAdapter)
-        self.client.force_login(self.view_user)
+        self.client.force_login(self.staff_view_user)
         response = self.client.get(self.get_url())
         self.assertIn("registered_workspace_adapters", response.context_data)
         self.assertEqual(len(response.context_data["registered_workspace_adapters"]), 2)

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -1503,7 +1503,7 @@ class WorkspaceList(auth.AnVILConsortiumManagerViewRequired, SingleTableMixin, F
 
 
 class WorkspaceListByType(
-    auth.AnVILConsortiumManagerStaffViewRequired,
+    auth.AnVILConsortiumManagerViewRequired,
     viewmixins.WorkspaceAdapterMixin,
     SingleTableMixin,
     FilterView,
@@ -1523,8 +1523,11 @@ class WorkspaceListByType(
 
     def get_table_class(self):
         """Use the adapter to get the table class."""
-        table_class = self.adapter.get_list_table_class_staff_view()
-        return table_class
+        staff_view_permission_codename = models.AnVILProjectManagerAccess.STAFF_VIEW_PERMISSION_CODENAME
+        if self.request.user.has_perm("anvil_consortium_manager." + staff_view_permission_codename):
+            return self.adapter.get_list_table_class_staff_view()
+        else:
+            return self.adapter.get_list_table_class_view()
 
 
 class WorkspaceDelete(auth.AnVILConsortiumManagerStaffEditRequired, SuccessMessageMixin, DeleteView):

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -907,7 +907,7 @@ class ManagedGroupMembershipAudit(
 
 
 class WorkspaceLandingPage(
-    auth.AnVILConsortiumManagerStaffViewRequired,
+    auth.AnVILConsortiumManagerViewRequired,
     viewmixins.RegisteredWorkspaceAdaptersMixin,
     TemplateView,
 ):

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -1523,7 +1523,7 @@ class WorkspaceListByType(
 
     def get_table_class(self):
         """Use the adapter to get the table class."""
-        table_class = self.adapter.get_list_table_class()
+        table_class = self.adapter.get_staff_list_table_class()
         return table_class
 
 

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -1478,11 +1478,10 @@ class WorkspaceUpdate(
         return self.object.get_absolute_url()
 
 
-class WorkspaceList(auth.AnVILConsortiumManagerStaffViewRequired, SingleTableMixin, FilterView):
+class WorkspaceList(auth.AnVILConsortiumManagerViewRequired, SingleTableMixin, FilterView):
     """Display a list of all workspaces using the default table."""
 
     model = models.Workspace
-    table_class = tables.WorkspaceStaffTable
     ordering = (
         "billing_project__name",
         "name",
@@ -1494,6 +1493,13 @@ class WorkspaceList(auth.AnVILConsortiumManagerStaffViewRequired, SingleTableMix
         context = super().get_context_data(**kwargs)
         context["workspace_type_display_name"] = "All workspace"
         return context
+
+    def get_table_class(self):
+        staff_view_permission_codename = models.AnVILProjectManagerAccess.STAFF_VIEW_PERMISSION_CODENAME
+        if self.request.user.has_perm("anvil_consortium_manager." + staff_view_permission_codename):
+            return tables.WorkspaceStaffTable
+        else:
+            return tables.WorkspaceUserTable
 
 
 class WorkspaceListByType(

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -1523,7 +1523,7 @@ class WorkspaceListByType(
 
     def get_table_class(self):
         """Use the adapter to get the table class."""
-        table_class = self.adapter.get_staff_list_table_class()
+        table_class = self.adapter.get_list_table_class_staff_view()
         return table_class
 
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -78,7 +78,8 @@ Next, set up the adapter by subclassing :class:`~anvil_consortium_manager.adapte
 * ``workspace_form_class``: the form to use to create an instance of the ``Workspace`` model. The default adapter uses :class:`~anvil_consortium_manager.forms.WorkspaceForm``.
 * ``workspace_data_model``: the model used to store additional data about a workspace, subclassed from :class:`~anvil_consortium_manager.models.BaseWorkspaceData`
 * ``workspace_data_form_class``: the form to use to create an instance of the ``workspace_data_model``
-* ``list_table_class``: the table to use to display the list of workspaces
+* ``list_table_class_staff_view``: the table to use to display the list of workspaces for Staff viewers
+* ``list_table_class_view``: the table to use to display the list of workspaces for non-Staff Viewers.
 * ``workspace_detail_template_name``: the template to use to render the detail of the workspace
 
 You may also override default settings and methods:
@@ -99,7 +100,8 @@ Here is example of the custom adapter for ``my_app`` with the model, form and ta
         name = "Custom workspace"
         type = "custom"
         description = "Example custom workspace type for demo app"
-        list_table_class = tables.CustomWorkspaceDataTable
+        list_table_class_staff_view = tables.CustomWorkspaceDataStaffTable
+        list_table_class_view = tables.CustomWorkspaceDataUserTable
         workspace_form_class = WorkspaceForm
         workspace_data_model = models.CustomWorkspaceData
         workspace_data_form_class = forms.CustomWorkspaceDataForm

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -101,11 +101,11 @@ The app provides four different permissions settings.
 
 3. ``anvil_consortium_manager_account_link`` - users with this permission can link their AnVIL accounts in the app using the `AccountLink` and `AccountLinkVerify` views.
 
-4. ``anvil_consortium_manager_view`` - in the future, this permission will be used to allow users to view a limited set of information within the site. Rigt now, it is not used by the app.
+4. ``anvil_consortium_manager_view`` - users with this permission can see a limited set of information from the :class:`~anvil_consortium_manager.views.WorkspaceLandingPage`, :class:`~anvil_consortium_manager.views.WorkspaceList`, :class:`~anvil_consortium_manager.views.WorkspaceListByType`, and :class:`~anvil_consortium_manager.views.WorkspaceDetail` views.
 
 We suggest creating three groups,
 staff viewers (with ``anvil_consortium_manager_staff_view`` permission),
 staff editors (with both ``anvil_consortium_manager_staff_view`` and ``anvil_consortium_manager_staff_edit`` permission),
-and a final group for users who are allowed to link their AnVIL account (with ``anvil_consortium_manager_account_link`` permission).
+a group for users who are allowed to link their AnVIL account (with ``anvil_consortium_manager_account_link`` permission).
 Users can then be added to the appropriate group.
-Note that users with staff edit permission but not view permission will not be able to see lists or detail pages, so anyone granted edit permission should also be granted staff view permission.
+Note that users with staff edit permission but not staff view permission will not be able to see lists or detail pages, so anyone granted edit permission should also be granted staff view permission.

--- a/example_site/app/adapters.py
+++ b/example_site/app/adapters.py
@@ -9,7 +9,7 @@ class CustomWorkspaceAdapter(BaseWorkspaceAdapter):
     name = "Custom workspace"
     type = "custom"
     description = "Example custom workspace type for demo app"
-    staff_list_table_class = tables.CustomWorkspaceDataTable
+    list_table_class_staff_view = tables.CustomWorkspaceDataTable
     workspace_form_class = forms.CustomWorkspaceForm
     workspace_data_model = models.CustomWorkspaceData
     workspace_data_form_class = forms.CustomWorkspaceDataForm

--- a/example_site/app/adapters.py
+++ b/example_site/app/adapters.py
@@ -9,7 +9,7 @@ class CustomWorkspaceAdapter(BaseWorkspaceAdapter):
     name = "Custom workspace"
     type = "custom"
     description = "Example custom workspace type for demo app"
-    list_table_class = tables.CustomWorkspaceDataTable
+    staff_list_table_class = tables.CustomWorkspaceDataTable
     workspace_form_class = forms.CustomWorkspaceForm
     workspace_data_model = models.CustomWorkspaceData
     workspace_data_form_class = forms.CustomWorkspaceDataForm

--- a/example_site/app/adapters.py
+++ b/example_site/app/adapters.py
@@ -10,6 +10,7 @@ class CustomWorkspaceAdapter(BaseWorkspaceAdapter):
     type = "custom"
     description = "Example custom workspace type for demo app"
     list_table_class_staff_view = tables.CustomWorkspaceDataTable
+    list_table_class_view = tables.CustomWorkspaceDataTable
     workspace_form_class = forms.CustomWorkspaceForm
     workspace_data_model = models.CustomWorkspaceData
     workspace_data_form_class = forms.CustomWorkspaceDataForm


### PR DESCRIPTION
- Change the permission required to ViewRequired for the WorkspaceList, WorkspaceListByType, and WorkspaceLanding views
- Rename the adapter list_table_class property to list_table_class_staff_view
- Add a new required adapter property, list_table_class_view, where users can specify which table show users with View but not StaffView permission.
- Add overrideable explanatory text to the WorkspaceLanding template.