### PR TITLE
Add after_account_link_verify to the BaseAccountAdapter 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Allow users to ignore a specific WorkspaceSharingAudit "not in app" record.
 * Update for changes in plotly 6.0.0.
 * Fix docs build on readthedocs, which has been broken since ~0.20.
+* Add a new `AccountAdapter` method (`after_account_link_verify`) that allows a site to perform custom actions after a user links their AnVIL account.
 
 ## 0.28.0 (2025-01-06)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.29.0.dev2"
+__version__ = "0.29.0.dev3"

--- a/anvil_consortium_manager/adapters/account.py
+++ b/anvil_consortium_manager/adapters/account.py
@@ -70,6 +70,10 @@ class BaseAccountAdapter(ABC):
         """Adapter to provide a label for an account in autocomplete views."""
         return str(account)
 
+    def after_account_link_verify(self, user):
+        """Custom actions to take for a user after their account is verified."""
+        pass
+
 
 def get_account_adapter():
     adapter = import_string(app_settings.ACCOUNT_ADAPTER)

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/account_link_error_email.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/account_link_error_email.html
@@ -1,0 +1,8 @@
+{% autoescape off %}
+
+Error unhandled exception encountered in call to after_account_link_verify
+For account {{ account }}, email entry {{ email_entry }}
+
+Account still linked. Details {{ error_description }}. Full exception in logs.
+
+{% endautoescape %}

--- a/anvil_consortium_manager/tests/test_app/adapters.py
+++ b/anvil_consortium_manager/tests/test_app/adapters.py
@@ -63,6 +63,13 @@ class TestAccountAdapter(BaseAccountAdapter):
         return "TEST {}".format(account.email)
 
 
+class TestAccountHookFailAdapter(TestAccountAdapter):
+    account_link_verify_exception_log_msg = "TestAccountHookFailAdapter:after_account_link_verify:test_exception"
+
+    def after_account_link_verify(self, user):
+        raise Exception(self.account_link_verify_exception_log_msg)
+
+
 class TestForeignKeyWorkspaceAdapter(BaseWorkspaceAdapter):
     """Adapter for TestForeignKeyWorkspace."""
 

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -389,6 +389,11 @@ class AccountLinkVerify(auth.AnVILConsortiumManagerAccountLinkRequired, Redirect
         # Add a success message.
         messages.add_message(self.request, messages.SUCCESS, self.message_success)
 
+        # Call account adapter after verify hook
+        adapter_class = get_account_adapter()
+        adapter_instance = adapter_class()
+        adapter_instance.after_account_link_verify(user=account.user)
+
         return super().get(request, *args, **kwargs)
 
 

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -412,7 +412,7 @@ class AccountLinkVerify(auth.AnVILConsortiumManagerAccountLinkRequired, Redirect
             error_description = f"{type(e).__name__}: {str(e)}"
 
             # Send a mail about issue if account veriy notification email is set
-            if get_account_adapter().account_verify_notification_email:
+            if adapter_instance.account_verify_notification_email:
                 mail_content = render_to_string(
                     self.mail_template_after_account_link_failed,
                     {"email_entry": email_entry, "account": account, "error_description": error_description},
@@ -421,7 +421,7 @@ class AccountLinkVerify(auth.AnVILConsortiumManagerAccountLinkRequired, Redirect
                     subject=self.mail_subject_after_account_link_failed,
                     message=mail_content,
                     from_email=None,
-                    recipient_list=[get_account_adapter().account_verify_notification_email],
+                    recipient_list=[adapter_instance.account_verify_notification_email],
                     fail_silently=False,
                 )
 

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -5,10 +5,12 @@ from django.conf import settings
 from django.contrib import messages
 from django.contrib.messages.views import SuccessMessageMixin
 from django.contrib.sites.shortcuts import get_current_site
+from django.core.mail import send_mail
 from django.db import transaction
 from django.db.models import ProtectedError, RestrictedError
 from django.forms import Form, HiddenInput, inlineformset_factory
 from django.http import Http404, HttpResponseRedirect
+from django.template.loader import render_to_string
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
@@ -317,7 +319,9 @@ class AccountLinkVerify(auth.AnVILConsortiumManagerAccountLinkRequired, Redirect
     message_account_does_not_exist = "This account does not exist on AnVIL."
     message_service_account = "Account is already marked as a service account."
     message_success = get_account_adapter().account_link_verify_message
-    log_message_after_account_failed = "Error in after_account_link_verify hook"
+    log_message_after_account_link_failed = "Error in after_account_link_verify hook"
+    mail_subject_after_account_link_failed = "AccountLinkVerify - error encountered in after_account_link_verify"
+    mail_template_after_account_link_failed = "anvil_consortium_manager/account_link_error_email.html"
 
     def get_redirect_url(self, *args, **kwargs):
         return reverse(get_account_adapter().account_link_redirect)
@@ -402,7 +406,24 @@ class AccountLinkVerify(auth.AnVILConsortiumManagerAccountLinkRequired, Redirect
             adapter_instance.after_account_link_verify(user=account.user)
         except Exception as e:
             # Log but do not stop execution
-            logger.error(f"[AccountLinkVerify] {self.log_message_after_account_failed}: {e}")
+            logger.exception(f"[AccountLinkVerify] {self.log_message_after_account_link_failed}: {e}")
+
+            # Get the exception type and message
+            error_description = f"{type(e).__name__}: {str(e)}"
+
+            # Send a mail about issue if account veriy notification email is set
+            if get_account_adapter().account_verify_notification_email:
+                mail_content = render_to_string(
+                    self.mail_template_after_account_link_failed,
+                    {"email_entry": email_entry, "account": account, "error_description": error_description},
+                )
+                send_mail(
+                    subject=self.mail_subject_after_account_link_failed,
+                    message=mail_content,
+                    from_email=None,
+                    recipient_list=[get_account_adapter().account_verify_notification_email],
+                    fail_silently=False,
+                )
 
         return super().get(request, *args, **kwargs)
 

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -34,7 +34,7 @@ Optionally, you can override the following methods:
 
 - ``get_autocomplete_queryset(self, queryset, q)``: a method that allows the user to provide custom filtering for the autocomplete view. By default, this filters to Accounts whose email contains the case-insensitive search string in ``q``.
 - ``get_autocomplete_label(self, account)``: a method that allows the user to set the label for an account shown in forms using the autocomplete widget.
-- ``after_account_link_verify(self, user)``: a method to perform any custom actions after an account is successfully linked.
+- ``after_account_link_verify(self, user)``: a method to perform any custom actions after an account is successfully linked. If an exception is raised by this method, account linking will still continue and the account_verify_notification_email email will be notified (if set).
 
 
 .. _managed_group_adapter:

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -34,6 +34,8 @@ Optionally, you can override the following methods:
 
 - ``get_autocomplete_queryset(self, queryset, q)``: a method that allows the user to provide custom filtering for the autocomplete view. By default, this filters to Accounts whose email contains the case-insensitive search string in ``q``.
 - ``get_autocomplete_label(self, account)``: a method that allows the user to set the label for an account shown in forms using the autocomplete widget.
+- ``after_account_link_verify(self, user)``: a method to perform any custom actions after an account is successfully linked.
+
 
 .. _managed_group_adapter:
 


### PR DESCRIPTION
Add as a no-op that can be overridden. 
Add tests to make sure this hook is called during successful calls to the AccountLinkVerify view