### PR TITLE
Update ManagedGroup graph for plotly changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Devel
 
 * Allow users to ignore a specific WorkspaceSharingAudit "not in app" record.
+* Update for changes in plotly 6.0.0.
 
 ## 0.28.0 (2025-01-06)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.29.0.dev0"
+__version__ = "0.29.0.dev1"

--- a/anvil_consortium_manager/viewmixins.py
+++ b/anvil_consortium_manager/viewmixins.py
@@ -123,9 +123,13 @@ class ManagedGroupGraphMixin:
                     colorscale="YlGnBu",
                     colorbar=dict(
                         thickness=15,
-                        title="Group or account members",
+                        # title="Group or account members",
                         xanchor="left",
-                        titleside="right",
+                        # titleside="right",
+                        title=dict(
+                            side="right",
+                            text="Group or account members",
+                        ),
                         tickmode="array",
                         tickvals=[np.min(node_color), np.max(node_color)],
                         ticktext=["Fewer", "More"],


### PR DESCRIPTION
The most recent version of plotly (6.0.0) removed some previously- backwards compatible changes with specifying title layout. Update the code to use the new(ish) way of specifying title info.