### PR TITLE
Use mocking when testing adapters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
     -  log any exceptions in `before_anvil_create`, `after_anvil_create`, or `after_anvil_import` adapter methods
     - show the user a message if an exception occurs
 * Break advanced docs into its own TOC and sub-section source documents
+* Reduce the number of defined test adapters in favor of mocking in tests
 
 ## 0.33.0 (2025-08-04)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.34.0.dev4"
+__version__ = "0.34.0.dev5"

--- a/anvil_consortium_manager/auditor/tests/test_views.py
+++ b/anvil_consortium_manager/auditor/tests/test_views.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 import responses
 from django.conf import settings
 from django.contrib.auth import get_user_model
@@ -2112,18 +2114,17 @@ class IgnoredManagedGroupMembershipDetailTest(TestCase):
 
     def test_detail_page_links_user_get_absolute_url(self):
         """HTML includes a link to the user profile when the added_by user has a get_absolute_url method."""
-
-        # Dynamically set the get_absolute_url method. This is hacky...
-        def foo(self):
-            return "test_profile_{}".format(self.username)
-
         UserModel = get_user_model()
-        setattr(UserModel, "get_absolute_url", foo)
         user = UserModel.objects.create(username="testuser2", password="testpassword")
         obj = factories.IgnoredManagedGroupMembershipFactory.create(added_by=user)
         self.client.force_login(self.user)
-        response = self.client.get(obj.get_absolute_url())
-        delattr(UserModel, "get_absolute_url")
+        with patch.object(
+            UserModel,
+            "get_absolute_url",
+            return_value="test_profile_testuser2",
+            create=True,
+        ):
+            response = self.client.get(obj.get_absolute_url())
         self.assertContains(response, "test_profile_testuser2")
 
 
@@ -4262,18 +4263,17 @@ class IgnoredWorkspaceSharingDetailTest(TestCase):
 
     def test_detail_page_links_user_get_absolute_url(self):
         """HTML includes a link to the user profile when the added_by user has a get_absolute_url method."""
-
-        # Dynamically set the get_absolute_url method. This is hacky...
-        def foo(self):
-            return "test_profile_{}".format(self.username)
-
         UserModel = get_user_model()
-        setattr(UserModel, "get_absolute_url", foo)
         user = UserModel.objects.create(username="testuser2", password="testpassword")
         obj = factories.IgnoredWorkspaceSharingFactory.create(added_by=user)
         self.client.force_login(self.user)
-        response = self.client.get(obj.get_absolute_url())
-        delattr(UserModel, "get_absolute_url")
+        with patch.object(
+            UserModel,
+            "get_absolute_url",
+            return_value="test_profile_testuser2",
+            create=True,
+        ):
+            response = self.client.get(obj.get_absolute_url())
         self.assertContains(response, "test_profile_testuser2")
 
 

