### PR TITLE
Allow the user to change app_access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
     - Add a new field to the `Workspace` model, app_access
     - Show alerts on appropriate detail views when the app does not have owner access
     - Update audits to check that access on AnVIL matches `app_access`, and operate accordingly
+* Allow the user to update `app_access` and `app_access_reason` via the WorkspaceUpdate form
 
 
 ## 0.34.0 (2026-12-21)

--- a/anvil_consortium_manager/__init__.py
+++ b/anvil_consortium_manager/__init__.py
@@ -1,1 +1,1 @@
-__version__ = "0.35.1.dev0"
+__version__ = "0.35.1.dev1"

--- a/anvil_consortium_manager/forms.py
+++ b/anvil_consortium_manager/forms.py
@@ -169,7 +169,10 @@ class ManagedGroupUpdateForm(forms.ModelForm):
 
     class Meta:
         model = models.ManagedGroup
-        fields = ("note",)
+        fields = (
+            "note",
+            "is_managed_by_app",
+        )
 
 
 class WorkspaceForm(Bootstrap5MediaFormMixin, forms.ModelForm):

--- a/anvil_consortium_manager/tests/test_forms.py
+++ b/anvil_consortium_manager/tests/test_forms.py
@@ -307,6 +307,12 @@ class ManagedGroupUpdateFormTest(TestCase):
         form = self.form_class(data=form_data)
         self.assertTrue(form.is_valid())
 
