### PR TITLE
Remove support for Django 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.8", "3.12"]
-        django-version: ["3.2", "4.2", "5.0"]
+        django-version: ["4.2", "5.0"]
         backend: ["sqlite", "mysql"]
         mariadb-version: ["10.4"]  # What we're currently running with.
         include:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Devel
 
 * Add AccountUserArchive model to the admin interface.
+* Drop support for Django 3.2.
 * Add support for Django 5.0.
 * Add `convert_mariadb_uuid_fields` command to convert UUID fields for MariaDB 10.7+ and Django 5.0+. See the documentation of this command for more information.
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.23.1.dev1"
+__version__ = "0.23.1.dev2"

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -1,5 +1,4 @@
 from dal import autocomplete
-from django import VERSION as DJANGO_VERSION
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.messages.views import SuccessMessageMixin
@@ -11,11 +10,8 @@ from django.http import Http404, HttpResponseRedirect
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
-from django.views.generic import CreateView, DetailView, FormView, RedirectView, TemplateView, UpdateView
-from django.views.generic import DeleteView as DjangoDeleteView
-from django.views.generic.detail import BaseDetailView, SingleObjectMixin, SingleObjectTemplateResponseMixin
-from django.views.generic.edit import BaseDeleteView as DjangoBaseDeleteView
-from django.views.generic.edit import DeletionMixin, FormMixin
+from django.views.generic import CreateView, DeleteView, DetailView, FormView, RedirectView, TemplateView, UpdateView
+from django.views.generic.detail import SingleObjectMixin
 from django_filters.views import FilterView
 from django_tables2 import SingleTableMixin, SingleTableView
 
@@ -25,49 +21,6 @@ from .adapters.workspace import workspace_adapter_registry
 from .anvil_api import AnVILAPIClient, AnVILAPIError
 from .audit import audit
 from .tokens import account_verification_token
-
-# Based on Wagtail: https://github.com/wagtail/wagtail/blob/main/wagtail/admin/views/generic/models.py
-if DJANGO_VERSION >= (4, 0):
-    BaseDeleteView = DjangoBaseDeleteView
-    DeleteView = DjangoDeleteView
-else:
-    # As of Django 4.0 BaseDeleteView has switched to a new implementation based on FormMixin
-    # where custom deletion logic now lives in form_valid:
-    # https://docs.djangoproject.com/en/4.0/releases/4.0/#deleteview-changes
-    # Here we define BaseDeleteView and DeleteView to match the Django 4.0 implementation to keep it
-    # consistent across all versions.
-    class BaseDeleteView(DeletionMixin, FormMixin, BaseDetailView):
-        """
-        Base view for deleting an object.
-        Using this base class requires subclassing to provide a response mixin.
-        """
-
-        form_class = Form
-
-        def post(self, request, *args, **kwargs):
-            # Set self.object before the usual form processing flow.
-            # Inlined because having DeletionMixin as the first base, for
-            # get_success_url(), makes leveraging super() with ProcessFormView
-            # overly complex.
-            self.object = self.get_object()
-            form = self.get_form()
-            if form.is_valid():
-                return self.form_valid(form)
-            else:
-                return self.form_invalid(form)
-
-        def form_valid(self, form):
-            success_url = self.get_success_url()
-            self.object.delete()
-            return HttpResponseRedirect(success_url)
-
-    class DeleteView(SingleObjectTemplateResponseMixin, BaseDeleteView):
-        """
-        View for deleting an object retrieved with self.get_object(), with a
-        response rendered by a template.
-        """
-
-        template_name_suffix = "_confirm_delete"
 
 
 class Index(auth.AnVILConsortiumManagerStaffViewRequired, TemplateView):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "Django >= 3.2",
+    "Django >= 4.0",
     "pytz >= 0",
     "crispy-bootstrap5 >= 0.6",
     "django-crispy-forms >= 1.12",
@@ -170,10 +170,9 @@ DBBACKEND = "sqlite3"
 DBNAME = ":memory:"
 [[tool.hatch.envs.test-sqlite.matrix]]
 python = ["3.8", "3.12"]
-django = ["3.2", "4.2", "5.0"]
+django = ["4.2", "5.0"]
 [tool.hatch.envs.test-sqlite.overrides]
 matrix.django.extra-dependencies = [
-    { value = "django ~= 3.2.0", if = ["3.2"] },
     { value = "django ~= 4.2.0", if = ["4.2"] },
     { value = "django ~= 5.0.0", if = ["5.0"] },
 ]
@@ -187,10 +186,9 @@ extra-dependencies = [
 DBBACKEND = "mysql"
 [[tool.hatch.envs.test-mysql.matrix]]
 python = ["3.8", "3.12"]
-django = ["3.2", "4.2", "5.0"]
+django = ["4.2", "5.0"]
 [tool.hatch.envs.test-mysql.overrides]
 matrix.django.extra-dependencies = [
-    { value = "django ~= 3.2.0", if = ["3.2"] },
     { value = "django ~= 4.2.0", if = ["4.2"] },
     { value = "django ~= 5.0.0", if = ["5.0"] },
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    "Django >= 4.0",
+    "Django >= 4.2",
     "pytz >= 0",
     "crispy-bootstrap5 >= 0.6",
     "django-crispy-forms >= 1.12",


### PR DESCRIPTION
- Remove support for Django 3.2.
- Increase minimum Django version to 4.2 in dependencies.
- Remove Django 3.2 from hatch and CI testing.
- Remove code to handle different implementation of DeleteView between Django 3.2 and 4.0.