--- a/anvil_consortium_manager/auditor/views.py
+++ b/anvil_consortium_manager/auditor/views.py
@@ -200,6 +200,14 @@ class IgnoredManagedGroupMembershipDetail(auth.AnVILConsortiumManagerStaffViewRe
             )
         return obj
 
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        try:
+            context["user_detail_link"] = self.object.added_by.get_absolute_url()
+        except AttributeError:
+            context["user_detail_link"] = None
+        return context
+
 
 class IgnoredManagedGroupMembershipCreate(
     auth.AnVILConsortiumManagerStaffEditRequired, SuccessMessageMixin, CreateView
@@ -568,6 +576,14 @@ class IgnoredWorkspaceSharingDetail(auth.AnVILConsortiumManagerStaffViewRequired
                 _("No %(verbose_name)s found matching the query") % {"verbose_name": queryset.model._meta.verbose_name}
             )
         return obj
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        try:
+            context["user_detail_link"] = self.object.added_by.get_absolute_url()
+        except AttributeError:
+            context["user_detail_link"] = None
+        return context
 
 
 class IgnoredWorkspaceSharingUpdate(auth.AnVILConsortiumManagerStaffEditRequired, SuccessMessageMixin, UpdateView):

--- a/anvil_consortium_manager/tables.py
+++ b/anvil_consortium_manager/tables.py
@@ -69,12 +69,13 @@ class AccountStaffTable(tables.Table):
 
     def render_user(self, record):
         """If user.get_absolute_url is defined, then include link to it. Otherwise, just show the user."""
-        if hasattr(record.user, "get_absolute_url"):
+        try:
+            record.user.get_absolute_url()
             link = """<a href="{url}">{link_text}</a>""".format(
                 link_text=str(record), url=record.user.get_absolute_url()
             )
             return mark_safe(link)
-        else:
+        except AttributeError:
             return str(record.user)
 
 

--- a/anvil_consortium_manager/templates/anvil_consortium_manager/account_detail.html
+++ b/anvil_consortium_manager/templates/anvil_consortium_manager/account_detail.html
@@ -34,8 +34,8 @@
   <dt class="col-sm-2">Status</dt> <dd class="col-sm-10">{{ object.get_status_display }}</dd>
   <dt class="col-sm-2">User</dt> <dd class="col-sm-10">
     {% if object.user and object.verified_email_entry %}
-      {% if object.verified_email_entry.user.get_absolute_url %}
-        <a href="{{ object.verified_email_entry.user.get_absolute_url }}">{{ object.verified_email_entry.user }}</a>
+      {% if user_detail_link %}
+        <a href="{{ user_detail_link }}">{{ object.verified_email_entry.user }}</a>
       {% else %}
         {{ object.verified_email_entry.user }}
       {% endif %}

--- a/anvil_consortium_manager/templates/auditor/ignoredmanagedgroupmembership_detail.html
+++ b/anvil_consortium_manager/templates/auditor/ignoredmanagedgroupmembership_detail.html
@@ -12,8 +12,8 @@
   </dd>
   <dt class="col-sm-2">Ignored email</dt> <dd class="col-sm-10">{{ object.ignored_email }}</dd>
   <dt class="col-sm-2">Added by</dt> <dd class="col-sm-10">
-    {% if object.added_by.get_absolute_url %}
-        <a href="{{ object.added_by.get_absolute_url }}">{{ object.added_by }}</a>
+    {% if user_detail_link %}
+        <a href="{{ user_detail_link }}">{{ object.added_by }}</a>
     {% else %}
         {{ object.added_by }}
     {% endif %}

--- a/anvil_consortium_manager/templates/auditor/ignoredworkspacesharing_detail.html
+++ b/anvil_consortium_manager/templates/auditor/ignoredworkspacesharing_detail.html
@@ -12,8 +12,8 @@
   </dd>
   <dt class="col-sm-2">Ignored email</dt> <dd class="col-sm-10">{{ object.ignored_email }}</dd>
   <dt class="col-sm-2">Added by</dt> <dd class="col-sm-10">
-    {% if object.added_by.get_absolute_url %}
-        <a href="{{ object.added_by.get_absolute_url }}">{{ object.added_by }}</a>
+    {% if user_detail_link %}
+        <a href="{{ user_detail_link }}">{{ object.added_by }}</a>
     {% else %}
         {{ object.added_by }}
     {% endif %}

--- a/anvil_consortium_manager/tests/settings/test.py
+++ b/anvil_consortium_manager/tests/settings/test.py
@@ -151,6 +151,7 @@ DJANGO_TABLES2_TEMPLATE = "django_tables2/bootstrap5.html"
 ANVIL_API_SERVICE_ACCOUNT_FILE = "foo"
 ANVIL_WORKSPACE_ADAPTERS = [
     "anvil_consortium_manager.adapters.default.DefaultWorkspaceAdapter",
+    "anvil_consortium_manager.tests.test_app.adapters.TestWorkspaceAdapter",
 ]
 
 CACHES = {

--- a/anvil_consortium_manager/tests/test_adapters.py
+++ b/anvil_consortium_manager/tests/test_adapters.py
@@ -941,6 +941,11 @@ class WorkspaceAdapterRegistryTest(TestCase):
             {"adapter1": "Adapter 1", "adapter2": "Adapter 2"},
         )
 
+    @override_settings(
+        ANVIL_WORKSPACE_ADAPTERS=[
+            "anvil_consortium_manager.adapters.default.DefaultWorkspaceAdapter",
+        ]
+    )
     def test_populate_from_settings_default(self):
         registry = WorkspaceAdapterRegistry()
         registry.populate_from_settings()

--- a/anvil_consortium_manager/tests/test_app/adapters.py
+++ b/anvil_consortium_manager/tests/test_app/adapters.py
@@ -1,4 +1,3 @@
-from anvil_consortium_manager.adapters.account import BaseAccountAdapter
 from anvil_consortium_manager.adapters.managed_group import BaseManagedGroupAdapter
 from anvil_consortium_manager.adapters.workspace import BaseWorkspaceAdapter
 from anvil_consortium_manager.forms import WorkspaceForm
@@ -7,7 +6,7 @@ from anvil_consortium_manager.tables import WorkspaceStaffTable, WorkspaceUserTa
 
 from ...adapters import mixins as adapter_mixins
 from ...adapters.default import DefaultManagedGroupAdapter, DefaultWorkspaceAdapter
-from . import filters, forms, models, tables
+from . import forms, models, tables
 
 
 class TestWorkspaceAdapter(BaseWorkspaceAdapter):
@@ -57,35 +56,6 @@ class TestManagedGroupWithMembershipAdapter(
             role=GroupGroupMembership.RoleChoices.MEMBER,
         )
     ]
-
-
-# TODO: can be mocked
-class TestAccountAdapter(BaseAccountAdapter):
-    """Test adapter for accounts."""
-
-    list_table_class = tables.TestAccountStaffTable
-    list_filterset_class = filters.TestAccountListFilter
-    account_link_verify_message = "Test Thank you for linking your AnVIL account."
-    account_link_redirect = "test_login"
-    account_link_email_subject = "custom subject"
-    account_verification_notification_email = "test@example.com"
-    account_link_email_template = "test_account_verification_email.html"
-
-    def get_autocomplete_queryset(self, queryset, q):
-        if q:
-            queryset = queryset.filter(email__startswith=q)
-        return queryset
-
-    def get_autocomplete_label(self, account):
-        return "TEST {}".format(account.email)
-
-
-# TODO: can be mocked
-class TestAccountHookFailAdapter(TestAccountAdapter):
-    account_link_verify_exception_log_msg = "TestAccountHookFailAdapter:after_account_verification:test_exception"
-
-    def after_account_verification(self, user):
-        raise Exception(self.account_link_verify_exception_log_msg)
 
 
 # TODO: can be mocked

--- a/anvil_consortium_manager/tests/test_app/adapters.py
+++ b/anvil_consortium_manager/tests/test_app/adapters.py
@@ -2,7 +2,7 @@ from anvil_consortium_manager.adapters.account import BaseAccountAdapter
 from anvil_consortium_manager.adapters.managed_group import BaseManagedGroupAdapter
 from anvil_consortium_manager.adapters.workspace import BaseWorkspaceAdapter
 from anvil_consortium_manager.forms import WorkspaceForm
-from anvil_consortium_manager.models import GroupGroupMembership, ManagedGroup, WorkspaceGroupSharing
+from anvil_consortium_manager.models import GroupGroupMembership, WorkspaceGroupSharing
 from anvil_consortium_manager.tables import WorkspaceStaffTable, WorkspaceUserTable
 
 from ...adapters import mixins as adapter_mixins
@@ -24,6 +24,7 @@ class TestWorkspaceAdapter(BaseWorkspaceAdapter):
     workspace_detail_template_name = "test_workspace_detail.html"
     workspace_list_template_name = "test_workspace_list.html"
 
+    # TODO: can be mocked
     def get_autocomplete_queryset(self, queryset, q, forwarded={}):
         billing_project = forwarded.get("billing_project", None)
         if billing_project:
@@ -33,6 +34,7 @@ class TestWorkspaceAdapter(BaseWorkspaceAdapter):
             queryset = queryset.filter(workspace__name=q)
         return queryset
 
+    # TODO: can be mocked
     def get_extra_detail_context_data(self, workspace, request):
         extra_context = {}
         extra_context["extra_text"] = "Extra text"
