### PR TITLE
Billing project api and import updates

### DIFF
--- a/anvil_consortium_manager/anvil_api.py
+++ b/anvil_consortium_manager/anvil_api.py
@@ -107,6 +107,17 @@ class AnVILAPIClient:
         url = self.rawls_entry_point + "/api/billing/v2/" + billing_project
         return self.auth_session.get(url, 200)
 
+    def get_billing_projects(self):
+        """Get a list of available billing projects.
+
+        Calls the Sam /api/billing/v2 GET method.
+
+        Returns:
+            requests.Response
+        """
+        url = self.rawls_entry_point + "/api/billing/v2"
+        return self.auth_session.get(url, 200)
+
     def get_groups(self):
         """Get a list of groups that the authenticated account is part of.
 

--- a/anvil_consortium_manager/forms.py
+++ b/anvil_consortium_manager/forms.py
@@ -59,12 +59,18 @@ class FilterForm(forms.Form):
 class BillingProjectImportForm(forms.ModelForm):
     """Form to import a BillingProject from AnVIL"""
 
+    name = forms.ChoiceField(help_text="Select the billing project to import from AnVIL")
+
     class Meta:
         model = models.BillingProject
         fields = (
             "name",
             "note",
         )
+
+    def __init__(self, billing_project_choices=[], *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["name"].choices = [("", "---------")] + billing_project_choices
 
     def clean_name(self):
         value = self.cleaned_data["name"]

--- a/anvil_consortium_manager/tests/test_forms.py
+++ b/anvil_consortium_manager/tests/test_forms.py
@@ -15,15 +15,17 @@ class BillingProjectImportFormTest(TestCase):
     def test_valid(self):
         """Form is valid with necessary input."""
         form_data = {
-            "name": "foo",
+            "name": "test-billing",
         }
-        form = self.form_class(data=form_data)
+        billing_project_choices = [("test-billing", "test-billing")]
+        form = self.form_class(billing_project_choices=billing_project_choices, data=form_data)
         self.assertTrue(form.is_valid())
 
     def test_form_valid_note(self):
         """Form is valid with the note field."""
-        form_data = {"name": "foo", "note": "test note"}
-        form = self.form_class(data=form_data)
+        form_data = {"name": "test-billing", "note": "test note"}
+        billing_project_choices = [("test-billing", "test-billing")]
+        form = self.form_class(billing_project_choices=billing_project_choices, data=form_data)
         self.assertTrue(form.is_valid())
 
     def test_invalid_missing_name(self):
@@ -36,31 +38,20 @@ class BillingProjectImportFormTest(TestCase):
         self.assertEqual(len(form.errors["name"]), 1)
         self.assertIn("required", form.errors["name"][0])
 
-    def test_invalid_duplicate_name(self):
-        """Form is invalid with a duplicated name."""
+    def test_invalid_name_choice(self):
+        """Form is invalid with a name not in choices."""
         billing_project = factories.BillingProjectFactory.create()
         form_data = {
             "name": billing_project.name,
         }
-        form = self.form_class(data=form_data)
-        self.assertFalse(form.is_valid())
-        self.assertEqual(len(form.errors), 1)
-        self.assertIn("name", form.errors)
-        self.assertEqual(len(form.errors["name"]), 1)
-        self.assertIn("already exists", form.errors["name"][0])
+        billing_project_choices = [("test-billing", "test-billing")]
+        form = self.form_class(billing_project_choices=billing_project_choices, data=form_data)
 
-    def test_invalid_duplicate_email_case_insensitive(self):
-        """Form is invalid with a duplicated email, regardless of case."""
-        factories.BillingProjectFactory.create(name="foo")
-        form_data = {
-            "name": "FOO",
-        }
-        form = self.form_class(data=form_data)
         self.assertFalse(form.is_valid())
         self.assertEqual(len(form.errors), 1)
         self.assertIn("name", form.errors)
         self.assertEqual(len(form.errors["name"]), 1)
-        self.assertIn("already exists", form.errors["name"][0])
+        self.assertIn("not one of the available choices", form.errors["name"][0])
 
 
 class BillingProjectUpdateFormTest(TestCase):

--- a/anvil_consortium_manager/tests/test_forms.py
+++ b/anvil_consortium_manager/tests/test_forms.py
@@ -53,6 +53,21 @@ class BillingProjectImportFormTest(TestCase):
         self.assertEqual(len(form.errors["name"]), 1)
         self.assertIn("not one of the available choices", form.errors["name"][0])
 
+    def test_duplicate_name_choice_case_insensitive(self):
+        """Form is invalid with a case insensitive name that already exists."""
+        factories.BillingProjectFactory.create(name="TEST-BILLING")
+        form_data = {
+            "name": "test-billing",
+        }
+        billing_project_choices = [("test-billing", "test-billing")]
+        form = self.form_class(billing_project_choices=billing_project_choices, data=form_data)
+
+        self.assertFalse(form.is_valid())
+        self.assertEqual(len(form.errors), 1)
+        self.assertIn("name", form.errors)
+        self.assertEqual(len(form.errors["name"]), 1)
+        self.assertIn("BillingProject with this Name already exists", form.errors["name"][0])
+
 
 class BillingProjectUpdateFormTest(TestCase):
     """Tests for the BillingProjectUpdateForm class."""


### PR DESCRIPTION
Add anvil api support for billing project list.
Use list to pre-populate choices for BillingProjectImport
Tests for form and view updates.