### PR TITLE
Set max_length to match what AnVIL allows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Add customizeable `get_extra_detail_context_data` method for workspace adapters. Users can override this method to provide additional context data on a workspace detail page.
 * Add filtering by workspace type to the admin interface.
+* Set max_length for `ManagedGroup` and `Workspace` models to match what AnVIL allows.
 
 ## 0.21.0 (2023-12-04)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.22.0.dev1"
+__version__ = "0.22.0.dev2"

--- a/anvil_consortium_manager/models.py
+++ b/anvil_consortium_manager/models.py
@@ -351,7 +351,11 @@ class Account(TimeStampedModel, ActivatorModel):
 class ManagedGroup(TimeStampedModel):
     """A model to store information about AnVIL Managed Groups."""
 
-    name = models.SlugField(max_length=64, unique=True, help_text="Name of the group on AnVIL.")
+    name = models.SlugField(
+        max_length=60,  # Max allowed by AnVIL.
+        unique=True,
+        help_text="Name of the group on AnVIL.",
+    )
     email = models.EmailField(
         help_text="Email for this group.",
         blank=False,
@@ -630,7 +634,7 @@ class Workspace(TimeStampedModel):
         help_text="Billing project associated with this Workspace.",
     )
     name = models.SlugField(
-        max_length=64,
+        max_length=254,  # Max allowed by AnVIL.
         help_text="Name of the workspace on AnVIL, not including billing project name.",
     )
     # This makes it possible to easily select the authorization domains in the WorkspaceForm.

--- a/anvil_consortium_manager/tests/test_models.py
+++ b/anvil_consortium_manager/tests/test_models.py
@@ -1006,6 +1006,14 @@ class ManagedGroupTest(TestCase):
         with self.assertRaises(IntegrityError):
             instance2.save()
 
+    def test_name_max_length(self):
+        """ValidationError is raised when the group name is too long."""
+        instance = factories.ManagedGroupFactory.build(name="a" * 60)
+        instance.full_clean()
+        instance = factories.ManagedGroupFactory.build(name="a" * 61)
+        with self.assertRaises(ValidationError):
+            instance.full_clean()
+
     def test_unique_email(self):
         """Saving a model with a duplicate name fails."""
         instance = factories.ManagedGroupFactory.create()
@@ -1479,6 +1487,15 @@ class WorkspaceTest(TestCase):
         )
         instance.save()
         self.assertIsInstance(instance, Workspace)
+
+    def test_name_max_length(self):
+        """ValidationError is raised when the group name is too long."""
+        billing_project = factories.BillingProjectFactory.create()
+        instance = factories.WorkspaceFactory.build(billing_project=billing_project, name="a" * 254)
+        instance.full_clean()
+        instance = factories.WorkspaceFactory.build(billing_project=billing_project, name="a" * 255)
+        with self.assertRaises(ValidationError):
+            instance.full_clean()
 
     def test_note_field(self):
         """Creation using the model constructor and .save() works when note is set."""


### PR DESCRIPTION
Set max_length for ManagedGroups and Workspaces, based on what AnVIL allows.

Closes #466