@@ -45,6 +47,7 @@ class TestManagedGroupAdapter(BaseManagedGroupAdapter):
     list_table_class = tables.TestManagedGroupTable
 
 
+# Cannot easily be mocked due to inheritance.
 class TestManagedGroupWithMembershipAdapter(
     adapter_mixins.GroupGroupMembershipAdapterMixin, DefaultManagedGroupAdapter
 ):
@@ -56,6 +59,7 @@ class TestManagedGroupWithMembershipAdapter(
     ]
 
 
+# TODO: can be mocked
 class TestAccountAdapter(BaseAccountAdapter):
     """Test adapter for accounts."""
 
@@ -76,6 +80,7 @@ class TestAccountAdapter(BaseAccountAdapter):
         return "TEST {}".format(account.email)
 
 
+# TODO: can be mocked
 class TestAccountHookFailAdapter(TestAccountAdapter):
     account_link_verify_exception_log_msg = "TestAccountHookFailAdapter:after_account_verification:test_exception"
 
@@ -83,6 +88,7 @@ class TestAccountHookFailAdapter(TestAccountAdapter):
         raise Exception(self.account_link_verify_exception_log_msg)
 
 
+# TODO: can be mocked
 class TestForeignKeyWorkspaceAdapter(BaseWorkspaceAdapter):
     """Adapter for TestForeignKeyWorkspace."""
 
@@ -98,6 +104,7 @@ class TestForeignKeyWorkspaceAdapter(BaseWorkspaceAdapter):
     workspace_list_template_name = "workspace_list.html"
 
 
+# TODO: can be mocked
 class TestWorkspaceMethodsAdapter(BaseWorkspaceAdapter):
     """Adapter superclass for testing adapter methods."""
 
@@ -113,6 +120,7 @@ class TestWorkspaceMethodsAdapter(BaseWorkspaceAdapter):
     workspace_list_template_name = "workspace_list.html"
 
 
+# TODO: can be mocked
 class TestBeforeWorkspaceCreateAdapter(TestWorkspaceMethodsAdapter):
     """Test adapter for workspaces with custom methods defined."""
 
@@ -122,6 +130,7 @@ class TestBeforeWorkspaceCreateAdapter(TestWorkspaceMethodsAdapter):
         workspace.save()
 
 
+# TODO: can be mocked
 class TestAfterWorkspaceCreateAdapter(TestWorkspaceMethodsAdapter):
     """Test adapter for workspaces with custom methods defined."""
 
@@ -131,6 +140,7 @@ class TestAfterWorkspaceCreateAdapter(TestWorkspaceMethodsAdapter):
         workspace.testworkspacemethodsdata.save()
 
 
+# TODO: can be mocked
 class TestAfterWorkspaceImportAdapter(TestWorkspaceMethodsAdapter):
     """Test adapter for workspaces with custom methods defined."""
 
@@ -140,27 +150,7 @@ class TestAfterWorkspaceImportAdapter(TestWorkspaceMethodsAdapter):
         workspace.testworkspacemethodsdata.save()
 
 
-class TestManagedGroupAfterAnVILCreateAdapter(TestManagedGroupAdapter):
-    """Test adapter for workspaces with custom methods defined."""
-
-    def after_anvil_create(self, managed_group):
-        # Change the name of the group to something else.
-        managed_group.name = "changed-name"
-        managed_group.save()
-
-
-class TestManagedGroupAfterAnVILCreateForeignKeyAdapter(TestManagedGroupAdapter):
-    """Test adapter for workspaces with custom methods defined."""
-
-    def after_anvil_create(self, managed_group):
-        parent_group = ManagedGroup.objects.get(name="parent-group")
-        GroupGroupMembership.objects.create(
-            parent_group=parent_group,
-            child_group=managed_group,
-            role=GroupGroupMembership.RoleChoices.MEMBER,
-        )
-
-
+# TODO: cannot be mocked due to interitance
 class TestWorkspaceWithSharingAdapter(adapter_mixins.WorkspaceSharingAdapterMixin, DefaultWorkspaceAdapter):
     """Test adapter using the WorkspaceSharingAdapterMixin."""
 

--- a/anvil_consortium_manager/tests/test_app/adapters.py
+++ b/anvil_consortium_manager/tests/test_app/adapters.py
@@ -23,22 +23,6 @@ class TestWorkspaceAdapter(BaseWorkspaceAdapter):
     workspace_detail_template_name = "test_workspace_detail.html"
     workspace_list_template_name = "test_workspace_list.html"
 
-    # TODO: can be mocked
-    def get_autocomplete_queryset(self, queryset, q, forwarded={}):
-        billing_project = forwarded.get("billing_project", None)
-        if billing_project:
-            queryset = queryset.filter(workspace__billing_project=billing_project)
-
-        if q:
-            queryset = queryset.filter(workspace__name=q)
-        return queryset
-
-    # TODO: can be mocked
-    def get_extra_detail_context_data(self, workspace, request):
-        extra_context = {}
-        extra_context["extra_text"] = "Extra text"
-        return extra_context
-
 
 class TestManagedGroupAdapter(BaseManagedGroupAdapter):
     """Test adapter for ManagedGroups."""

--- a/anvil_consortium_manager/tests/test_app/adapters.py
+++ b/anvil_consortium_manager/tests/test_app/adapters.py
@@ -58,52 +58,6 @@ class TestForeignKeyWorkspaceAdapter(BaseWorkspaceAdapter):
     workspace_list_template_name = "workspace_list.html"
 
 
