### PR TITLE
Also convert uuid fields in historical models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
     - show the user a message if an exception occurs
 * Break advanced docs into its own TOC and sub-section source documents
 * Reduce the number of defined test adapters in favor of mocking in tests
+* Fix `convert_mariadb_uuid_fields` command to also convert historical models.
 
 ## 0.33.0 (2025-08-04)
 

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.34.0.dev5"
+__version__ = "0.34.0.dev6"

--- a/anvil_consortium_manager/tests/test_commands.py
+++ b/anvil_consortium_manager/tests/test_commands.py
@@ -4,7 +4,7 @@ from io import StringIO
 from unittest import skipUnless
 
 from django.conf import settings
-from django.core.management import call_command
+from django.core.management import CommandError, call_command
 from django.test import TransactionTestCase
 
 
@@ -16,3 +16,22 @@ class ConvertMariaDbUUIDFieldsTest(TransactionTestCase):
         out = StringIO()
         # Just make sure the command runs?
         call_command("convert_mariadb_uuid_fields", stdout=out)
+
+    @skipUnless(settings.DATABASES["default"]["ENGINE"] == "django.db.backends.mysql", "Only for MariaDB")
+    def test_convert_mariadb_uuid_fields_one_model(self):
+        """Test convert_mariadb_uuid_fields command with one model."""
+        # Add a response.
+        out = StringIO()
+        # Just make sure the command runs?
+        call_command("convert_mariadb_uuid_fields", "--models=Account", stdout=out)
+
+    @skipUnless(settings.DATABASES["default"]["ENGINE"] == "django.db.backends.mysql", "Only for MariaDB")
+    def test_convert_mariadb_uuid_fields_invalid_model(self):
+        """Test convert_mariadb_uuid_fields command with an invalid model."""
+        # Add a response.
+        out = StringIO()
+        with self.assertRaises(CommandError) as e:
+            # Call with the "--models=foo" so it goes through the argparse validation.
+            # Calling with models=["foo"] does not throw an exception.
+            call_command("convert_mariadb_uuid_fields", "--models=foo", stdout=out)
+        self.assertIn("invalid choice", str(e.exception))


### PR DESCRIPTION
The previous version of this command only converted the Account and UserEmailEntry models, but this caused server errors after deployment because the historical models from django-simple-history were not updated. Fix the command so that it also updates the historical models for these models. Also add a command line argument to allow the user to specify a subset of models to update.