### PR TITLE
Allow workspace adapter to specify the template for the workspace list page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Move most account settings into the Account adapter
 * Allow the user to set a custom success message to be displayed after they verify an AnVIL account
 * Move the setting to specify the template for account link verification emails into the AccountAdapter
+* Allow users to specify the template for the WorkspaceListByType view in the WorkspaceAdapter
 
 ## 0.25.0 (2024-08-07)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.26.0.dev1"
+__version__ = "0.26.0.dev2"

--- a/anvil_consortium_manager/adapters/default.py
+++ b/anvil_consortium_manager/adapters/default.py
@@ -31,3 +31,4 @@ class DefaultWorkspaceAdapter(BaseWorkspaceAdapter):
     list_table_class_staff_view = tables.WorkspaceStaffTable
     list_table_class_view = tables.WorkspaceUserTable
     workspace_detail_template_name = "anvil_consortium_manager/workspace_detail.html"
+    workspace_list_template_name = "anvil_consortium_manager/workspace_list.html"

--- a/anvil_consortium_manager/adapters/workspace.py
+++ b/anvil_consortium_manager/adapters/workspace.py
@@ -12,6 +12,9 @@ from .. import app_settings, models
 class BaseWorkspaceAdapter(ABC):
     """Base class to inherit when customizing the workspace adapter."""
 
+    workspace_list_template_name = "anvil_consortium_manager/workspace_list.html"
+    """ path to workspace list template"""
+
     @abstractproperty
     def name(self):
         """String specifying the namee of this type of workspace."""

--- a/anvil_consortium_manager/tests/test_adapters.py
+++ b/anvil_consortium_manager/tests/test_adapters.py
@@ -281,6 +281,7 @@ class WorkspaceAdapterTest(TestCase):
             workspace_data_model = models.TestWorkspaceData
             workspace_data_form_class = forms.TestWorkspaceDataForm
             workspace_detail_template_name = "custom/workspace_detail.html"
+            workspace_list_template_name = "custom/workspace_list.html"
 
         return TestAdapter
 
@@ -531,6 +532,22 @@ class WorkspaceAdapterTest(TestCase):
         setattr(TestAdapter, "workspace_detail_template_name", None)
         with self.assertRaises(ImproperlyConfigured):
             TestAdapter().get_workspace_detail_template_name()
+
+    def test_get_workspace_list_template_name_default(self):
+        """get_workspace_list_template_name returns the correct template using the default adapter."""
+        self.assertEqual(
+            DefaultWorkspaceAdapter().workspace_list_template_name,
+            "anvil_consortium_manager/workspace_list.html",
+        )
+
+    def test_get_workspace_list_template_name_custom(self):
+        """get_workspace_list_template_name returns the corret template when using a custom adapter"""
+        TestAdapter = self.get_test_adapter()
+        setattr(TestAdapter, "workspace_list_template_name", "foo")
+        self.assertEqual(
+            TestAdapter().workspace_list_template_name,
+            "foo",
+        )
 
 
 class WorkspaceAdapterRegistryTest(TestCase):

--- a/anvil_consortium_manager/tests/test_app/adapters.py
+++ b/anvil_consortium_manager/tests/test_app/adapters.py
@@ -20,6 +20,7 @@ class TestWorkspaceAdapter(BaseWorkspaceAdapter):
     workspace_data_model = models.TestWorkspaceData
     workspace_data_form_class = forms.TestWorkspaceDataForm
     workspace_detail_template_name = "test_workspace_detail.html"
+    workspace_list_template_name = "test_workspace_list.html"
 
     def get_autocomplete_queryset(self, queryset, q, forwarded={}):
         billing_project = forwarded.get("billing_project", None)
@@ -74,6 +75,7 @@ class TestForeignKeyWorkspaceAdapter(BaseWorkspaceAdapter):
     workspace_data_model = models.TestForeignKeyWorkspaceData
     workspace_data_form_class = forms.TestForeignKeyWorkspaceDataForm
     workspace_detail_template_name = "workspace_detail.html"
+    workspace_list_template_name = "workspace_list.html"
 
 
 class TestWorkspaceMethodsAdapter(BaseWorkspaceAdapter):
@@ -88,6 +90,7 @@ class TestWorkspaceMethodsAdapter(BaseWorkspaceAdapter):
     workspace_data_model = models.TestWorkspaceMethodsData
     workspace_data_form_class = forms.TestWorkspaceMethodsForm
     workspace_detail_template_name = "workspace_detail.html"
+    workspace_list_template_name = "workspace_list.html"
 
 
 class TestBeforeWorkspaceCreateAdapter(TestWorkspaceMethodsAdapter):