-# TODO: can be mocked
-class TestWorkspaceMethodsAdapter(BaseWorkspaceAdapter):
-    """Adapter superclass for testing adapter methods."""
-
-    name = "workspace adapter methods testing"
-    type = "methods_tester"
-    description = "Workspace type for testing custom adapter methods method"
-    list_table_class_staff_view = WorkspaceStaffTable
-    list_table_class_view = WorkspaceUserTable
-    workspace_form_class = WorkspaceForm
-    workspace_data_model = models.TestWorkspaceMethodsData
-    workspace_data_form_class = forms.TestWorkspaceMethodsForm
-    workspace_detail_template_name = "workspace_detail.html"
-    workspace_list_template_name = "workspace_list.html"
-
-
-# TODO: can be mocked
-class TestBeforeWorkspaceCreateAdapter(TestWorkspaceMethodsAdapter):
-    """Test adapter for workspaces with custom methods defined."""
-
-    def before_anvil_create(self, workspace):
-        # Append a -2 to the name of the workspace.
-        workspace.name = workspace.name + "-2"
-        workspace.save()
-
-
-# TODO: can be mocked
-class TestAfterWorkspaceCreateAdapter(TestWorkspaceMethodsAdapter):
-    """Test adapter for workspaces with custom methods defined."""
-
-    def after_anvil_create(self, workspace):
-        # Set the extra field to "FOO"
-        workspace.testworkspacemethodsdata.test_field = "FOO"
-        workspace.testworkspacemethodsdata.save()
-
-
-# TODO: can be mocked
-class TestAfterWorkspaceImportAdapter(TestWorkspaceMethodsAdapter):
-    """Test adapter for workspaces with custom methods defined."""
-
-    def after_anvil_import(self, workspace):
-        # Set the extra field.
-        workspace.testworkspacemethodsdata.test_field = "imported!"
-        workspace.testworkspacemethodsdata.save()
-
-
 # TODO: cannot be mocked due to interitance
 class TestWorkspaceWithSharingAdapter(adapter_mixins.WorkspaceSharingAdapterMixin, DefaultWorkspaceAdapter):
     """Test adapter using the WorkspaceSharingAdapterMixin."""

--- a/anvil_consortium_manager/tests/test_app/adapters.py
+++ b/anvil_consortium_manager/tests/test_app/adapters.py
@@ -1,8 +1,6 @@
 from anvil_consortium_manager.adapters.managed_group import BaseManagedGroupAdapter
 from anvil_consortium_manager.adapters.workspace import BaseWorkspaceAdapter
-from anvil_consortium_manager.forms import WorkspaceForm
 from anvil_consortium_manager.models import GroupGroupMembership, WorkspaceGroupSharing
-from anvil_consortium_manager.tables import WorkspaceStaffTable, WorkspaceUserTable
 
 from ...adapters import mixins as adapter_mixins
 from ...adapters.default import DefaultManagedGroupAdapter, DefaultWorkspaceAdapter
@@ -40,22 +38,6 @@ class TestManagedGroupWithMembershipAdapter(
             role=GroupGroupMembership.RoleChoices.MEMBER,
         )
     ]
-
-
-# TODO: can be mocked
-class TestForeignKeyWorkspaceAdapter(BaseWorkspaceAdapter):
-    """Adapter for TestForeignKeyWorkspace."""
-
-    name = "Test foreign key workspace"
-    type = "test_fk"
-    description = "Workspace type for testing"
-    list_table_class_staff_view = WorkspaceStaffTable
-    list_table_class_view = WorkspaceUserTable
-    workspace_form_class = WorkspaceForm
-    workspace_data_model = models.TestForeignKeyWorkspaceData
-    workspace_data_form_class = forms.TestForeignKeyWorkspaceDataForm
-    workspace_detail_template_name = "workspace_detail.html"
-    workspace_list_template_name = "workspace_list.html"
 
 
 # TODO: cannot be mocked due to interitance

--- a/anvil_consortium_manager/tests/test_app/adapters.py
+++ b/anvil_consortium_manager/tests/test_app/adapters.py
@@ -40,7 +40,7 @@ class TestManagedGroupWithMembershipAdapter(
     ]
 
 
-# TODO: cannot be mocked due to interitance
+# Cannot easily be mocked due to inheritance.
 class TestWorkspaceWithSharingAdapter(adapter_mixins.WorkspaceSharingAdapterMixin, DefaultWorkspaceAdapter):
     """Test adapter using the WorkspaceSharingAdapterMixin."""
 

--- a/anvil_consortium_manager/tests/test_app_settings.py
+++ b/anvil_consortium_manager/tests/test_app_settings.py
@@ -22,7 +22,12 @@ class TestAppSettings(TestCase):
         with self.assertRaisesMessage(ImproperlyConfigured, "ANVIL_AUDIT_CACHE is required in settings.py"):
             app_settings.AUDIT_CACHE
 