+    def test_form_is_managed_by_app(self):
+        """Form is valid with the is_managed_by_app field."""
+        form_data = {"is_managed_by_app": True}
+        form = self.form_class(data=form_data)
+        self.assertTrue(form.is_valid())
+
 
 class WorkspaceFormTest(TestCase):
     """Tests for the WorkspaceForm class."""

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -12852,6 +12852,8 @@ class WorkspaceUpdateTest(TestCase):
             self.get_url(self.workspace.billing_project.name, self.workspace.name),
             {
                 "note": "new note",
+                "app_access": self.workspace.app_access,
+                "app_access_reason": self.workspace.app_access_reason,
                 # Default workspace data for formset.
                 "workspacedata-TOTAL_FORMS": 1,
                 "workspacedata-INITIAL_FORMS": 1,
@@ -12873,6 +12875,7 @@ class WorkspaceUpdateTest(TestCase):
         response = self.client.post(
             self.get_url(self.workspace.billing_project.name, self.workspace.name),
             {
+                "note": self.workspace.note,
                 "app_access": models.Workspace.AppAccessChoices.LIMITED,
                 "app_access_reason": "new reason",
                 # Default workspace data for formset.
@@ -12898,6 +12901,8 @@ class WorkspaceUpdateTest(TestCase):
             self.get_url(self.workspace.billing_project.name, self.workspace.name),
             {
                 "note": "new note",
+                "app_access": self.workspace.app_access,
+                "app_access_reason": self.workspace.app_access_reason,
                 # Default workspace data for formset.
                 "workspacedata-TOTAL_FORMS": 1,
                 "workspacedata-INITIAL_FORMS": 1,
@@ -12921,6 +12926,8 @@ class WorkspaceUpdateTest(TestCase):
             self.get_url(self.workspace.billing_project.name, self.workspace.name),
             {
                 "note": "new note",
+                "app_access": self.workspace.app_access,
+                "app_access_reason": self.workspace.app_access_reason,
                 # Default workspace data for formset.
                 "workspacedata-TOTAL_FORMS": 1,
                 "workspacedata-INITIAL_FORMS": 1,
@@ -12943,6 +12950,8 @@ class WorkspaceUpdateTest(TestCase):
         response = self.client.post(
             self.get_url(workspace.billing_project.name, workspace.name),
             {
+                "app_access": self.workspace.app_access,
+                "app_access_reason": self.workspace.app_access_reason,
                 # Default workspace data for formset.
                 "workspacedata-TOTAL_FORMS": 1,
                 "workspacedata-INITIAL_FORMS": 1,
@@ -13047,6 +13056,8 @@ class WorkspaceUpdateTest(TestCase):
                 self.get_url(self.workspace.billing_project.name, self.workspace.name),
                 {
                     "note": "Foo",
+                    "app_access": self.workspace.app_access,
+                    "app_access_reason": self.workspace.app_access_reason,
                     # Default workspace data for formset.
                     "workspacedata-TOTAL_FORMS": 1,
                     "workspacedata-INITIAL_FORMS": 1,

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -12827,8 +12827,13 @@ class WorkspaceUpdateTest(TestCase):
         self.client.force_login(self.user)
         response = self.client.get(self.get_url(self.workspace.billing_project.name, self.workspace.name))
         form = response.context_data.get("form")
-        self.assertEqual(len(form.fields), 1)  # is_locked
+        self.assertEqual(len(form.fields), 3)  # note, app_access, app_access_reason
+        self.assertNotIn("billing_project", form.fields)
+        self.assertNotIn("name", form.fields)
+        self.assertNotIn("authorization_domains", form.fields)
         self.assertIn("note", form.fields)
+        self.assertIn("app_access", form.fields)
+        self.assertIn("app_access_reason", form.fields)
 
     def test_has_formset_in_context(self):
         """Response includes a formset for the workspace_data model."""
@@ -12861,6 +12866,30 @@ class WorkspaceUpdateTest(TestCase):
         self.workspace_data.refresh_from_db()
         self.workspace.refresh_from_db()
         self.assertEqual(self.workspace.note, "new note")
+
+    def test_can_modify_app_access(self):
+        """Can set the note when creating a billing project."""
+        self.client.force_login(self.user)
+        response = self.client.post(
+            self.get_url(self.workspace.billing_project.name, self.workspace.name),
+            {
+                "app_access": models.Workspace.AppAccessChoices.LIMITED,
+                "app_access_reason": "new reason",
+                # Default workspace data for formset.
+                "workspacedata-TOTAL_FORMS": 1,
+                "workspacedata-INITIAL_FORMS": 1,
+                "workspacedata-MIN_NUM_FORMS": 1,
+                "workspacedata-MAX_NUM_FORMS": 1,
+                "workspacedata-0-id": self.workspace_data.pk,
+                "workspacedata-0-workspace": self.workspace.pk,
+                "workspacedata-0-study_name": "updated name",
+            },
+        )
+        self.assertEqual(response.status_code, 302)
+        self.workspace_data.refresh_from_db()
+        self.workspace.refresh_from_db()
+        self.assertEqual(self.workspace.app_access, models.Workspace.AppAccessChoices.LIMITED)
+        self.assertEqual(self.workspace.app_access_reason, "new reason")
 
     def test_success_message(self):
         """Response includes a success message if successful."""
@@ -12981,8 +13010,10 @@ class WorkspaceUpdateTest(TestCase):
         self.assertTrue("form" in response.context_data)
         form = response.context_data["form"]
         self.assertIsInstance(form, TestWorkspaceAdapter().get_workspace_form_class())
-        self.assertEqual(len(form.fields), 1)  # is_locked
+        self.assertEqual(len(form.fields), 3)  # note, app_access, app_access_reason
         self.assertIn("note", form.fields)
+        self.assertIn("app_access", form.fields)
+        self.assertIn("app_access_reason", form.fields)
 
     def test_get_workspace_data_with_second_foreign_key_to_workspace(self):
         other_workspace = factories.WorkspaceFactory.create()

--- a/anvil_consortium_manager/tests/test_views.py
+++ b/anvil_consortium_manager/tests/test_views.py
@@ -5924,6 +5924,16 @@ class ManagedGroupUpdateTest(TestCase):
         instance.refresh_from_db()
         self.assertEqual(instance.note, "new note")
 
+    def test_can_modify_is_managed_by_app(self):
+        """Can set the is_managed_by_app field when creating a billing project."""
+        instance = factories.ManagedGroupFactory.create(is_managed_by_app=False)
+        # Need a client for messages.
+        self.client.force_login(self.user)
+        response = self.client.post(self.get_url(instance.name), {"is_managed_by_app": True})
+        self.assertEqual(response.status_code, 302)
+        instance.refresh_from_db()
+        self.assertEqual(instance.is_managed_by_app, True)
+
     def test_success_message(self):
         """Response includes a success message if successful."""
         instance = factories.ManagedGroupFactory.create()

--- a/anvil_consortium_manager/views.py
+++ b/anvil_consortium_manager/views.py
@@ -1600,11 +1600,14 @@ class WorkspaceUpdate(
 
         class WorkspaceUpdateForm(form_class):
             class Meta(form_class.Meta):
+                # Exclude fields that shouldn't be updated after workspace creation.
                 exclude = (
                     "billing_project",
                     "name",
                     "authorization_domains",
                 )
+                # Include fields that can be updated after workspace creation, even if they are not in the default form.
+                fields = form_class.Meta.fields + ("app_access", "app_access_reason")
 
         return WorkspaceUpdateForm
 


### PR DESCRIPTION
Instead of going through the admin, allow the user to change app_access and associated reason via the WorkspaceUpdate view.