### PR TITLE
Add a managed group adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Devel
 
-* Add an adapter for ManagedGroups that lets the user set table classes to display as well as an `after_anvil_create` method.
+* Add an adapter for ManagedGroups that lets the user set the table class to display as well as an `after_anvil_create` method.
 * Add model class checks to adapter methods where appropriate.
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## Devel
+
+* Add an adapter for ManagedGroups that lets the user set table classes to display as well as an `after_anvil_create` method.
+* Add model class checks to adapter methods where appropriate.
+
+
 ## 0.24.0 (2024-07-03)
 
 * Add AccountUserArchive model to the admin interface.

--- a/anvil_consortium_manager/adapters/account.py
+++ b/anvil_consortium_manager/adapters/account.py
@@ -26,6 +26,10 @@ class BaseAccountAdapter(ABC):
         """Return the table class to use for the AccountList view."""
         if not self.list_table_class:
             raise ImproperlyConfigured("Set `list_table_class` in `{}`.".format(type(self)))
+        if self.list_table_class.Meta.model != models.Account:
+            raise ImproperlyConfigured(
+                "list_table_class Meta model field must be anvil_consortium_manager.models.Account."
+            )
         return self.list_table_class
 
     def get_list_filterset_class(self):

--- a/anvil_consortium_manager/adapters/default.py
+++ b/anvil_consortium_manager/adapters/default.py
@@ -2,6 +2,7 @@
 
 from .. import filters, forms, models, tables
 from .account import BaseAccountAdapter
+from .managed_group import BaseManagedGroupAdapter
 from .workspace import BaseWorkspaceAdapter
 
 
@@ -10,6 +11,13 @@ class DefaultAccountAdapter(BaseAccountAdapter):
 
     list_table_class = tables.AccountStaffTable
     list_filterset_class = filters.AccountListFilter
+
+
+class DefaultManagedGroupAdapter(BaseManagedGroupAdapter):
+    """Default adapter to use for ManagedGroups in the app."""
+
+    list_table_class_staff_view = tables.ManagedGroupStaffTable
+    list_table_class_view = tables.ManagedGroupUserTable
 
 
 class DefaultWorkspaceAdapter(BaseWorkspaceAdapter):

--- a/anvil_consortium_manager/adapters/default.py
+++ b/anvil_consortium_manager/adapters/default.py
@@ -16,8 +16,7 @@ class DefaultAccountAdapter(BaseAccountAdapter):
 class DefaultManagedGroupAdapter(BaseManagedGroupAdapter):
     """Default adapter to use for ManagedGroups in the app."""
 
-    list_table_class_staff_view = tables.ManagedGroupStaffTable
-    list_table_class_view = tables.ManagedGroupUserTable
+    list_table_class = tables.ManagedGroupStaffTable
 
 
 class DefaultWorkspaceAdapter(BaseWorkspaceAdapter):

--- a/anvil_consortium_manager/adapters/managed_group.py
+++ b/anvil_consortium_manager/adapters/managed_group.py
@@ -12,36 +12,20 @@ class BaseManagedGroupAdapter(ABC):
     """Base class to inherit when customizing the account adapter."""
 
     @abstractproperty
-    def list_table_class_staff_view(self):
+    def list_table_class(self):
         """Table class to use in a list of ManagedGroups."""
         ...
 
-    @abstractproperty
-    def list_table_class_view(self):
-        """Table class to use in a list of ManagedGroups."""
-        ...
-
-    def get_list_table_class_staff_view(self):
+    def get_list_table_class(self):
         """Return the table class to use for the ManagedGroupList view for staff view users."""
         # Make sure that ManagedGroup is the model being passed.
-        if not self.list_table_class_staff_view:
-            raise ImproperlyConfigured("Set `list_table_class_staff_view` in `{}`.".format(type(self)))
-        if self.list_table_class_staff_view.Meta.model != models.ManagedGroup:
+        if not self.list_table_class:
+            raise ImproperlyConfigured("Set `list_table_class` in `{}`.".format(type(self)))
+        if self.list_table_class.Meta.model != models.ManagedGroup:
             raise ImproperlyConfigured(
-                "list_table_class_staff_view Meta model field must be anvil_consortium_manager.models.ManagedGroup."
+                "list_table_class Meta model field must be anvil_consortium_manager.models.ManagedGroup."
             )
-        return self.list_table_class_staff_view
-
-    def get_list_table_class_view(self):
-        """Return the table class to use for the ManagedGroupList view for view users."""
-        # Make sure that ManagedGroup is the model being passed.
-        if not self.list_table_class_view:
-            raise ImproperlyConfigured("Set `list_table_class_view` in `{}`.".format(type(self)))
-        if self.list_table_class_view.Meta.model != models.ManagedGroup:
-            raise ImproperlyConfigured(
-                "list_table_class_view Meta model field must be anvil_consortium_manager.models.ManagedGroup."
-            )
-        return self.list_table_class_view
+        return self.list_table_class
 
     def after_anvil_create(self, managed_group):
         """Custom actions to run after a ManagedGroup is created by the app."""