-    def test_workspace_adapters(self):
+    @override_settings(
+        ANVIL_WORKSPACE_ADAPTERS=[
+            "anvil_consortium_manager.adapters.default.DefaultWorkspaceAdapter",
+        ]
+    )
+    def test_workspace_adapters_one(self):
         # Using test settings.
         self.assertEqual(
             app_settings.WORKSPACE_ADAPTERS, ["anvil_consortium_manager.adapters.default.DefaultWorkspaceAdapter"]

--- a/anvil_consortium_manager/tests/test_tables.py
+++ b/anvil_consortium_manager/tests/test_tables.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.contrib.auth import get_user_model
 from django.test import TestCase
 
@@ -129,18 +131,18 @@ class AccountStaffTableTest(TestCase):
 
     def test_render_user_with_get_absolute_url(self):
         """Table renders a link to the user profile when the user has a get_absolute_url method."""
-
-        # Dynamically set the get_absolute_url method. This is hacky...
-        def foo(self):
-            return "test_profile_{}".format(self.username)
-
         UserModel = get_user_model()
-        setattr(UserModel, "get_absolute_url", foo)
         user = UserModel.objects.create(username="testuser", password="testpassword")
         self.model_factory.create(user=user)
         table = self.table_class(self.model.objects.all())
-        self.assertIn(str(user), table.rows[0].get_cell("user"))
-        self.assertIn("test_profile_testuser", table.rows[0].get_cell("user"))
+        with patch.object(
+            UserModel,
+            "get_absolute_url",
+            return_value="test_profile_testuser",
+            create=True,
+        ):
+            self.assertIn(str(user), table.rows[0].get_cell("user"))
+            self.assertIn("test_profile_testuser", table.rows[0].get_cell("user"))
 
 
 class ManagedGroupUserTableTest(TestCase):

--- a/anvil_consortium_manager/tests/test_viewmixins.py
+++ b/anvil_consortium_manager/tests/test_viewmixins.py
@@ -23,17 +23,20 @@ class RegisteredWorkspaceAdaptersMixinTest(TestCase):
 
     def tearDown(self):
         """Clean up after tests."""
+        super().tearDown()
         # Unregister all adapters.
         workspace_adapter_registry._registry = {}
         # Register the default adapter.
         workspace_adapter_registry.register(DefaultWorkspaceAdapter)
-        super().tearDown()
+        workspace_adapter_registry.register(TestWorkspaceAdapter)
 
     def get_view_class(self):
         return viewmixins.RegisteredWorkspaceAdaptersMixin
 
     def test_context_registered_workspace_adapters_with_one_type(self):
         """registered_workspace_adapters contains an instance of DefaultWorkspaceAdapter."""
+        # The test app has two, so we need to unregister one of them.
+        workspace_adapter_registry.unregister(TestWorkspaceAdapter)
         context = self.get_view_class()().get_context_data()
         self.assertIn("registered_workspace_adapters", context)
         workspace_types = context["registered_workspace_adapters"]
@@ -42,7 +45,6 @@ class RegisteredWorkspaceAdaptersMixinTest(TestCase):
 
     def test_context_registered_workspace_adapters_with_two_types(self):
         """registered_workspace_adapters contains an instance of a test adapter when it is registered."""
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         context = self.get_view_class()().get_context_data()
         self.assertIn("registered_workspace_adapters", context)
         workspace_types = context["registered_workspace_adapters"]

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -13689,13 +13689,10 @@ class WorkspaceAutocompleteByTypeTest(TestCase):
 
         def get_autocomplete_queryset(*args, **kwargs):
             queryset = args[0]
-            q = args[1]
             forwarded = kwargs.get("forwarded", {})
             billing_project = forwarded.get("billing_project", None)
             if billing_project:
                 queryset = queryset.filter(workspace__billing_project=billing_project)
-            if q:
-                queryset = queryset.filter(workspace__name=q)
             return queryset
 
         with patch(

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -7417,6 +7417,7 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
         workspace_adapter_registry._registry = {}
         # Register the default adapter.
         workspace_adapter_registry.register(DefaultWorkspaceAdapter)
+        workspace_adapter_registry.register(TestWorkspaceAdapter)
         super().tearDown()
 
     def get_url(self, *args):
@@ -8107,11 +8108,6 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_adapter_includes_workspace_data_formset(self):
         """Response includes the workspace data formset if specified."""
-        # Overriding settings doesn't work, because appconfig.ready has already run and
-        # registered the default adapter. Instead, unregister the default and register the
-        # new adapter here.
-        workspace_adapter_registry.unregister(DefaultWorkspaceAdapter)
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         self.workspace_type = "test"
         self.client.force_login(self.user)
         response = self.client.get(self.get_url(self.workspace_type))
@@ -8123,11 +8119,6 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_adapter_creates_workspace_data(self):
         """Posting valid data to the form creates a workspace data object when using a custom adapter."""
-        # Overriding settings doesn't work, because appconfig.ready has already run and
-        # registered the default adapter. Instead, unregister the default and register the
-        # new adapter here.
-        workspace_adapter_registry.unregister(DefaultWorkspaceAdapter)
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         self.workspace_type = "test"
         billing_project = factories.BillingProjectFactory.create(name="test-billing-project")
         json_data = {
@@ -8171,11 +8162,6 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_adapter_does_not_create_objects_if_workspace_data_form_invalid(self):
         """Posting invalid data to the workspace_data_form form does not create a workspace when using an adapter."""
-        # Overriding settings doesn't work, because appconfig.ready has already run and
-        # registered the default adapter. Instead, unregister the default and register the
-        # new adapter here.
-        workspace_adapter_registry.unregister(DefaultWorkspaceAdapter)
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         self.workspace_type = "test"
         billing_project = factories.BillingProjectFactory.create()
         self.client.force_login(self.user)
@@ -8211,22 +8197,12 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_adapter_custom_workspace_form_class(self):
         """No workspace is created if custom workspace form is invalid."""
-        # Overriding settings doesn't work, because appconfig.ready has already run and
-        # registered the default adapter. Instead, unregister the default and register the
-        # new adapter here.
-        workspace_adapter_registry.unregister(DefaultWorkspaceAdapter)
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         self.workspace_type = "test"
         self.client.force_login(self.user)
         response = self.client.get(self.get_url(self.workspace_type))
         self.assertIsInstance(response.context_data["form"], app_forms.TestWorkspaceForm)
 
     def test_adapter_does_not_create_object_if_workspace_form_invalid(self):
-        # Overriding settings doesn't work, because appconfig.ready has already run and
-        # registered the default adapter. Instead, unregister the default and register the
-        # new adapter here.
-        workspace_adapter_registry.unregister(DefaultWorkspaceAdapter)
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         self.workspace_type = "test"
         billing_project = factories.BillingProjectFactory.create()
         self.client.force_login(self.user)
@@ -8724,6 +8700,7 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
         workspace_adapter_registry._registry = {}
         # Register the default adapter.
         workspace_adapter_registry.register(DefaultWorkspaceAdapter)
+        workspace_adapter_registry.register(TestWorkspaceAdapter)
         super().tearDown()
 
     def get_url(self, *args):
@@ -9853,11 +9830,6 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_adapter_includes_workspace_data_formset(self):
         """Response includes the workspace data formset if specified."""
-        # Overriding settings doesn't work, because appconfig.ready has already run and
-        # registered the default adapter. Instead, unregister the default and register the
-        # new adapter here.
-        workspace_adapter_registry.unregister(DefaultWorkspaceAdapter)
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         self.workspace_type = TestWorkspaceAdapter().get_type()
         billing_project_name = "test-billing-project"
         workspace_name = "test-workspace"
@@ -9880,11 +9852,6 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_adapter_creates_workspace_data(self):
         """Posting valid data to the form creates a workspace data object when using a custom adapter."""
-        # Overriding settings doesn't work, because appconfig.ready has already run and
-        # registered the default adapter. Instead, unregister the default and register the
-        # new adapter here.
-        workspace_adapter_registry.unregister(DefaultWorkspaceAdapter)
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         self.workspace_type = TestWorkspaceAdapter().get_type()
         billing_project = factories.BillingProjectFactory.create(name="billing-project")
         workspace_name = "workspace"
@@ -9940,11 +9907,6 @@ class WorkspaceImportTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_adapter_does_not_create_objects_if_workspace_data_form_invalid(self):
         """Posting invalid data to the workspace_data_form form does not create a workspace when using an adapter."""
-        # Overriding settings doesn't work, because appconfig.ready has already run and
-        # registered the default adapter. Instead, unregister the default and register the
-        # new adapter here.
-        workspace_adapter_registry.unregister(DefaultWorkspaceAdapter)
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         self.workspace_type = TestWorkspaceAdapter().get_type()
         billing_project = factories.BillingProjectFactory.create(name="billing-project")
         workspace_name = "workspace"
@@ -10620,6 +10582,7 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
         workspace_adapter_registry._registry = {}
         # Register the default adapter.
         workspace_adapter_registry.register(DefaultWorkspaceAdapter)
+        workspace_adapter_registry.register(TestWorkspaceAdapter)
         super().tearDown()
 
     def get_url(self, *args):
@@ -11487,11 +11450,6 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_adapter_includes_workspace_data_formset(self):
         """Response includes the workspace data formset if specified."""
-        # Overriding settings doesn't work, because appconfig.ready has already run and
-        # registered the default adapter. Instead, unregister the default and register the
-        # new adapter here.
-        workspace_adapter_registry.unregister(DefaultWorkspaceAdapter)
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         self.workspace_type = "test"
         self.client.force_login(self.user)
         response = self.client.get(
@@ -11509,11 +11467,6 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_adapter_creates_workspace_data(self):
         """Posting valid data to the form creates a workspace data object when using a custom adapter."""
-        # Overriding settings doesn't work, because appconfig.ready has already run and
-        # registered the default adapter. Instead, unregister the default and register the
-        # new adapter here.
-        workspace_adapter_registry.unregister(DefaultWorkspaceAdapter)
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         self.workspace_type = "test"
         billing_project = factories.BillingProjectFactory.create(name="test-billing-project")
         json_data = {
@@ -11562,11 +11515,6 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_adapter_does_not_create_objects_if_workspace_data_form_invalid(self):
         """Posting invalid data to the workspace_data_form form does not create a workspace when using an adapter."""
-        # Overriding settings doesn't work, because appconfig.ready has already run and
-        # registered the default adapter. Instead, unregister the default and register the
-        # new adapter here.
-        workspace_adapter_registry.unregister(DefaultWorkspaceAdapter)
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         self.workspace_type = "test"
         billing_project = factories.BillingProjectFactory.create()
         self.client.force_login(self.user)
@@ -11606,8 +11554,6 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_adapter_custom_workspace_form_class(self):
         """Form uses the custom workspace form as a superclass."""
-        workspace_adapter_registry.unregister(DefaultWorkspaceAdapter)
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         self.workspace_type = "test"
         self.client.force_login(self.user)
         response = self.client.get(
@@ -11623,8 +11569,6 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_adapter_custom_workspace_form_with_error_in_workspace_form(self):
         """Form uses the custom workspace form as a superclass."""
-        workspace_adapter_registry.unregister(DefaultWorkspaceAdapter)
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         billing_project = factories.BillingProjectFactory.create()
         self.workspace_type = "test"
         self.client.force_login(self.user)
@@ -12214,6 +12158,7 @@ class WorkspaceUpdateTest(TestCase):
         workspace_adapter_registry._registry = {}
         # Register the default adapter.
         workspace_adapter_registry.register(DefaultWorkspaceAdapter)
+        workspace_adapter_registry.register(TestWorkspaceAdapter)
         super().tearDown()
 
     def get_url(self, *args):
@@ -12376,7 +12321,6 @@ class WorkspaceUpdateTest(TestCase):
     def test_can_update_workspace_data(self):
         """Can update workspace data when updating the workspace."""
         # Note that we need to use the test adapter for this.
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         workspace = factories.WorkspaceFactory(workspace_type=TestWorkspaceAdapter().get_type())
         workspace_data = app_models.TestWorkspaceData.objects.create(workspace=workspace, study_name="original name")
         # Need a client for messages.
@@ -12399,8 +12343,6 @@ class WorkspaceUpdateTest(TestCase):
         self.assertEqual(workspace_data.study_name, "updated name")
 
     def test_custom_adapter_workspace_data(self):
-        # Note that we need to use the test adapter for this.
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         workspace = factories.WorkspaceFactory(workspace_type=TestWorkspaceAdapter().get_type())
         app_models.TestWorkspaceData.objects.create(workspace=workspace, study_name="original name")
         # Need a client for messages.
@@ -12415,7 +12357,6 @@ class WorkspaceUpdateTest(TestCase):
     def test_no_updates_if_invalid_workspace_data_form(self):
         """Nothing is updated if workspace_data_form is invalid."""
         # Note that we need to use the test adapter for this.
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         workspace = factories.WorkspaceFactory(
             workspace_type=TestWorkspaceAdapter().get_type(),
             note="original note",
@@ -12446,7 +12387,6 @@ class WorkspaceUpdateTest(TestCase):
     def test_custom_adapter_workspace_form(self):
         """Workspace form is subclass of the custom adapter form."""
         # Note that we need to use the test adapter for this.
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         workspace = factories.WorkspaceFactory(workspace_type=TestWorkspaceAdapter().get_type())
         app_models.TestWorkspaceData.objects.create(workspace=workspace, study_name="original name")
         # Need a client for messages.

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -6506,6 +6506,7 @@ class WorkspaceLandingPageTest(TestCase):
         workspace_adapter_registry._registry = {}
         # Register the default adapter.
         workspace_adapter_registry.register(DefaultWorkspaceAdapter)
+        workspace_adapter_registry.register(TestWorkspaceAdapter)
         super().tearDown()
 
     def get_url(self):
@@ -6619,6 +6620,7 @@ class WorkspaceLandingPageTest(TestCase):
 
     def test_one_registered_workspace_in_context(self):
         """One registered workspace in context when only DefaultWorkspaceAdapter is registered"""
+        workspace_adapter_registry.unregister(TestWorkspaceAdapter)
         self.client.force_login(self.view_user)
         response = self.client.get(self.get_url())
         self.assertIn("registered_workspace_adapters", response.context_data)
@@ -6626,7 +6628,6 @@ class WorkspaceLandingPageTest(TestCase):
 
     def test_two_registered_workspaces_in_context(self):
         """Two registered workspaces in context when two workspace adapters are registered"""
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         self.client.force_login(self.view_user)
         response = self.client.get(self.get_url())
         self.assertIn("registered_workspace_adapters", response.context_data)
@@ -6651,6 +6652,7 @@ class WorkspaceDetailTest(TestCase):
         workspace_adapter_registry._registry = {}
         # Register the default adapter.
         workspace_adapter_registry.register(DefaultWorkspaceAdapter)
+        workspace_adapter_registry.register(TestWorkspaceAdapter)
         super().tearDown()
 
     def get_view(self):
@@ -7096,11 +7098,6 @@ class WorkspaceDetailTest(TestCase):
 
     def test_render_custom_template_name(self):
         """Rendering a correct template when custom template name is specified."""
-        # Overriding settings doesn't work, because appconfig.ready has already run and
-        # registered the default adapter. Instead, unregister the default and register the
-        # new adapter here.
-        workspace_adapter_registry.unregister(DefaultWorkspaceAdapter)
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         workspace = TestWorkspaceDataFactory.create()
         self.client.force_login(self.user)
         response = self.client.get(workspace.get_absolute_url())
@@ -7119,8 +7116,6 @@ class WorkspaceDetailTest(TestCase):
 
     def test_context_workspace_type_display_name_custom_adapter(self):
         """workspace_type_display_name is present in context with a custom adapter."""
-        workspace_adapter_registry.unregister(DefaultWorkspaceAdapter)
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         workspace = TestWorkspaceDataFactory.create()
         self.client.force_login(self.user)
         response = self.client.get(workspace.get_absolute_url())
@@ -7133,8 +7128,6 @@ class WorkspaceDetailTest(TestCase):
 
     def test_context_workspace_with_extra_context(self):
         """workspace_type_display_name is present in context with a custom adapter."""
-        workspace_adapter_registry.unregister(DefaultWorkspaceAdapter)
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         workspace = TestWorkspaceDataFactory.create()
         self.client.force_login(self.user)
         with patch(
@@ -7229,7 +7222,6 @@ class WorkspaceDetailTest(TestCase):
 
     def test_clone_links_with_two_registered_workspace_adapters(self):
         """Links to clone into each type of workspace appear when there are two registered workspace types."""
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         edit_user = User.objects.create_user(username="edit", password="test")
         edit_user.user_permissions.add(
             Permission.objects.get(codename=models.AnVILProjectManagerAccess.STAFF_VIEW_PERMISSION_CODENAME),
@@ -7364,11 +7356,6 @@ class WorkspaceDetailTest(TestCase):
 
     def test_template_block_extra_pills(self):
         """The extra_pills template block is shown on the detail page."""
-        # Overriding settings doesn't work, because appconfig.ready has already run and
-        # registered the default adapter. Instead, unregister the default and register the
-        # new adapter here.
-        workspace_adapter_registry.unregister(DefaultWorkspaceAdapter)
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         workspace = TestWorkspaceDataFactory.create()
         self.client.force_login(self.user)
         response = self.client.get(workspace.get_absolute_url())
@@ -12788,6 +12775,7 @@ class WorkspaceListTest(TestCase):
         workspace_adapter_registry._registry = {}
         # Register the default adapter.
         workspace_adapter_registry.register(DefaultWorkspaceAdapter)
+        workspace_adapter_registry.register(TestWorkspaceAdapter)
         super().tearDown()
 
     def get_url(self, *args):
@@ -12867,7 +12855,6 @@ class WorkspaceListTest(TestCase):
 
     def test_only_shows_workspaces_of_any_type(self):
         """The table includes all workspaces regardless of type."""
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         test_workspace = factories.WorkspaceFactory(workspace_type=TestWorkspaceAdapter().get_type())
         default_workspace = factories.WorkspaceFactory(workspace_type=DefaultWorkspaceAdapter().get_type())
         self.client.force_login(self.view_user)
@@ -12957,6 +12944,7 @@ class WorkspaceListByTypeTest(TestCase):
         workspace_adapter_registry._registry = {}
         # Register the default adapter.
         workspace_adapter_registry.register(DefaultWorkspaceAdapter)
+        workspace_adapter_registry.register(TestWorkspaceAdapter)
         super().tearDown()
 
     def get_url(self, *args):
@@ -13041,11 +13029,6 @@ class WorkspaceListByTypeTest(TestCase):
 
     def test_adapter_table_class_staff_view(self):
         """Displays the correct table if specified in the adapter."""
-        # Overriding settings doesn't work, because appconfig.ready has already run and
-        # registered the default adapter. Instead, unregister the default and register the
-        # new adapter here.
-        workspace_adapter_registry.unregister(DefaultWorkspaceAdapter)
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         self.workspace_type = TestWorkspaceAdapter().get_type()
         self.client.force_login(self.staff_view_user)
         response = self.client.get(self.get_url(self.workspace_type))
@@ -13054,11 +13037,6 @@ class WorkspaceListByTypeTest(TestCase):
 
     def test_adapter_table_class_view(self):
         """Displays the correct table if specified in the adapter."""
-        # Overriding settings doesn't work, because appconfig.ready has already run and
-        # registered the default adapter. Instead, unregister the default and register the
-        # new adapter here.
-        workspace_adapter_registry.unregister(DefaultWorkspaceAdapter)
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         self.workspace_type = TestWorkspaceAdapter().get_type()
         self.client.force_login(self.view_user)
         response = self.client.get(self.get_url(self.workspace_type))
@@ -13067,7 +13045,6 @@ class WorkspaceListByTypeTest(TestCase):
 
     def test_only_shows_workspaces_with_correct_type(self):
         """Only workspaces with the same workspace_type are shown in the table."""
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         factories.WorkspaceFactory(workspace_type=TestWorkspaceAdapter().get_type())
         default_type = DefaultWorkspaceAdapter().get_type()
         self.client.force_login(self.view_user)
@@ -13141,8 +13118,6 @@ class WorkspaceListByTypeTest(TestCase):
         self.assertTemplateUsed(response, "anvil_consortium_manager/workspace_list.html")
 
     def test_view_with_custom_adapter_use_custom_workspace_list_template(self):
-        workspace_adapter_registry.unregister(DefaultWorkspaceAdapter)
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         self.workspace_type = TestWorkspaceAdapter().get_type()
         self.client.force_login(self.view_user)
         response = self.client.get(self.get_url(self.workspace_type))
@@ -13172,6 +13147,7 @@ class WorkspaceDeleteTest(AnVILAPIMockTestMixin, TestCase):
         workspace_adapter_registry._registry = {}
         # Register the default adapter.
         workspace_adapter_registry.register(DefaultWorkspaceAdapter)
+        workspace_adapter_registry.register(TestWorkspaceAdapter)
         super().tearDown()
 
     def get_url(self, *args):
@@ -13347,8 +13323,6 @@ class WorkspaceDeleteTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_adapter_success_url(self):
         """Redirects to the expected page."""
-        # Register a new adapter.
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
         object = factories.WorkspaceFactory.create(workspace_type=TestWorkspaceAdapter().get_type())
         # Need to use the client instead of RequestFactory to check redirection url.
         api_url = self.get_api_url(object.billing_project.name, object.name)
@@ -13587,10 +13561,6 @@ class WorkspaceAutocompleteByTypeTest(TestCase):
             Permission.objects.get(codename=models.AnVILProjectManagerAccess.STAFF_VIEW_PERMISSION_CODENAME)
         )
         self.default_workspace_type = DefaultWorkspaceAdapter().get_type()
-        workspace_adapter_registry.register(TestWorkspaceAdapter)
-
-    def tearDown(self):
-        workspace_adapter_registry.unregister(TestWorkspaceAdapter)
 
     def get_url(self, *args):
         """Get the url for the view being tested."""

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -1659,11 +1659,16 @@ class AccountDetailTest(TestCase):
             return "test_profile_{}".format(self.username)
 
         UserModel = get_user_model()
-        setattr(UserModel, "get_absolute_url", foo)
         user = UserModel.objects.create(username="testuser2", password="testpassword")
         account = factories.AccountFactory.create(verified=True, verified_email_entry__user=user)
         self.client.force_login(self.user)
-        response = self.client.get(self.get_url(account.uuid))
+        with patch.object(
+            UserModel,
+            "get_absolute_url",
+            return_value="test_profile_{}".format(user.username),
+            create=True,
+        ):
+            response = self.client.get(self.get_url(account.uuid))
         self.assertInHTML(
             """<a href="test_profile_testuser2">testuser2</a>""",
             response.content.decode(),

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -2769,9 +2769,7 @@ class AccountLinkVerifyTest(AnVILAPIMockTestMixin, TestCase):
             # Verify hook called
             mock_verify_function.assert_called_once()
 
-    @override_settings(
-        ADMINS=[("Admin", "admin@example.com")],
-    )
+    @override_settings(ADMINS=[("Admin", "admin@example.com")])
     def test_after_account_link_hook_fail_handled(self):
         email = "test@example.com"
         email_entry = factories.UserEmailEntryFactory.create(user=self.user, email=email)
@@ -5466,8 +5464,6 @@ class ManagedGroupCreateTest(AnVILAPIMockTestMixin, TestCase):
         # Function to use in mocking.
         def after_anvil_create(*args, **kwargs):
             # Change the name of the group to something else.
-            print("in mock")
-            print(args)
             managed_group = args[0]
             parent_group = models.ManagedGroup.objects.get(name="parent-group")
             models.GroupGroupMembership.objects.create(
@@ -8272,9 +8268,6 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_post_custom_adapter_before_anvil_create(self):
         """The before_anvil_create method is run before a workspace is created."""
-        # Overriding settings doesn't work, because appconfig.ready has already run and
-        # registered the default adapter. Instead, unregister the default and register the
-        # new adapter here.
         self.workspace_type = TestWorkspaceAdapter().get_type()
         billing_project = factories.BillingProjectFactory.create(name="test-billing-project")
         json_data = {
@@ -8320,9 +8313,6 @@ class WorkspaceCreateTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_post_custom_adapter_after_anvil_create(self):
         """The after_anvil_create method is run after a workspace is created."""
-        # Overriding settings doesn't work, because appconfig.ready has already run and
-        # registered the default adapter. Instead, unregister the default and register the
-        # new adapter here.
         self.workspace_type = TestWorkspaceAdapter().get_type()
         billing_project = factories.BillingProjectFactory.create(name="test-billing-project")
         json_data = {
@@ -11785,9 +11775,6 @@ class WorkspaceCloneTest(AnVILAPIMockTestMixin, TestCase):
 
     def test_post_custom_adapter_after_anvil_create(self):
         """The after_anvil_create method is run after a workspace is created."""
-        # Overriding settings doesn't work, because appconfig.ready has already run and
-        # registered the default adapter. Instead, unregister the default and register the
-        # new adapter here.
         self.workspace_type = TestWorkspaceAdapter().get_type()
         billing_project = factories.BillingProjectFactory.create(name="test-billing-project")
         json_data = {

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -188,7 +188,10 @@ class AccountDetail(
         context["show_reactivate_button"] = context["is_inactive"]
         context["show_unlink_button"] = self.object.user is not None
         context["unlinked_users"] = self.object.unlinked_users.all()
-
+        try:
+            context["user_detail_link"] = self.object.user.get_absolute_url()
+        except AttributeError:
+            context["user_detail_link"] = None
         context["group_table"] = tables.GroupAccountMembershipStaffTable(
             self.object.groupaccountmembership_set.all(),
             exclude=["account", "is_service_account"],


### PR DESCRIPTION
Instead of defining a number of repetitive test app adapters to use in testing, mock adapters when possible. Some adapters will still need to be defined, especially in cases when there need to inherit from new classes (eg, adapter mixins).

Closes #594 