### PR TITLE
Bugfix: Use custom workspace form when cloning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Devel
 
 * Bugfix: `run_anvil_audit` now raises a `CommandException` if an API call fails.
+* Bugfix: use the workspace form specified in the workspace adapter when cloning a workspace.
 
 ## 0.26.0 (2024-11-08)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.26.1.dev0"
+__version__ = "0.26.1.dev1"

--- a/anvil_consortium_manager/tests/test_forms.py
+++ b/anvil_consortium_manager/tests/test_forms.py
@@ -699,13 +699,13 @@ class WorkspaceCloneFormMixinTest(TestCase):
                 fields = ("billing_project", "name", "authorization_domains")
 
             def clean_authorization_domains(self):
+                # No return statement because the test never gets there, and it breaks coverage.
                 authorization_domains = self.cleaned_data.get("authorization_domains")
                 if authorization_domains:
                     for auth_domain in authorization_domains:
                         print(auth_domain.name)
                         if auth_domain.name == "invalid-name":
                             raise forms.ValidationError("Test error")
-                return authorization_domains  # pragma: no cover
 
         class TestWorkspaceCloneForm(forms.WorkspaceCloneFormMixin, TestWorkspaceForm):
             class Meta(TestWorkspaceForm.Meta):
@@ -737,9 +737,6 @@ class WorkspaceCloneFormMixinTest(TestCase):
 
             def clean_authorization_domains(self):
                 authorization_domains = self.cleaned_data.get("authorization_domains")
-                if authorization_domains:
-                    for auth_domain in authorization_domains:
-                        print(auth_domain.name)
                 return authorization_domains
 
         class TestWorkspaceCloneForm(forms.WorkspaceCloneFormMixin, TestWorkspaceForm):

--- a/anvil_consortium_manager/tests/test_forms.py
+++ b/anvil_consortium_manager/tests/test_forms.py
@@ -469,14 +469,21 @@ class WorkspaceImportFormTest(TestCase):
         self.assertEqual(len(form.errors), 1)
 
 
-class WorkspaceCloneFormTest(TestCase):
-    """Tests for the WorkspaceCloneForm."""
-
-    form_class = forms.WorkspaceCloneForm
+class WorkspaceCloneFormMixinTest(TestCase):
+    """Tests for the WorkspaceCloneFormMixin."""
 
     def setUp(self):
         """Create a workspace to clone for use in tests."""
         self.workspace_to_clone = factories.WorkspaceFactory.create()
+
+    def get_form_class(self):
+        """Create a subclass using the mixin."""
+
+        class TestForm(forms.WorkspaceCloneFormMixin, forms.WorkspaceForm):
+            class Meta(forms.WorkspaceForm.Meta):
+                pass
+
+        return TestForm
 
     def test_valid_no_required_auth_domains(self):
         """Form is valid with a workspace to clone with no auth domains, and no auth domains selected."""
@@ -486,7 +493,7 @@ class WorkspaceCloneFormTest(TestCase):
             "name": "test-workspace",
             "authorization_domains": [],
         }
-        form = self.form_class(self.workspace_to_clone, data=form_data)
+        form = self.get_form_class()(self.workspace_to_clone, data=form_data)
         self.assertTrue(form.is_valid())
 
     def test_valid_no_required_auth_domains_with_one_selected_auth_domain(self):
@@ -498,7 +505,7 @@ class WorkspaceCloneFormTest(TestCase):
             "name": "test-workspace",
             "authorization_domains": [new_auth_domain],
         }
-        form = self.form_class(self.workspace_to_clone, data=form_data)
+        form = self.get_form_class()(self.workspace_to_clone, data=form_data)
         self.assertTrue(form.is_valid())
 
     def test_valid_no_required_auth_domains_with_two_selected_auth_domains(self):
@@ -511,7 +518,7 @@ class WorkspaceCloneFormTest(TestCase):
             "name": "test-workspace",
             "authorization_domains": [new_auth_domain_1, new_auth_domain_2],
         }
-        form = self.form_class(self.workspace_to_clone, data=form_data)
+        form = self.get_form_class()(self.workspace_to_clone, data=form_data)
         self.assertTrue(form.is_valid())
 
     def test_valid_one_required_auth_domains(self):
@@ -524,7 +531,7 @@ class WorkspaceCloneFormTest(TestCase):
             "name": "test-workspace",
             "authorization_domains": [auth_domain],
         }
-        form = self.form_class(self.workspace_to_clone, data=form_data)
+        form = self.get_form_class()(self.workspace_to_clone, data=form_data)
         self.assertTrue(form.is_valid())
 
     def test_invalid_one_required_auth_domains_no_auth_domains_selected(self):
@@ -537,7 +544,7 @@ class WorkspaceCloneFormTest(TestCase):
             "name": "test-workspace",
             "authorization_domains": [],
         }