--- a/anvil_consortium_manager/adapters/managed_group.py
+++ b/anvil_consortium_manager/adapters/managed_group.py
@@ -1,0 +1,45 @@
+"""Contains base adapter for accounts."""
+
+from abc import ABC, abstractproperty
+
+from django.core.exceptions import ImproperlyConfigured
+from django.utils.module_loading import import_string
+
+from .. import app_settings, models
+
+
+class BaseManagedGroupAdapter(ABC):
+    """Base class to inherit when customizing the account adapter."""
+
+    @abstractproperty
+    def list_table_class_staff_view(self):
+        """Table class to use in a list of ManagedGroups."""
+        ...
+
+    @abstractproperty
+    def list_table_class_view(self):
+        """Table class to use in a list of ManagedGroups."""
+        ...
+
+    def get_list_table_class_staff_view(self):
+        """Return the table class to use for the ManagedGroupList view for staff view users."""
+        # Make sure that ManagedGroup is the model being passed.
+        if not self.list_table_class_staff_view:
+            raise ImproperlyConfigured("Set `list_table_class_staff_view` in `{}`.".format(type(self)))
+        if self.list_table_class_staff_view.Meta.model != models.ManagedGroup:
+            raise ImproperlyConfigured("The Meta model for `list_table_class_staff_view` must be ManagedGroup.")
+        return self.list_table_class_staff_view
+
+    def get_list_table_class_view(self):
+        """Return the table class to use for the ManagedGroupList view for view users."""
+        # Make sure that ManagedGroup is the model being passed.
+        if not self.list_table_class_view:
+            raise ImproperlyConfigured("Set `list_table_class_view` in `{}`.".format(type(self)))
+        if self.list_table_class_view.Meta.model != models.ManagedGroup:
+            raise ImproperlyConfigured("The Meta model for `list_table_class_view` must be ManagedGroup.")
+        return self.list_table_class_view
+
+
+def get_managed_group_adapter():
+    adapter = import_string(app_settings.MANAGED_GROUP_ADAPTER)
+    return adapter

--- a/anvil_consortium_manager/adapters/managed_group.py
+++ b/anvil_consortium_manager/adapters/managed_group.py
@@ -39,7 +39,7 @@ class BaseManagedGroupAdapter(ABC):
             raise ImproperlyConfigured("The Meta model for `list_table_class_view` must be ManagedGroup.")
         return self.list_table_class_view
 
-    def after_anvil_create(self):
+    def after_anvil_create(self, managed_group):
         """Custom actions to run after a ManagedGroup is created by the app."""
         pass
 

--- a/anvil_consortium_manager/adapters/managed_group.py
+++ b/anvil_consortium_manager/adapters/managed_group.py
@@ -27,7 +27,9 @@ class BaseManagedGroupAdapter(ABC):
         if not self.list_table_class_staff_view:
             raise ImproperlyConfigured("Set `list_table_class_staff_view` in `{}`.".format(type(self)))
         if self.list_table_class_staff_view.Meta.model != models.ManagedGroup:
-            raise ImproperlyConfigured("The Meta model for `list_table_class_staff_view` must be ManagedGroup.")
+            raise ImproperlyConfigured(
+                "list_table_class_staff_view Meta model field must be anvil_consortium_manager.models.ManagedGroup."
+            )
         return self.list_table_class_staff_view
 
     def get_list_table_class_view(self):
@@ -36,7 +38,9 @@ class BaseManagedGroupAdapter(ABC):
         if not self.list_table_class_view:
             raise ImproperlyConfigured("Set `list_table_class_view` in `{}`.".format(type(self)))
         if self.list_table_class_view.Meta.model != models.ManagedGroup:
-            raise ImproperlyConfigured("The Meta model for `list_table_class_view` must be ManagedGroup.")
+            raise ImproperlyConfigured(
+                "list_table_class_view Meta model field must be anvil_consortium_manager.models.ManagedGroup."
+            )
         return self.list_table_class_view
 
     def after_anvil_create(self, managed_group):

--- a/anvil_consortium_manager/adapters/managed_group.py
+++ b/anvil_consortium_manager/adapters/managed_group.py
@@ -39,6 +39,10 @@ class BaseManagedGroupAdapter(ABC):
             raise ImproperlyConfigured("The Meta model for `list_table_class_view` must be ManagedGroup.")
         return self.list_table_class_view
 
+    def after_anvil_create(self):
+        """Custom actions to run after a ManagedGroup is created by the app."""
+        pass
+
 
 def get_managed_group_adapter():
     adapter = import_string(app_settings.MANAGED_GROUP_ADAPTER)

--- a/anvil_consortium_manager/adapters/workspace.py
+++ b/anvil_consortium_manager/adapters/workspace.py
@@ -78,12 +78,20 @@ class BaseWorkspaceAdapter(ABC):
         """Return the table class to use for the WorkspaceListByType view for staff."""
         if not self.list_table_class_staff_view:
             raise ImproperlyConfigured("Set `list_table_class_staff_view` in `{}`.".format(type(self)))
