### PR TITLE
Add "extra_pills" template block to the workspace detail template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add model class checks to adapter methods where appropriate.
 * Drop support for MariaDB 10.4.
 * Drop support for Python 3.8.
+* Add a new `extra_pills` block to the workspace detail template, which allows users to add additional pills/badges to the workspace detail page for a given workspace type.
 
 
 ## 0.24.0 (2024-07-03)

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.25.0.dev1"
+__version__ = "0.25.0.dev2"

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/workspace_detail.html
@@ -34,6 +34,9 @@
   </span>
   {% endif %}
 
+  {% block extra_pills %}
+  {% endblock extra_pills %}
+
   {% if has_access or user.is_superuser %}
   <a class="badge bg-light text-dark btn btn-light" href="{{ object.get_anvil_url }}" target="_blank" role="button">
     <span class="fa-solid fa-arrow-up-right-from-square mx-1"></span>

--- a/anvil_consortium_manager/tests/test_app/templates/test_workspace_detail.html
+++ b/anvil_consortium_manager/tests/test_app/templates/test_workspace_detail.html
@@ -1,0 +1,3 @@
+{% block extra_pills %}
+<span class="badge">Extra workspace pill</span>
+{% endblock extra_pills %}

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -7385,6 +7385,18 @@ class WorkspaceDetailTest(TestCase):
         self.assertNotContains(response, "Date added")
         self.assertNotContains(response, "Date modified")
 
+    def test_template_block_extra_pills(self):
+        """The extra_pills template block is shown on the detail page."""
+        # Overriding settings doesn't work, because appconfig.ready has already run and
+        # registered the default adapter. Instead, unregister the default and register the
+        # new adapter here.
+        workspace_adapter_registry.unregister(DefaultWorkspaceAdapter)
+        workspace_adapter_registry.register(TestWorkspaceAdapter)
+        workspace = TestWorkspaceDataFactory.create()
+        self.client.force_login(self.user)
+        response = self.client.get(workspace.get_absolute_url())
+        self.assertContains(response, """<span class="badge">Extra workspace pill</span>""")
+
 
 class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
     api_success_code = 201


### PR DESCRIPTION
This allows a project to specify additional workspace pills in their template, as appropriate for that workspace type.

Closes #496 