-        form = self.form_class(self.workspace_to_clone, data=form_data)
+        form = self.get_form_class()(self.workspace_to_clone, data=form_data)
         self.assertFalse(form.is_valid())
         self.assertEqual(len(form.errors), 1)
         self.assertIn("authorization_domains", form.errors)
@@ -559,7 +566,7 @@ class WorkspaceCloneFormTest(TestCase):
             "name": "test-workspace",
             "authorization_domains": [other_auth_domain],
         }
-        form = self.form_class(self.workspace_to_clone, data=form_data)
+        form = self.get_form_class()(self.workspace_to_clone, data=form_data)
         self.assertFalse(form.is_valid())
         self.assertEqual(len(form.errors), 1)
         self.assertIn("authorization_domains", form.errors)
@@ -581,7 +588,7 @@ class WorkspaceCloneFormTest(TestCase):
             "name": "test-workspace",
             "authorization_domains": [auth_domain, new_auth_domain],
         }
-        form = self.form_class(self.workspace_to_clone, data=form_data)
+        form = self.get_form_class()(self.workspace_to_clone, data=form_data)
         self.assertTrue(form.is_valid())
 
     def test_valid_two_required_auth_domains(self):
@@ -595,7 +602,7 @@ class WorkspaceCloneFormTest(TestCase):
             "name": "test-workspace",
             "authorization_domains": [auth_domain_1, auth_domain_2],
         }
-        form = self.form_class(self.workspace_to_clone, data=form_data)
+        form = self.get_form_class()(self.workspace_to_clone, data=form_data)
         self.assertTrue(form.is_valid())
 
     def test_invalid_two_required_auth_domains_no_auth_domains_selected(self):
@@ -609,7 +616,7 @@ class WorkspaceCloneFormTest(TestCase):
             "name": "test-workspace",
             "authorization_domains": [],
         }
-        form = self.form_class(self.workspace_to_clone, data=form_data)
+        form = self.get_form_class()(self.workspace_to_clone, data=form_data)
         self.assertFalse(form.is_valid())
         self.assertEqual(len(form.errors), 1)
         self.assertIn("authorization_domains", form.errors)
@@ -632,7 +639,7 @@ class WorkspaceCloneFormTest(TestCase):
             "name": "test-workspace",
             "authorization_domains": [auth_domain_1],
         }
-        form = self.form_class(self.workspace_to_clone, data=form_data)
+        form = self.get_form_class()(self.workspace_to_clone, data=form_data)
         self.assertFalse(form.is_valid())
         self.assertEqual(len(form.errors), 1)
         self.assertIn("authorization_domains", form.errors)
@@ -657,7 +664,7 @@ class WorkspaceCloneFormTest(TestCase):
             "name": "test-workspace",
             "authorization_domains": [other_auth_domain_1, other_auth_domain_2],
         }
-        form = self.form_class(self.workspace_to_clone, data=form_data)
+        form = self.get_form_class()(self.workspace_to_clone, data=form_data)
         self.assertFalse(form.is_valid())
         self.assertEqual(len(form.errors), 1)
         self.assertIn("authorization_domains", form.errors)
@@ -681,7 +688,7 @@ class WorkspaceCloneFormTest(TestCase):
             "name": "test-workspace",
             "authorization_domains": [auth_domain_1, auth_domain_2, new_auth_domain],
         }
-        form = self.form_class(self.workspace_to_clone, data=form_data)
+        form = self.get_form_class()(self.workspace_to_clone, data=form_data)
         self.assertTrue(form.is_valid())
 
 

--- a/anvil_consortium_manager/tests/test_forms.py
+++ b/anvil_consortium_manager/tests/test_forms.py
@@ -705,7 +705,7 @@ class WorkspaceCloneFormMixinTest(TestCase):
                         print(auth_domain.name)
                         if auth_domain.name == "invalid-name":
                             raise forms.ValidationError("Test error")
-                return authorization_domains
+                return authorization_domains  # pragma: no cover
 
         class TestWorkspaceCloneForm(forms.WorkspaceCloneFormMixin, TestWorkspaceForm):
             class Meta(TestWorkspaceForm.Meta):
@@ -740,8 +740,6 @@ class WorkspaceCloneFormMixinTest(TestCase):
                 if authorization_domains:
                     for auth_domain in authorization_domains:
                         print(auth_domain.name)
-                        if auth_domain.name == "invalid-name":
-                            raise forms.ValidationError("Test error")
                 return authorization_domains
 
         class TestWorkspaceCloneForm(forms.WorkspaceCloneFormMixin, TestWorkspaceForm):

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -8222,7 +8222,7 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(app_models.TestWorkspaceData.objects.count(), 0)
         self.assertEqual(len(responses.calls), 0)
 