+        if self.list_table_class_staff_view.Meta.model != models.Workspace:
+            raise ImproperlyConfigured(
+                "list_table_class_staff_view Meta model field must be anvil_consortium_manager.models.Workspace."
+            )
         return self.list_table_class_staff_view
 
     def get_list_table_class_view(self):
         """Return the table class to use for the WorkspaceListByType view for non-staff users."""
         if not self.list_table_class_view:
             raise ImproperlyConfigured("Set `list_table_class_view` in `{}`.".format(type(self)))
+        if self.list_table_class_view.Meta.model != models.Workspace:
+            raise ImproperlyConfigured(
+                "list_table_class_view Meta model field must be anvil_consortium_manager.models.Workspace."
+            )
         return self.list_table_class_view
 
     def get_workspace_form_class(self):

--- a/anvil_consortium_manager/app_settings.py
+++ b/anvil_consortium_manager/app_settings.py
@@ -60,6 +60,13 @@ class AppSettings(object):
         """Account adapter. Default: anvil_consortium_manager.adapters.default.DefaultAccountAdapter."""
         return self._setting("ACCOUNT_ADAPTER", "anvil_consortium_manager.adapters.default.DefaultAccountAdapter")
 
+    @property
+    def MANAGED_GROUP_ADAPTER(self):
+        """ManagedGroup adapter. Default: anvil_consortium_manager.adapters.default.DefaultManagedGroupAdapter."""
+        return self._setting(
+            "MANAGED_GROUP_ADAPTER", "anvil_consortium_manager.adapters.default.DefaultManagedGroupAdapter"
+        )
+
 
 _app_settings = AppSettings("ANVIL_")
 

--- a/anvil_consortium_manager/tests/test_adapters.py
+++ b/anvil_consortium_manager/tests/test_adapters.py
@@ -19,7 +19,6 @@ from ..models import Account, DefaultWorkspaceData
 from ..tables import (
     AccountStaffTable,
     ManagedGroupStaffTable,
-    ManagedGroupUserTable,
     WorkspaceStaffTable,
     WorkspaceUserTable,
 )
@@ -169,31 +168,30 @@ class ManagedGroupAdapterTest(TestCase):
         """Return a test adapter class for use in tests."""
 
         class TestAdapter(BaseManagedGroupAdapter):
-            list_table_class_staff_view = tables.TestManagedGroupStaffTable
-            list_table_class_view = tables.TestManagedGroupUserTable
+            list_table_class = tables.TestManagedGroupTable
 
         return TestAdapter
 
-    def test_list_table_class_staff_view_default(self):
-        """get_list_table_class_staff_view returns the correct table when using the default adapter."""
-        self.assertEqual(DefaultManagedGroupAdapter().get_list_table_class_staff_view(), ManagedGroupStaffTable)
+    def test_list_table_class_default(self):
+        """get_list_table_class returns the correct table when using the default adapter."""
+        self.assertEqual(DefaultManagedGroupAdapter().get_list_table_class(), ManagedGroupStaffTable)
 
-    def test_list_table_class_staff_view_custom(self):
-        """get_list_table_class_staff_view returns the correct table when using a custom adapter."""
+    def test_list_table_class_custom(self):
+        """get_list_table_class returns the correct table when using a custom adapter."""
         TestAdapter = self.get_test_adapter()
-        setattr(TestAdapter, "list_table_class_staff_view", tables.TestManagedGroupStaffTable)
-        self.assertEqual(TestAdapter().get_list_table_class_staff_view(), tables.TestManagedGroupStaffTable)
+        setattr(TestAdapter, "list_table_class", tables.TestManagedGroupTable)
+        self.assertEqual(TestAdapter().get_list_table_class(), tables.TestManagedGroupTable)
 
-    def test_list_table_class_staff_view_none(self):
-        """get_list_table_class_staff_view raises ImproperlyConfigured when list_table_class is not set."""
+    def test_list_table_class_none(self):
+        """get_list_table_class raises ImproperlyConfigured when list_table_class is not set."""
         TestAdapter = self.get_test_adapter()
-        setattr(TestAdapter, "list_table_class_staff_view", None)
+        setattr(TestAdapter, "list_table_class", None)
         with self.assertRaises(ImproperlyConfigured) as e:
-            TestAdapter().get_list_table_class_staff_view()
-        self.assertIn("Set `list_table_class_staff_view`", str(e.exception))
+            TestAdapter().get_list_table_class()
+        self.assertIn("Set `list_table_class`", str(e.exception))
 
-    def test_list_table_class_staff_view_wrong_model(self):
-        """get_list_table_class_staff_view raises ImproperlyConfigured when incorrect model is used for the table."""
+    def test_list_table_class_wrong_model(self):
+        """get_list_table_class raises ImproperlyConfigured when incorrect model is used for the table."""
 
         class TestTable(django_tables2.Table):
             class Meta:
@@ -201,41 +199,9 @@ class ManagedGroupAdapterTest(TestCase):
                 fields = ("email",)
 
         TestAdapter = self.get_test_adapter()
