### PR TITLE
Move account link verification email template(s) into the account adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Move most account settings into the Account adapter
 * Allow the user to set a custom success message to be displayed after they verify an AnVIL account
+* Move the setting to specify the template for account link verification emails into the AccountAdapter
 
 ## 0.25.0 (2024-08-07)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.26.0.dev0"
+__version__ = "0.26.0.dev1"

--- a/anvil_consortium_manager/adapters/account.py
+++ b/anvil_consortium_manager/adapters/account.py
@@ -25,6 +25,9 @@ class BaseAccountAdapter(ABC):
     """If desired, specify the email address to send an email to after a user verifies an account."""
     account_verify_notification_email = None
 
+    """path to account verification email template"""
+    account_verification_email_template = "anvil_consortium_manager/account_verification_email.html"
+
     @abstractproperty
     def list_table_class(self):
         """Table class to use in a list of Accounts."""

--- a/anvil_consortium_manager/models.py
+++ b/anvil_consortium_manager/models.py
@@ -144,6 +144,8 @@ class UserEmailEntry(TimeStampedModel, models.Model):
             domain (str): The domain of the current site, used to create the link.
         """
         mail_subject = get_account_adapter().account_link_email_subject
+        account_verification_template = get_account_adapter().account_verification_email_template
+
         url_subdirectory = "http://{domain}{url}".format(
             domain=domain,
             url=reverse(
@@ -152,7 +154,7 @@ class UserEmailEntry(TimeStampedModel, models.Model):
             ),
         )
         message = render_to_string(
-            "anvil_consortium_manager/account_verification_email.html",
+            account_verification_template,
             {
                 "user": self.user,
                 "verification_link": url_subdirectory,

--- a/anvil_consortium_manager/tests/test_adapters.py
+++ b/anvil_consortium_manager/tests/test_adapters.py
@@ -206,6 +206,20 @@ class AccountAdapterTestCase(TestCase):
         setattr(TestAdapter, "account_verify_notification_email", custom_email)
         self.assertEqual(TestAdapter().account_verify_notification_email, custom_email)
 
+    def test_account_verification_email_template_default(self):
+        """account_verification_email_template returns the correct template when using the default adapter."""
+        self.assertEqual(
+            DefaultAccountAdapter().account_verification_email_template,
+            "anvil_consortium_manager/account_verification_email.html",
+        )
+
+    def test_account_verification_email_template_custom(self):
+        """account_verification_email_template returns the correct template when using a custom adapter."""
+        custom_template = "custom_template.html"
+        TestAdapter = self.get_test_adapter()
+        setattr(TestAdapter, "account_verification_email_template", custom_template)
+        self.assertEqual(TestAdapter().account_verification_email_template, custom_template)
+
 
 class ManagedGroupAdapterTest(TestCase):
     """Tests for ManagedGroup adapters."""

--- a/anvil_consortium_manager/tests/test_app/adapters.py
+++ b/anvil_consortium_manager/tests/test_app/adapters.py
@@ -51,6 +51,7 @@ class TestAccountAdapter(BaseAccountAdapter):
     account_link_redirect = "test_login"
     account_link_email_subject = "custom subject"
     account_verify_notification_email = "test@example.com"
+    account_verification_email_template = "test_account_verification_email.html"
 
     def get_autocomplete_queryset(self, queryset, q):
         if q:

--- a/anvil_consortium_manager/tests/test_app/templates/test_account_verification_email.html
+++ b/anvil_consortium_manager/tests/test_app/templates/test_account_verification_email.html
@@ -1,0 +1,14 @@
+{% autoescape off %}
+Hi {{ user.username }},
+
+{% block before_link %}
+Please click on the link to verify your AnVIL account email:
+{% endblock before_link %}
+
+{{ verification_link }}
+
+{% block after_link %}
+This is a custom template.
+{% endblock after_link %}
+
+{% endautoescape %}

--- a/anvil_consortium_manager/tests/test_models.py
+++ b/anvil_consortium_manager/tests/test_models.py
@@ -214,6 +214,17 @@ class UserEmailEntryTest(TestCase):
         email_entry.send_notification_email()
         self.assertEqual(len(mail.outbox), 0)
 
+    @freeze_time("2022-11-22 03:12:34")
+    @override_settings(ANVIL_ACCOUNT_ADAPTER="anvil_consortium_manager.tests.test_app.adapters.TestAccountAdapter")
+    def test_send_verification_email_custom_template(self):
+        email_entry = factories.UserEmailEntryFactory.create()
+        email_entry.send_verification_email("www.test.com")
+        # One message has been sent.
+        self.assertEqual(len(mail.outbox), 1)
+        # Correct custom template is used.
+        email_body = mail.outbox[0].body
+        self.assertIn("This is a custom template", email_body)
+
 
 class AccountTest(TestCase):
     def test_model_saving(self):

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -28,6 +28,7 @@ The following attributes have defaults, but can be overridden:
 - ``account_link_verify_redirect``: The URL to redirect to after a user has successfully linked their AnVIL account. (Default: ``settings.LOGIN_REDIRECT_URL``)
 - ``account_link_email_subject``: Subject line for AnVIL account verification emails. (Default: ``"Verify your AnVIL account email"``)
 - ``account_verify_notification_email``: Email address to send an email to after a user verifies an account. If ``None``, no email will be sent. (Default: ``None``)
+- ``account_verification_email_template``: The path to account verification email template. (Default: ``anvil_consortium_manager/account_verification_email.html``)
 
 Optionally, you can override the following methods:
 


### PR DESCRIPTION
- Add a new AccountAdapter attribute, account_verification_email_template
- Use the template when sending verification email in UserEmailEntry Model
- Add tests that the correct template is used when set in custom Account adapter.