--- a/anvil_consortium_manager/tests/test_app/templates/test_workspace_list.html
+++ b/anvil_consortium_manager/tests/test_app/templates/test_workspace_list.html
@@ -1,0 +1,27 @@
+{% extends "anvil_consortium_manager/base.html" %}
+{% load static %}
+
+{% load render_table from django_tables2 %}
+{% load crispy_forms_tags %}
+
+{% block title %}{{workspace_type_display_name}}s{% endblock %}
+
+{% block content %}
+
+  <div class="row">
+    <div class="col-sm-12">
+
+      <h2>{{workspace_type_display_name}}s</h2>
+
+      <div class="container pt-3">
+        {% crispy filter.form %}
+      </div>
+
+      {% render_table table %}
+
+    </div>
+  </div>
+
+</div>
+
+{% endblock content %}

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -11781,6 +11781,20 @@ class WorkspaceListByTypeTest(TestCase):
         self.assertIn("table", response.context_data)
         self.assertEqual(len(response.context_data["table"].rows), 2)
 
+    def test_view_with_default_adapter_use_default_workspace_list_template(self):
+        default_type = DefaultWorkspaceAdapter().get_type()
+        self.client.force_login(self.view_user)
+        response = self.client.get(self.get_url(default_type))
+        self.assertTemplateUsed(response, "anvil_consortium_manager/workspace_list.html")
+
+    def test_view_with_custom_adapter_use_custom_workspace_list_template(self):
+        workspace_adapter_registry.unregister(DefaultWorkspaceAdapter)
+        workspace_adapter_registry.register(TestWorkspaceAdapter)
+        self.workspace_type = TestWorkspaceAdapter().get_type()
+        self.client.force_login(self.view_user)
+        response = self.client.get(self.get_url(self.workspace_type))
+        self.assertTemplateUsed(response, "test_workspace_list.html")
+
 
 class WorkspaceDeleteTest(AnVILAPIMockTestMixin, TestCase):
     api_success_code = 202

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -1526,7 +1526,6 @@ class WorkspaceListByType(
         "billing_project__name",
         "name",
     )
-    template_name = "anvil_consortium_manager/workspace_list.html"
     filterset_class = filters.WorkspaceListFilter
 
     def get_queryset(self):
@@ -1539,6 +1538,10 @@ class WorkspaceListByType(
             return self.adapter.get_list_table_class_staff_view()
         else:
             return self.adapter.get_list_table_class_view()
+
+    def get_template_names(self):
+        """Return the workspace list template name specified in the adapter."""
+        return [self.adapter.workspace_list_template_name]
 
 
 class WorkspaceDelete(auth.AnVILConsortiumManagerStaffEditRequired, SuccessMessageMixin, DeleteView):

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -124,6 +124,9 @@ Next, set up the adapter by subclassing :class:`~anvil_consortium_manager.adapte
 * ``list_table_class_view``: the table to use to display the list of workspaces for non-Staff Viewers.
 * ``workspace_detail_template_name``: the template to use to render the detail of the workspace
 
+The following attribute for WorkspaceListByType view has a default, but can be overridden:
+* ``workspace_list_template_name``: a path to the template to use to render the list of the workspace
+
 You may also override default settings and methods:
 
 - ``get_autocomplete_queryset``: a method to filter a workspace queryset for use in the :class:`~anvil_consortium_manager.views.WorkspaceAutocompleteByType` view. This queryset passed to this method is the workspace data model specified by the adapter, not the `Workspace` model.
@@ -152,6 +155,7 @@ Here is example of the custom adapter for ``my_app`` with the model, form and ta
         workspace_data_model = models.CustomWorkspaceData
         workspace_data_form_class = forms.CustomWorkspaceDataForm
         workspace_detail_template_name = "my_app/custom_workspace_detail.html"
+        workspace_list_template_name = "my_app/custom_workspace_list.html"
 
 Finally, to tell the app to use this adapter, set ``ANVIL_WORKSPACE_ADAPTERS`` in your settings file, e.g.: ``ANVIL_WORKSPACE_ADAPTERS = ["my_app.adapters.CustomWorkspaceAdapter"]``.
 

--- a/example_site/app/adapters.py
+++ b/example_site/app/adapters.py
@@ -16,6 +16,7 @@ class CustomWorkspaceAdapter(BaseWorkspaceAdapter):
     workspace_data_model = models.CustomWorkspaceData
     workspace_data_form_class = forms.CustomWorkspaceDataForm
     workspace_detail_template_name = "app/custom_workspace_detail.html"
+    workspace_list_template_name = "app/custom_workspace_list.html"
 
     def before_anvil_create(self, workspace):
         """Add authorization domain to workspace."""


### PR DESCRIPTION
- Add a new "workspace_list_template_name" attribute to the workspace adapter with a default path "anvil_consortium_manager/workspace_list.html"
- Update the WorkspaceListByType view to use the new adapter.
- Add adapter tests to check that the correct template is being used.
- Update docs