-        setattr(TestAdapter, "list_table_class_staff_view", TestTable)
+        setattr(TestAdapter, "list_table_class", TestTable)
         with self.assertRaises(ImproperlyConfigured) as e:
-            TestAdapter().get_list_table_class_staff_view()
-        self.assertIn("anvil_consortium_manager.models.ManagedGroup", str(e.exception))
-
-    def test_list_table_class_view_default(self):
-        """get_list_table_class_view returns the correct table when using the default adapter."""
-        self.assertEqual(DefaultManagedGroupAdapter().get_list_table_class_view(), ManagedGroupUserTable)
-
-    def test_list_table_class_view_custom(self):
-        """get_list_table_class_view returns the correct table when using a custom adapter."""
-        TestAdapter = self.get_test_adapter()
-        setattr(TestAdapter, "list_table_class_view", tables.TestManagedGroupUserTable)
-        self.assertEqual(TestAdapter().get_list_table_class_view(), tables.TestManagedGroupUserTable)
-
-    def test_list_table_class_view_none(self):
-        """get_list_table_class_view raises ImproperlyConfigured when list_table_class is not set."""
-        TestAdapter = self.get_test_adapter()
-        setattr(TestAdapter, "list_table_class_view", None)
-        with self.assertRaises(ImproperlyConfigured) as e:
-            TestAdapter().get_list_table_class_view()
-        self.assertIn("Set `list_table_class_view`", str(e.exception))
-
-    def test_list_table_class_view_wrong_model(self):
-        """get_list_table_class_view raises ImproperlyConfigured when incorrect model is used for the table."""
-
-        class TestTable(django_tables2.Table):
-            class Meta:
-                model = Account
-                fields = ("email",)
-
-        TestAdapter = self.get_test_adapter()
-        setattr(TestAdapter, "list_table_class_view", TestTable)
-        with self.assertRaises(ImproperlyConfigured) as e:
-            TestAdapter().get_list_table_class_view()
+            TestAdapter().get_list_table_class()
         self.assertIn("anvil_consortium_manager.models.ManagedGroup", str(e.exception))
 
 

--- a/anvil_consortium_manager/tests/test_adapters.py
+++ b/anvil_consortium_manager/tests/test_adapters.py
@@ -2,6 +2,7 @@ import django_tables2
 from django.core.exceptions import ImproperlyConfigured
 from django.forms import Form, ModelForm
 from django.test import TestCase, override_settings
+from django_filters import FilterSet
 
 from ..adapters.account import BaseAccountAdapter
 from ..adapters.default import DefaultAccountAdapter, DefaultManagedGroupAdapter, DefaultWorkspaceAdapter
@@ -56,6 +57,20 @@ class AccountAdapterTestCase(TestCase):
         with self.assertRaises(ImproperlyConfigured):
             TestAdapter().get_list_table_class()
 
+    def test_list_table_class_wrong_model(self):
+        """get_list_table_class raises ImproperlyConfigured when incorrect model is used for the table."""
+
+        class TestTable(django_tables2.Table):
+            class Meta:
+                model = DefaultWorkspaceData
+                fields = ("name",)
+
+        TestAdapter = self.get_test_adapter()
+        setattr(TestAdapter, "list_table_class", TestTable)
+        with self.assertRaises(ImproperlyConfigured) as e:
+            TestAdapter().get_list_table_class()
+        self.assertIn("anvil_consortium_manager.models.Account", str(e.exception))
+
     def test_list_filterset_class_default(self):
         """get_list_filterset_class returns the correct filter when using the default adapter."""
         self.assertEqual(DefaultAccountAdapter().get_list_filterset_class(), AccountListFilter)
@@ -90,6 +105,20 @@ class AccountAdapterTestCase(TestCase):
         setattr(TestAdapter, "list_filterset_class", Foo)
         with self.assertRaises(ImproperlyConfigured):
             TestAdapter().get_list_filterset_class()
+
+    def test_list_filterset_class_wrong_model(self):
+        """Raises ImproperlyConfigured when incorrect model is used for the filterset."""
+
+        class TestFilterSet(FilterSet):
+            class Meta:
+                model = models.ManagedGroup
+                fields = {"email": ["icontains"]}
+
+        TestAdapter = self.get_test_adapter()
+        setattr(TestAdapter, "list_filterset_class", TestFilterSet)
+        with self.assertRaises(ImproperlyConfigured) as e:
+            TestAdapter().get_list_filterset_class()
+        self.assertIn("anvil_consortium_manager.models.Account", str(e.exception))
 
     def test_get_autocomplete_queryset_default(self):
         """get_autocomplete_queryset returns the correct queryset when using the default adapter."""
@@ -175,7 +204,7 @@ class ManagedGroupAdapterTest(TestCase):
         setattr(TestAdapter, "list_table_class_staff_view", TestTable)
         with self.assertRaises(ImproperlyConfigured) as e:
             TestAdapter().get_list_table_class_staff_view()
-        self.assertIn("ManagedGroup", str(e.exception))
+        self.assertIn("anvil_consortium_manager.models.ManagedGroup", str(e.exception))
 
     def test_list_table_class_view_default(self):
         """get_list_table_class_view returns the correct table when using the default adapter."""