-    def test_adapter_custom_form_class(self):
+    def test_adapter_custom_workspace_form_class(self):
         """No workspace is created if custom workspace form is invalid."""
         # Overriding settings doesn't work, because appconfig.ready has already run and
         # registered the default adapter. Instead, unregister the default and register the
@@ -10078,7 +10078,9 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
             )
         )
         self.assertTrue("form" in response.context_data)
-        self.assertIsInstance(response.context_data["form"], forms.WorkspaceCloneForm)
+        # self.assertIsInstance(response.context_data["form"], (forms.WorkspaceForm, forms.WorkspaceCloneFormMixin))
+        self.assertIsInstance(response.context_data["form"], forms.WorkspaceForm)
+        self.assertIsInstance(response.context_data["form"], forms.WorkspaceCloneFormMixin)
 
     def test_has_formset_in_context(self):
         """Response includes a formset for the workspace_data model."""
@@ -10782,7 +10784,7 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
         form = response.context_data["form"]
         self.assertFalse(form.is_valid())
         self.assertIn("billing_project", form.errors.keys())
-        self.assertIn("valid choice", form.errors["billing_project"][0])
+        self.assertIn("must have has_app_as_user set to True", form.errors["billing_project"][0])
         # No workspace was created.
         self.assertEqual(models.Workspace.objects.count(), 1)
         self.assertIn(self.workspace_to_clone, models.Workspace.objects.all())
@@ -10905,6 +10907,23 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
         self.assertEqual(models.Workspace.objects.count(), 1)
         self.assertIn(self.workspace_to_clone, models.Workspace.objects.all())
         self.assertEqual(app_models.TestWorkspaceData.objects.count(), 0)
+
+    def test_adapter_custom_workspace_form(self):
+        """Form uses the custom workspace form as a superclass."""
+        workspace_adapter_registry.unregister(DefaultWorkspaceAdapter)
+        workspace_adapter_registry.register(TestWorkspaceAdapter)
+        self.workspace_type = "test"
+        self.client.force_login(self.user)
+        response = self.client.get(
+            self.get_url(
+                self.workspace_to_clone.billing_project.name,
+                self.workspace_to_clone.name,
+                self.workspace_type,
+            )
+        )
+        self.assertTrue("form" in response.context_data)
+        self.assertIsInstance(response.context_data["form"], app_forms.TestWorkspaceForm)
+        self.assertIsInstance(response.context_data["form"], forms.WorkspaceCloneFormMixin)
 
     def test_workspace_to_clone_does_not_exist_on_anvil(self):
         """Shows a method if an AnVIL API 404 error occurs."""

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -1238,7 +1238,6 @@ class WorkspaceClone(
     FormView,
 ):
     model = models.Workspace
-    form_class = forms.WorkspaceCloneForm
     success_message = "Successfully created Workspace on AnVIL."
     template_name = "anvil_consortium_manager/workspace_clone.html"
 
@@ -1269,10 +1268,22 @@ class WorkspaceClone(
         initial["authorization_domains"] = self.object.authorization_domains.all()
         return initial
 
+    def get_form_class(self):
+        # Create a custom class from the custom workspace form, and add cleaning
+        # methods with the WorkspaceCloneFormMixin
+        workspace_form_class = self.adapter.get_workspace_form_class()
+
+        class WorkspaceCloneForm(forms.WorkspaceCloneFormMixin, workspace_form_class):
+            # class WorkspaceCloneForm(forms.WorkspaceCloneFormMixin, forms.WorkspaceForm):
+
+            class Meta(workspace_form_class.Meta):
+                pass
+
+        return WorkspaceCloneForm
+
     def get_form(self, form_class=None):
         """Return an instance of the form to be used in this view."""
-        if form_class is None:
-            form_class = self.get_form_class()
+        form_class = self.get_form_class()
         return form_class(self.object, **self.get_form_kwargs())
 
     def get_workspace_data_formset(self):

--- a/example_site/app/adapters.py
+++ b/example_site/app/adapters.py
@@ -16,7 +16,7 @@ class CustomWorkspaceAdapter(BaseWorkspaceAdapter):
     workspace_data_model = models.CustomWorkspaceData
     workspace_data_form_class = forms.CustomWorkspaceDataForm
     workspace_detail_template_name = "app/custom_workspace_detail.html"
-    workspace_list_template_name = "app/custom_workspace_list.html"
+    # workspace_list_template_name = "app/custom_workspace_list.html"
 
     def before_anvil_create(self, workspace):
         """Add authorization domain to workspace."""


### PR DESCRIPTION
- Change the WorkspaceCloneForm to a mixin that can be combined with another form
- Modify the WorkspaceClone view to create a custom class for a workspace clone form by using the workspace form specified in the adapter and the WorkspaceCloneFormMixin
- Add some tests to check correct behavior

Closes #516 