### PR TITLE
MariaDB 10.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,11 +25,11 @@ jobs:
         python-version: ["3.8", "3.12"]
         django-version: ["3.2", "4.2"]
         backend: ["sqlite", "mysql"]
-        mariadb-version: ["10.4", "10.5", "10.11"]
-        exclude:
-          - backend: sqlite
+        include:
+          - mariadb-version: "10.4"
+          - backend: "mysql"
             mariadb-version: "10.5"
-          - backend: sqlite
+          - backend: "mysql"
             mariadb-version: "10.11"
 
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,14 @@ jobs:
         backend: ["sqlite", "mysql"]
         mariadb-version: ["10.4"]  # What we're currently running with.
         include:
-          - mariadb-version: "10.5"  # Possible future update.
-            python-version: "3.12"
+          - python-version: "3.12"  # Possible future update.
             django-version: "4.2"
             backend: "mysql"
-          - mariadb-version: "10.11"  # Possible future update.
-            python-version: "3.12"
+            mariadb-version: "10.5"
+          - python-version: "3.12"  # Possible future update.
             django-version: "4.2"
             backend: "mysql"
+            mariadb-version: "10.11"
 
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,13 +25,16 @@ jobs:
         python-version: ["3.8", "3.12"]
         django-version: ["3.2", "4.2"]
         backend: ["sqlite", "mysql"]
+        mariadb-version: ["10.4"]  # What we're currently running with.
         include:
-          - mariadb-version: "10.4"
-          - backend: "mysql"
-            mariadb-version: "10.5"
-          - backend: "mysql"
-            mariadb-version: "10.11"
-    name: "py${{ matrix.python-version }} - dj${{ matrix.django-version }} - ${{ matrix.backend }} (MariaDB ${{ matrix.mariadb-version }})"
+          - mariadb-version: "10.5"  # Possible future update.
+            python-version: "3.12"
+            django-version: "4.2"
+            backend: "mysql"
+          - mariadb-version: "10.11"  # Possible future update.
+            python-version: "3.12"
+            django-version: "4.2"
+            backend: "mysql"
 
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
             mariadb-version: "10.5"
           - backend: "mysql"
             mariadb-version: "10.11"
-    name: "Python ${{ matrix.python-version }} - Django ${{ matrix.django-version }} - ${{ matrix.backend }} (MariaDB ${{ matrix.mariadb-version }})"
+    name: "py${{ matrix.python-version }} - dj${{ matrix.django-version }} - ${{ matrix.backend }} (MariaDB ${{ matrix.mariadb-version }})"
 
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,10 +25,12 @@ jobs:
         python-version: ["3.8", "3.12"]
         django-version: ["3.2", "4.2"]
         backend: ["sqlite", "mysql"]
-        mariadb-version: ["10.4", "10.5"]
+        mariadb-version: ["10.4", "10.5", "10.11"]
         exclude:
           - backend: sqlite
             mariadb-version: "10.5"
+          - backend: sqlite
+            mariadb-version: "10.11"
 
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
             django-version: "4.2"
             backend: "mysql"
             mariadb-version: "10.11"
+      name: "py${{ matrix.python-version }}-dj${{ matrix.django-version }}-${{ matrix.backend }}-${{ matrix.mariadb-version }}"
 
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
             django-version: "4.2"
             backend: "mysql"
             mariadb-version: "10.11"
-      name: "py${{ matrix.python-version }}-dj${{ matrix.django-version }}-${{ matrix.backend }}-${{ matrix.mariadb-version }}"
+    name: "py${{ matrix.python-version }}-dj${{ matrix.django-version }}-${{ matrix.backend }}-${{ matrix.mariadb-version }}"
 
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
             mariadb-version: "10.5"
           - backend: "mysql"
             mariadb-version: "10.11"
+    name: "Python ${{ matrix.python-version }} - Django ${{ matrix.django-version }} - ${{ matrix.backend }} (MariaDB ${{ matrix.mariadb-version }})"
 
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
MariaDB 10.11 is the default in the new OS to be installed on GAC web servers.

- Add MariaDB 10.11 to CI