@@ -207,7 +236,7 @@ class ManagedGroupAdapterTest(TestCase):
         setattr(TestAdapter, "list_table_class_view", TestTable)
         with self.assertRaises(ImproperlyConfigured) as e:
             TestAdapter().get_list_table_class_view()
-        self.assertIn("ManagedGroup", str(e.exception))
+        self.assertIn("anvil_consortium_manager.models.ManagedGroup", str(e.exception))
 
 
 class WorkspaceAdapterTest(TestCase):
@@ -246,6 +275,20 @@ class WorkspaceAdapterTest(TestCase):
         with self.assertRaises(ImproperlyConfigured):
             TestAdapter().get_list_table_class_staff_view()
 
+    def test_list_table_class_staff_view_wrong_model(self):
+        """get_list_table_class_staff_view raises ImproperlyConfigured when incorrect model is used for the table."""
+
+        class TestTable(django_tables2.Table):
+            class Meta:
+                model = Account
+                fields = ("email",)
+
+        TestAdapter = self.get_test_adapter()
+        setattr(TestAdapter, "list_table_class_staff_view", TestTable)
+        with self.assertRaises(ImproperlyConfigured) as e:
+            TestAdapter().get_list_table_class_staff_view()
+        self.assertIn("anvil_consortium_manager.models.Workspace", str(e.exception))
+
     def test_list_table_class_view_default(self):
         """get_list_table_class returns the correct table when using the default adapter."""
         self.assertEqual(DefaultWorkspaceAdapter().get_list_table_class_view(), WorkspaceUserTable)
@@ -262,6 +305,20 @@ class WorkspaceAdapterTest(TestCase):
         setattr(TestAdapter, "list_table_class_view", None)
         with self.assertRaises(ImproperlyConfigured):
             TestAdapter().get_list_table_class_view()
+
+    def test_list_table_class_view_wrong_model(self):
+        """get_list_table_class_view raises ImproperlyConfigured when incorrect model is used for the table."""
+
+        class TestTable(django_tables2.Table):
+            class Meta:
+                model = Account
+                fields = ("email",)
+
+        TestAdapter = self.get_test_adapter()
+        setattr(TestAdapter, "list_table_class_view", TestTable)
+        with self.assertRaises(ImproperlyConfigured) as e:
+            TestAdapter().get_list_table_class_view()
+        self.assertIn("anvil_consortium_manager.models.Workspace", str(e.exception))
 
     def test_get_workspace_form_class_default(self):
         """get_workspace_form_class returns the correct form when using the default adapter."""

--- a/anvil_consortium_manager/tests/test_app/adapters.py
+++ b/anvil_consortium_manager/tests/test_app/adapters.py
@@ -110,3 +110,12 @@ class TestAfterWorkspaceImportAdapter(TestWorkspaceMethodsAdapter):
         # Set the extra field.
         workspace.testworkspacemethodsdata.test_field = "imported!"
         workspace.testworkspacemethodsdata.save()
+
+
+class TestManagedGroupAfterAnVILCreateAdapter(TestManagedGroupAdapter):
+    """Test adapter for workspaces with custom methods defined."""
+
+    def after_anvil_create(self, managed_group):
+        # Change the name of the group to something else.
+        managed_group.name = "changed-name"
+        managed_group.save()

--- a/anvil_consortium_manager/tests/test_app/adapters.py
+++ b/anvil_consortium_manager/tests/test_app/adapters.py
@@ -38,8 +38,7 @@ class TestWorkspaceAdapter(BaseWorkspaceAdapter):
 class TestManagedGroupAdapter(BaseManagedGroupAdapter):
     """Test adapter for ManagedGroups."""
 
-    list_table_class_staff_view = tables.TestManagedGroupStaffTable
-    list_table_class_view = tables.TestManagedGroupUserTable
+    list_table_class = tables.TestManagedGroupTable
 
 
 class TestAccountAdapter(BaseAccountAdapter):

--- a/anvil_consortium_manager/tests/test_app/adapters.py
+++ b/anvil_consortium_manager/tests/test_app/adapters.py
@@ -1,4 +1,5 @@
 from anvil_consortium_manager.adapters.account import BaseAccountAdapter
+from anvil_consortium_manager.adapters.managed_group import BaseManagedGroupAdapter
 from anvil_consortium_manager.adapters.workspace import BaseWorkspaceAdapter
 from anvil_consortium_manager.forms import WorkspaceForm
 from anvil_consortium_manager.tables import WorkspaceStaffTable, WorkspaceUserTable
@@ -32,6 +33,13 @@ class TestWorkspaceAdapter(BaseWorkspaceAdapter):
         extra_context = {}
         extra_context["extra_text"] = "Extra text"
         return extra_context
+
+
+class TestManagedGroupAdapter(BaseManagedGroupAdapter):
+    """Test adapter for ManagedGroups."""
+
+    list_table_class_staff_view = tables.TestManagedGroupStaffTable
+    list_table_class_view = tables.TestManagedGroupUserTable
 
 
 class TestAccountAdapter(BaseAccountAdapter):

