### PR TITLE
Fix python version in release-drafter workflow

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5.4.0
         with:
-          python-version: 3.10
+          python-version: "3.10"
 
       # Install packaging tool.
       - name: Install hatch


### PR DESCRIPTION
3.10 without quotes resolves to 3.1