### PR TITLE
Fix coverage for newest upload-artifact action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
         run: hatch run $TEST_ENV:cov
 
       - name: Upload coverage data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.3.6
         with:
           name: coverage-data-${{ strategy.job-index }}
           path: ".coverage.*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,10 @@ jobs:
         options: --tmpfs /var/lib/mysql
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.7
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.2.0
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -95,10 +95,10 @@ jobs:
     needs: [test]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v4.1.7
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v5.2.0
         with:
           python-version: "3.12"
 
@@ -106,7 +106,7 @@ jobs:
         run: python -m pip install --upgrade hatch
 
       - name: Download coverage data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v4.1.8
         with:
           path: ./artifacts/
 
@@ -122,7 +122,7 @@ jobs:
           ls -la .
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v4.5.0
         with:
           fail_ci_if_error: true # optional (default = false)
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,12 @@ jobs:
       - name: Run Tests
         run: hatch run $TEST_ENV:cov
 
+      - name: Rename coverage file
+        run: |
+          ls -la .coverage*
+
       - name: Upload coverage data
-        uses: actions/upload-artifact@v4.3.6
+        uses: actions/upload-artifact@v4.4.0
         with:
           name: coverage-data-${{ strategy.job-index }}
           path: ".coverage.*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,12 +77,13 @@ jobs:
       - name: Rename coverage file
         run: |
           ls -la .coverage*
+          mv .coverage.* coverage-${{ strategy.job-index }}
 
       - name: Upload coverage data
         uses: actions/upload-artifact@v4.4.0
         with:
           name: coverage-data-${{ strategy.job-index }}
-          path: ".coverage.*"
+          path: coverage-${{ strategy.job-index }}
           if-no-files-found: error
 
 
@@ -109,14 +110,10 @@ jobs:
         with:
           path: ./artifacts/
 
-      - name: Merge coverage files
-        run: |
-          mv ./artifacts/coverage-data*/.coverage* .
-          ls -la .coverage*
-
       - name: Combine coverage data
         run: |
-          hatch run cov:combine
+          ls -la ./artifacts/coverage-data*
+          hatch run cov:combine ./artifacts/coverage-data*/coverage-*
           ls -la .coverage*
 
       - name: Create coverage xml file

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -203,9 +203,8 @@ dependencies = [
     "coverage[toml]>=6.5"
 ]
 [tool.hatch.envs.cov.scripts]
+clean = ["rm -f .coverage"]
 combine = [
-    # Clean up old files first.
-    "rm -f .coverage",
     "python -m coverage combine {args}",
 ]
 report = ["coverage report"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -206,7 +206,7 @@ dependencies = [
 combine = [
     # Clean up old files first.
     "rm -f .coverage",
-    "coverage combine",
+    "python -m coverage combine {args}",
 ]
 report = ["coverage report"]
 html = ["coverage html"]


### PR DESCRIPTION
v4.4.0 had a breaking change that prevents upload of hidden files.

- Pin to a specific version of the action so we can catch this issue in a dependabot update in the future
- Rename coverage files before uploading