--- a/anvil_consortium_manager/tests/test_app/tables.py
+++ b/anvil_consortium_manager/tests/test_app/tables.py
@@ -33,7 +33,7 @@ class TestAccountStaffTable(tables.Table):
         fields = ("email",)
 
 
-class TestManagedGroupStaffTable(tables.Table):
+class TestManagedGroupTable(tables.Table):
     """Table for testing the ManagedGroup adapter."""
 
     name = tables.columns.Column(linkify=True)
@@ -44,13 +44,3 @@ class TestManagedGroupStaffTable(tables.Table):
             "name",
             "email",
         )
-
-
-class TestManagedGroupUserTable(tables.Table):
-    """Table for testing the ManagedGroup adapter."""
-
-    name = tables.columns.Column(linkify=True)
-
-    class Meta:
-        model = acm_models.ManagedGroup
-        fields = ("name",)

--- a/anvil_consortium_manager/tests/test_app/tables.py
+++ b/anvil_consortium_manager/tests/test_app/tables.py
@@ -31,3 +31,26 @@ class TestAccountStaffTable(tables.Table):
     class Meta:
         model = acm_models.Account
         fields = ("email",)
+
+
+class TestManagedGroupStaffTable(tables.Table):
+    """Table for testing the ManagedGroup adapter."""
+
+    name = tables.columns.Column(linkify=True)
+
+    class Meta:
+        model = acm_models.ManagedGroup
+        fields = (
+            "name",
+            "email",
+        )
+
+
+class TestManagedGroupUserTable(tables.Table):
+    """Table for testing the ManagedGroup adapter."""
+
+    name = tables.columns.Column(linkify=True)
+
+    class Meta:
+        model = acm_models.ManagedGroup
+        fields = ("name",)

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -5407,6 +5407,16 @@ class ManagedGroupListTest(TestCase):
         self.assertIn("table", response.context_data)
         self.assertEqual(len(response.context_data["table"].rows), 2)
 
+    @override_settings(
+        ANVIL_MANAGED_GROUP_ADAPTER="anvil_consortium_manager.tests.test_app.adapters.TestManagedGroupAdapter"
+    )
+    def test_adapter(self):
+        """Displays the correct table if specified in the adapter."""
+        self.client.force_login(self.user)
+        response = self.client.get(self.get_url())
+        self.assertIn("table", response.context_data)
+        self.assertIsInstance(response.context_data["table"], app_tables.TestManagedGroupStaffTable)
+
 
 class ManagedGroupDeleteTest(AnVILAPIMockTestMixin, TestCase):
     api_success_code = 204

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -5171,6 +5171,20 @@ class ManagedGroupCreateTest(AnVILAPIMockTestMixin, TestCase):
         # Make sure that no object is created.
         self.assertEqual(models.ManagedGroup.objects.count(), 0)
 
+    @override_settings(
+        ANVIL_MANAGED_GROUP_ADAPTER="anvil_consortium_manager.tests.test_app.adapters.TestManagedGroupAfterAnVILCreateAdapter"
+    )
+    def test_post_custom_adapter_after_anvil_create(self):
+        """The after_anvil_create method is run after a managed group is created."""
+        api_url = self.get_api_url("test-group")
+        self.anvil_response_mock.add(responses.POST, api_url, status=self.api_success_code)
+        self.client.force_login(self.user)
+        response = self.client.post(self.get_url(), {"name": "test-group"})
+        self.assertEqual(response.status_code, 302)
+        # Check that the name was changed by the adaapter.
+        new_object = models.ManagedGroup.objects.latest("pk")
+        self.assertEqual(new_object.name, "changed-name")
+
 
 class ManagedGroupUpdateTest(TestCase):
     def setUp(self):

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -5429,7 +5429,7 @@ class ManagedGroupListTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url())
         self.assertIn("table", response.context_data)
-        self.assertIsInstance(response.context_data["table"], app_tables.TestManagedGroupStaffTable)
+        self.assertIsInstance(response.context_data["table"], app_tables.TestManagedGroupTable)
 
 
 class ManagedGroupDeleteTest(AnVILAPIMockTestMixin, TestCase):

--- a/anvil_consortium_manager/viewmixins.py
+++ b/anvil_consortium_manager/viewmixins.py
@@ -13,6 +13,7 @@ from django.views.generic.detail import SingleObjectMixin
 
 from . import models
 from .adapters.account import get_account_adapter
+from .adapters.managed_group import get_managed_group_adapter
 from .adapters.workspace import workspace_adapter_registry
 from .audit import audit
 
@@ -63,6 +64,14 @@ class AccountAdapterMixin:
 
     def get_table_class(self):
         return self.adapter().get_list_table_class()
+
+
+class ManagedGroupAdapterMixin:
+    """Mixin to handle managed group adapters."""
+
+    def get(self, request, *args, **kwargs):
+        self.adapter = get_managed_group_adapter()()
+        return super().get(request, *args, **kwargs)
 
 
 class ManagedGroupGraphMixin:

--- a/anvil_consortium_manager/viewmixins.py
+++ b/anvil_consortium_manager/viewmixins.py
@@ -73,6 +73,10 @@ class ManagedGroupAdapterMixin:
         self.adapter = get_managed_group_adapter()()
         return super().get(request, *args, **kwargs)
 
+    def post(self, request, *args, **kwargs):
+        self.adapter = get_managed_group_adapter()()
+        return super().post(request, *args, **kwargs)
+
 
 class ManagedGroupGraphMixin:
     """Mixin to add a plotly graph of group structure to context data."""

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -693,7 +693,12 @@ class ManagedGroupDetail(
         return context
 
 
-class ManagedGroupCreate(auth.AnVILConsortiumManagerStaffEditRequired, SuccessMessageMixin, CreateView):
+class ManagedGroupCreate(
+    auth.AnVILConsortiumManagerStaffEditRequired,
+    viewmixins.ManagedGroupAdapterMixin,
+    SuccessMessageMixin,
+    CreateView,
+):
     model = models.ManagedGroup
     form_class = forms.ManagedGroupCreateForm
     template_name = "anvil_consortium_manager/managedgroup_create.html"
@@ -708,6 +713,7 @@ class ManagedGroupCreate(auth.AnVILConsortiumManagerStaffEditRequired, SuccessMe
         # Make an API call to AnVIL to create the group.
         try:
             self.object.anvil_create()
+            self.adapter.after_anvil_create(self.object)
         except AnVILAPIError as e:
             # If the API call failed, rerender the page with the responses and show a message.
             messages.add_message(self.request, messages.ERROR, "AnVIL API Error: " + str(e))

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -747,7 +747,7 @@ class ManagedGroupList(
 
     def get_table_class(self):
         """Use the adapter to get the table class."""
-        return self.adapter.get_list_table_class_staff_view()
+        return self.adapter.get_list_table_class()
 
 
 class ManagedGroupVisualization(

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -730,13 +730,23 @@ class ManagedGroupUpdate(
     success_message = "Successfully updated ManagedGroup."
 
 
-class ManagedGroupList(auth.AnVILConsortiumManagerStaffViewRequired, SingleTableMixin, FilterView):
+class ManagedGroupList(
+    auth.AnVILConsortiumManagerStaffViewRequired, viewmixins.ManagedGroupAdapterMixin, SingleTableMixin, FilterView
+):
     model = models.ManagedGroup
-    table_class = tables.ManagedGroupStaffTable
     ordering = ("name",)
     template_name = "anvil_consortium_manager/managedgroup_list.html"
 
     filterset_class = filters.ManagedGroupListFilter
+
+    def get_table_class(self):
+        """Use the adapter to get the table class."""
+        staff_view_permission_codename = models.AnVILProjectManagerAccess.STAFF_VIEW_PERMISSION_CODENAME
+        print(self.adapter)
+        if self.request.user.has_perm("anvil_consortium_manager." + staff_view_permission_codename):
+            return self.adapter.get_list_table_class_staff_view()
+        else:
+            return self.adapter.get_list_table_class_view()
 
 
 class ManagedGroupVisualization(

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -747,12 +747,7 @@ class ManagedGroupList(
 
     def get_table_class(self):
         """Use the adapter to get the table class."""
-        staff_view_permission_codename = models.AnVILProjectManagerAccess.STAFF_VIEW_PERMISSION_CODENAME
-        print(self.adapter)
-        if self.request.user.has_perm("anvil_consortium_manager." + staff_view_permission_codename):
-            return self.adapter.get_list_table_class_staff_view()
-        else:
-            return self.adapter.get_list_table_class_view()
+        return self.adapter.get_list_table_class_staff_view()
 
 
 class ManagedGroupVisualization(

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -44,8 +44,7 @@ By default, the app uses :class:`~anvil_consortium_manager.adapters.default.Defa
 To customize app behavior for accounts, you must subclass :class:`~anvil_consortium_manager.adapters.account.BaseManagedGroupAdapter`
 and set the following attributes:
 
-- ``list_table_class_staff_view``: an attribute set to the class of the table used to display managed groups in the :class:`~anvil_consortium_manager.views.ManagedGroupList` view to users with StaffView permission. The default adapter uses :class:`anvil_consortium_manager.tables.ManagedGroupStaffTable`.
-- ``list_table_class_staff_view``: an attribute set to the class of the table used to display accounts in the :class:`~anvil_consortium_manager.views.ManagedGroupList` view to users with View permission. The default adapter uses :class:`anvil_consortium_manager.tables.ManagedGroupUserTable`.
+- ``list_table_class``: an attribute set to the class of the table used to display managed groups in the :class:`~anvil_consortium_manager.views.ManagedGroupList` view to users with StaffView permission. The default adapter uses :class:`anvil_consortium_manager.tables.ManagedGroupStaffTable`.
 
 Optionally, you can override the following methods:
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -22,6 +22,24 @@ Optionally, you can override the following methods:
 - ``get_autocomplete_queryset(self, queryset, q)``: a method that allows the user to provide custom filtering for the autocomplete view. By default, this filters to Accounts whose email contains the case-insensitive search string in ``q``.
 - ``get_autocomplete_label(self, account)``: a method that allows the user to set the label for an account shown in forms using the autocomplete widget.
 
+.. _managed_group_adapter:
+
+The Managed Group adapter
+-------------------
+
+The app provides an adapter that you can use to customize behavior for Managed Groups.
+By default, the app uses :class:`~anvil_consortium_manager.adapters.default.DefaultManagedGroupAdapter`.
+
+To customize app behavior for accounts, you must subclass :class:`~anvil_consortium_manager.adapters.account.BaseManagedGroupAdapter`
+and set the following attributes:
+
+- ``list_table_class_staff_view``: an attribute set to the class of the table used to display managed groups in the :class:`~anvil_consortium_manager.views.ManagedGroupList` view to users with StaffView permission. The default adapter uses :class:`anvil_consortium_manager.tables.ManagedGroupStaffTable`.
+- ``list_table_class_staff_view``: an attribute set to the class of the table used to display accounts in the :class:`~anvil_consortium_manager.views.ManagedGroupList` view to users with View permission. The default adapter uses :class:`anvil_consortium_manager.tables.ManagedGroupUserTable`.
+
+Optionally, you can override the following methods:
+
+- ``after_anvil_create(self, managed_group)``: a method to perform any actions after creating the Managed Group on AnVIL via the :class:`~anvil_consortium_manager.views.ManagedGroupCreate` view.
+
 .. _workspace_adapter:
 
 The workspace adapter

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -9,7 +9,12 @@ The account adapter
 -------------------
 
 The app provides an adapter that you can use to customize behavior for Accounts.
-By default, the app uses :class:`~anvil_consortium_manager.adapters.default.DefaultAccountAdapter`.
+You can override this setting by specifying the ``ANVIL_ACCOUNT_ADAPTER`` setting in your ``settings.py`` file.
+By default, the app uses :class:`~anvil_consortium_manager.adapters.default.DefaultAccountAdapter`, e.g.,:
+
+.. code-block:: python
+
+        ANVIL_ACCOUNT_ADAPTER = "anvil_consortium_manager.adapters.default.DefaultAccountAdapter"
 
 To customize app behavior for accounts, you must subclass :class:`~anvil_consortium_manager.adapters.account.BaseAccountAdapter`
 and set the following attributes:
@@ -28,7 +33,13 @@ The Managed Group adapter
 -------------------
 
 The app provides an adapter that you can use to customize behavior for Managed Groups.
-By default, the app uses :class:`~anvil_consortium_manager.adapters.default.DefaultManagedGroupAdapter`.
+You can override this setting by specifying the ``ANVIL_MANAGED_GROUP_ADAPTER`` setting in your ``settings.py`` file.
+By default, the app uses :class:`~anvil_consortium_manager.adapters.default.DefaultManagedGroupAdapter`, e.g.,:
+
+.. code-block:: python
+
+        ANVIL_MANAGED_GROUP_ADAPTER = "anvil_consortium_manager.adapters.default.DefaultManagedGroupAdapter"
+
 
 To customize app behavior for accounts, you must subclass :class:`~anvil_consortium_manager.adapters.account.BaseManagedGroupAdapter`
 and set the following attributes:
@@ -46,6 +57,8 @@ The workspace adapter
 ---------------------
 
 The app provides an adapter that you can use to provide extra, customized data about a workspace.
+Unlike the other adapter classes above, you can specify any number of custom adapters in your settings file.
+
 The default workspace adapter provided by the app is :class:`~anvil_consortium_manager.adapters.default.DefaultWorkspaceAdapter`.
 The default ``workspace_data_model`` specified in this adapter has no fields other than those provided by :class:`~anvil_consortium_manager.models.BaseWorkspaceData`.
 This section describes how to store additional information about a workspace by setting up a custom adapter.
@@ -133,7 +146,9 @@ Here is example of the custom adapter for ``my_app`` with the model, form and ta
         workspace_data_form_class = forms.CustomWorkspaceDataForm
         workspace_detail_template_name = "my_app/custom_workspace_detail.html"
 
-Finally, to tell the app to use this adapter, set ``ANVIL_WORKSPACE_ADAPTERS`` in your settings file, e.g.: ``ANVIL_WORKSPACE_ADAPTERS = ["my_app.adapters.CustomWorkspaceAdapter"]``. You can even define multiple adapters for different types of workspaces, e.g.:
+Finally, to tell the app to use this adapter, set ``ANVIL_WORKSPACE_ADAPTERS`` in your settings file, e.g.: ``ANVIL_WORKSPACE_ADAPTERS = ["my_app.adapters.CustomWorkspaceAdapter"]``.
+
+To define multiple adapters for different types of workspaces, e.g.:
 
 .. code-block:: python
 


### PR DESCRIPTION
- Add a managed group base adapter and default class
- Allow the user to define custom list table classes in this adapter
- Allow the user to define an `after_anvil_create` method in the adapter
- Add the default adapter to the app settings
